### PR TITLE
Set node_from_env_var filter for k8sattributes

### DIFF
--- a/otel-agent/CHANGELOG.md
+++ b/otel-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### v0.0.18 / 2022-12-21
 
-* [FIX] Set node_from_env_var filter for k8sattributes 
+* [FIX] Set node_from_env_var filter for k8sattributes, reducing memory and cpu usage for those using k8sattributes
 
 ### v0.0.17 / 2022-12-20
 

--- a/otel-agent/CHANGELOG.md
+++ b/otel-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemtry-Agent
 
+### v0.0.18 / 2022-12-21
+
+* [FIX] Set node_from_env_var filter for k8sattributes 
+
 ### v0.0.17 / 2022-12-20
 
 * [FEATURE] Add pprof extension

--- a/otel-agent/Chart.yaml
+++ b/otel-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: opentelemetry-coralogix
 description: OpenTelemetry agent to which instrumentation libraries export their telemetry data
-version: 0.0.17
+version: 0.0.18
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry agent

--- a/otel-agent/values.yaml
+++ b/otel-agent/values.yaml
@@ -36,6 +36,11 @@ opentelemetry-collector:
         key: PRIVATE_KEY
   - name: OTEL_RESOURCE_ATTRIBUTES
     value: "k8s.node.name=$(K8S_NODE_NAME)"
+  - name: KUBE_NODE_NAME
+    valueFrom:
+      fieldRef:
+        apiVersion: v1
+        fieldPath: spec.nodeName
   config:
     extensions:
       zpages:
@@ -67,6 +72,9 @@ opentelemetry-collector:
         application_name: "{{.Values.global.defaultApplicationName }}"
         subsystem_name: "{{.Values.global.defaultSubsystemName }}"
     processors:
+      k8sattributes:
+        filter:
+          node_from_env_var: KUBE_NODE_NAME     
       memory_limiter: null # Will get the k8s resource limits
       resourcedetection/env:
         detectors: ["system","env"]


### PR DESCRIPTION
### Adding node_from_env_var filter for the k8sattributes processor

By adding this filter, the agent will query pods running on the same node only.
`It reduces resource usage`. 

As you can see in the following img , the amount of hosts the agent is querying before using this filter was much higher, 
which affected the resources usage. 

<img width="1712" alt="image" src="https://user-images.githubusercontent.com/63235510/208881648-f347fabc-5766-45a3-ac2f-e70b058785a4.png">


