### PR TITLE
Set version 0.0.1 as an initial version for all charts

### DIFF
--- a/fluent-bit/coralogix/Chart.yaml
+++ b/fluent-bit/coralogix/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: fluent-bit-coralogix
 description: Fluent-Bit Chart with Coralogix output plugin
-version: 0.0.5
+version: 0.0.1
 appVersion: 1.8.10
 keywords:
   - Fluent-Bit

--- a/fluent-bit/http/Chart.yaml
+++ b/fluent-bit/http/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: fluent-bit-http
 description: Fluent-Bit Chart with HTTP output plugin
-version: 0.0.6
+version: 0.0.1
 appVersion: 1.8.10
 keywords:
   - Fluent-Bit

--- a/fluentd/coralogix/Chart.yaml
+++ b/fluentd/coralogix/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: fluentd-coralogix
 description: Fluentd Chart with Coralogix output plugin
-version: 0.0.12
+version: 0.0.1
 appVersion: v1.12.0
 keywords:
   - Fluentd

--- a/fluentd/http/Chart.yaml
+++ b/fluentd/http/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: fluentd-http
 description: Fluentd Chart with HTTP output plugin
-version: 0.0.12
+version: 0.0.1
 appVersion: v1.12.0
 keywords:
   - Fluentd


### PR DESCRIPTION
### Setting an initial version 0.0.1 in all Helm charts:
* Fluentd-http 
* Fluentd-coralogix
* Fluent-bit-http
* Fluent-bit-coralogix