### PR TITLE
Push in order to trigger the workflow

### DIFF
--- a/otel-agent/Chart.yaml
+++ b/otel-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: opentelemetry-coralogix
 description: OpenTelemetry agent to which instrumentation libraries export their telemetry data
-version: 0.0.11
+version: 0.0.11 
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry agent


### PR DESCRIPTION
Until we enable our workflow to be triggered manually after it fails, by adding 'workflow_dispatch' to the workflow, 
we must push something to the otel-agent directory in order to trigger it to run again 