### PR TITLE
FIX: hostmetrics didnt include anything except filesystem metrics

### DIFF
--- a/otel-agent/CHANGELOG.md
+++ b/otel-agent/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## OpenTelemtry-Agent
 
+### v0.0.14 / 2022-11-11
+* [BUGFIX] Add all of the relevant metrics to be suported in hostmetrics   
+
+### v0.0.13 / 2022-11-08
+* [FEATURE] Configure hostmetrics filesystem metrics
+
 ### v0.0.12 / 2022-11-30
 * [FEATURE] Add zpages extension
 * [BUGFIX] Increase Coralogix exporter timeout 5s -> 30s

--- a/otel-agent/Chart.yaml
+++ b/otel-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: opentelemetry-coralogix
 description: OpenTelemetry agent to which instrumentation libraries export their telemetry data
-version: 0.0.13
+version: 0.0.14
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry agent

--- a/otel-agent/values.yaml
+++ b/otel-agent/values.yaml
@@ -84,11 +84,11 @@ opentelemetry-collector:
       hostmetrics:
         collection_interval: 10s
         scrapers:
-            cpu:
-            load:
-            memory:
-            disk:
-            network:
+            cpu: null
+            load: null
+            memory: null
+            disk: null
+            network: null
             filesystem:
               exclude_mount_points:
                 mount_points:


### PR DESCRIPTION
Without setting these to null, it disable them completely, so no hostmetrics are included except filesystem metrics 