### PR TITLE
Upgrade chart and app version to v0.66.0

### DIFF
--- a/otel-agent/CHANGELOG.md
+++ b/otel-agent/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## OpenTelemtry-Agent
 
+### v0.0.11 / 2022-11-28
+* [UPGRADE] Upgrading chart version from 0.39.0 to 0.40.2
+* [UPGRADE] Upgrading app version from v0.64.0 to v0.66.0
+
+### v0.0.10 / 2022-11-21
+* [FEATURE] Add self monitoring 
+
 ### v0.0.9 / 2022-11-10
 * [FEATURE] Support OpenTelemetry native agent
 * [FIX] Example override file attribute

--- a/otel-agent/Chart.yaml
+++ b/otel-agent/Chart.yaml
@@ -1,14 +1,14 @@
 apiVersion: v2
 name: opentelemetry-coralogix
 description: OpenTelemetry agent to which instrumentation libraries export their telemetry data
-version: 0.0.10
+version: 0.0.11
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry agent
   - Coralogix
 dependencies:
   - name: opentelemetry-collector
-    version: "0.39.0"
+    version: "0.40.2"
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
 sources:
   - https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector


### PR DESCRIPTION
* Upgraded chart version - there were no changes in the chart itself, but it upgrades the otel collector version from 64 to 66. 
* Updated changelog both retro and for current version
* version v0.66.0 - it has a few small updates like: Add AWS CloudWatch Receiver, add snmp receiver, small bug fixes 