### PR TITLE
Create a helm chart for Prometheus Agent

### DIFF
--- a/.github/workflows/prometheus-agent.yml
+++ b/.github/workflows/prometheus-agent.yml
@@ -1,0 +1,39 @@
+
+name: Prometheus-Agent-Coralogix-Chart
+
+on:
+  push:
+    branches: master
+    paths:
+    - 'metrics/prometheus-agent/**'
+
+env:
+  CHART_VERSION: $(yq eval '.version' metrics/prometheus-agent/Chart.yaml)
+  CHART_NAME: prometheus-agent-coralogix
+  ARTIFACTORY_URL: https://cgx.jfrog.io/artifactory/
+  ARTIFACTORY_USERNAME: integrations-actions
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2.4.0
+      -
+        name: Setup Helm Repo
+        run: |
+          helm repo add coralogix-charts-virtual ${{ env.ARTIFACTORY_URL }}coralogix-charts-virtual --username ${{ env.ARTIFACTORY_USERNAME }} --password ${{ secrets.ARTIFACTORY_NONUSER_ACCESS_TOKEN }}
+          helm repo update
+          cd metrics/prometheus-agent
+          helm package .
+      -
+        name: Setup JFrog CLI
+        uses: jfrog/setup-jfrog-cli@v2.1.0
+        with:
+          version: 2.12.1
+      -
+        name: use-jfrog-cli
+        run: |
+          cd metrics/prometheus-agent
+          jfrog rt upload --access-token ${{ secrets.ARTIFACTORY_NONUSER_ACCESS_TOKEN }} "${{ env.CHART_NAME }}-*.tgz" coralogix-charts --url ${{ env.ARTIFACTORY_URL }}

--- a/metrics/prometheus-agent/Chart.yaml
+++ b/metrics/prometheus-agent/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: prometheus-agent-coralogix
+namespace: observability
+description: Prometheus running in agent mode
+version: 0.0.1
+appVersion: 0.61.1
+keywords:
+  - prometheus
+  - agent
+maintainers:
+  - name: support
+    email: support@coralogix.com

--- a/metrics/prometheus-agent/README.md
+++ b/metrics/prometheus-agent/README.md
@@ -69,7 +69,7 @@ prometheus:
         maxSamplesPerSend: 1000
         maxShards: 200
       remoteTimeout: 120s
-      url: https://prometheus-gateway.coralogix.in:9090/prometheus/api/v1/write?external_labels=CX_LEVEL
+      url: https://prometheus-gateway.coralogix.in/prometheus/api/v1/write?external_labels=CX_LEVEL
 ```
 
 ```bash

--- a/metrics/prometheus-agent/README.md
+++ b/metrics/prometheus-agent/README.md
@@ -43,11 +43,11 @@ Depending on your region, you need to configure correct Coralogix endpoint. Here
 
 | Cluster (Region)  | Remote_write URL                                                     |
 |-------------------|----------------------------------------------------------------------|
-| EU (Irland)       | https://prometheus-gateway.coralogix.com/prometheus/api/v1/write?external_labels=CX_LEVEL   |
-| EU2 (Sweden)      | https://prometheus-gateway.eu2.coralogix.com/prometheus/api/v1/write?external_labels=CX_LEVEL |
-| US                | https://prometheus-gateway.coralogix.us/prometheus/api/v1/write?external_labels=CX_LEVEL    |
-| APAC1 (India)     | https://prometheus-gateway.coralogix.in/prometheus/api/v1/write?external_labels=CX_LEVEL     |
-| APAC2 (Singapore) | https://prometheus-gateway.coralogixsg.com/prometheus/api/v1/write?external_labels=CX_LEVEL   |
+| EU (Irland)       | https://prometheus-gateway.coralogix.com/prometheus/api/v1/write |
+| EU2 (Sweden)      | https://prometheus-gateway.eu2.coralogix.com/prometheus/api/v1/write |
+| US                | https://prometheus-gateway.coralogix.us/prometheus/api/v1/write    |
+| APAC1 (India)     | https://prometheus-gateway.coralogix.in/prometheus/api/v1/write     |
+| APAC2 (Singapore) | https://prometheus-gateway.coralogixsg.com/prometheus/api/v1/write   |
 
 ## Installation
 
@@ -69,7 +69,7 @@ prometheus:
         maxSamplesPerSend: 1000
         maxShards: 200
       remoteTimeout: 120s
-      url: https://prometheus-gateway.coralogix.in/prometheus/api/v1/write?external_labels=CX_LEVEL
+      url: https://prometheus-gateway.coralogix.in/prometheus/api/v1/write
 ```
 
 ```bash

--- a/metrics/prometheus-agent/README.md
+++ b/metrics/prometheus-agent/README.md
@@ -43,11 +43,11 @@ Depending on your region, you need to configure correct Coralogix endpoint. Here
 
 | Cluster (Region)  | Remote_write URL                                                     |
 |-------------------|----------------------------------------------------------------------|
-| EU (Irland)       | prometheus-gateway.coralogix.com   |
-| EU2 (Sweden)      | prometheus-gateway.eu2.coralogix.com |
-| US                | prometheus-gateway.coralogix.us    |
-| APAC1 (India)     | prometheus-gateway.coralogix.in     |
-| APAC2 (Singapore) | prometheus-gateway.coralogixsg.com   |
+| EU (Irland)       | https://prometheus-gateway.coralogix.com/prometheus/api/v1/write?external_labels=CX_LEVE   |
+| EU2 (Sweden)      | https://prometheus-gateway.eu2.coralogix.com/prometheus/api/v1/write?external_labels=CX_LEVE |
+| US                | https://prometheus-gateway.coralogix.us/prometheus/api/v1/write?external_labels=CX_LEVE    |
+| APAC1 (India)     | https://prometheus-gateway.coralogix.in/prometheus/api/v1/write?external_labels=CX_LEVE     |
+| APAC2 (Singapore) | https://prometheus-gateway.coralogixsg.com/prometheus/api/v1/write?external_labels=CX_LEVE   |
 
 ## Installation
 

--- a/metrics/prometheus-agent/README.md
+++ b/metrics/prometheus-agent/README.md
@@ -15,7 +15,7 @@ The Prometheus Agent collects servicemonitors and podmonitors, which are enabled
 
 Follow the [private key docs](https://coralogix.com/docs/private-key/) tutorial to obtain your secret key tutorial to obtain your secret key.
 
-OpenTelemetry Agent require a `secret` called `coralogix-keys` with the relevant `private key` under a secret key called `PRIVATE_KEY`, inside the `same namespace` that the chart is installed in.
+Prometheus Agent require a `secret` called `coralogix-keys` with the relevant `private key` under a secret key called `PRIVATE_KEY`, inside the `same namespace` that the chart is installed in.
 
 
 ```bash

--- a/metrics/prometheus-agent/README.md
+++ b/metrics/prometheus-agent/README.md
@@ -1,0 +1,81 @@
+# Prometheus Agent
+
+The Agent Mode of Prometheus optimizes the remote write use case of Prometheus. 
+When running in Agent mode, the querying and alerting are disabled, it focuses on scraping the metrics and send them to the destination.
+It is using the same API and discover capabilities as Prometheus, in an efficient way by using customised TSDB WAL that keeps the data that can't be delivered, until the delivery succeeds.
+In addition, it is scalable, enabling easier horizontal scalability for ingestion compared to server-mode.
+
+## Prerequisites
+
+### Prometheus Operator 
+
+The Prometheus Agent collects servicemonitors and podmonitors, which are enabled only when using the Prometheus Operator.
+
+###  Secret Key
+
+Follow the [private key docs](https://coralogix.com/docs/private-key/) tutorial to obtain your secret key tutorial to obtain your secret key.
+
+OpenTelemetry Agent require a `secret` called `coralogix-keys` with the relevant `private key` under a secret key called `PRIVATE_KEY`, inside the `same namespace` that the chart is installed in.
+
+
+```bash
+kubectl create secret generic coralogix-keys \
+  --from-literal=PRIVATE_KEY=<private-key>
+```
+
+The created secret should look like this:
+```yaml
+apiVersion: v1
+data:
+  PRIVATE_KEY: <encrypted-private-key>
+kind: Secret
+metadata:
+  name: coralogix-keys
+  namespace: <the-release-namespace>
+type: Opaque 
+```
+
+### Endpoints
+
+### Coralogix's Endpoints 
+
+Depending on your region, you need to configure correct Coralogix endpoint. Here are the available Endpoints:
+
+| Cluster (Region)  | Remote_write URL                                                     |
+|-------------------|----------------------------------------------------------------------|
+| EU (Irland)       | prometheus-gateway.coralogix.com   |
+| EU2 (Sweden)      | prometheus-gateway.eu2.coralogix.com |
+| US                | prometheus-gateway.coralogix.us    |
+| APAC1 (India)     | prometheus-gateway.coralogix.in     |
+| APAC2 (Singapore) | prometheus-gateway.coralogixsg.com   |
+
+## Installation
+
+In order to override the Coralogix url, a new file must be created, including the following section:
+
+```yaml
+---
+# override.yaml:
+prometheus:
+  prometheusSpec:
+    remoteWrite:
+    - authorization:
+        credentials:
+          name: coralogix-keys
+          key: PRIVATE_KEY
+      name: prometheus-agent-coralogix
+      queueConfig:
+        capacity: 2500
+        maxSamplesPerSend: 1000
+        maxShards: 200
+      remoteTimeout: 120s
+      url: https://prometheus-gateway.coralogix.in:9090/prometheus/api/v1/write?external_labels=CX_LEVEL
+```
+
+```bash
+helm upgrade prometheus-agent coralogix-charts-virtual/prometheus-agent-coralogix \
+  --install \
+  --namespace=<your-namespace> \
+  --create-namespace \
+  -f override.yaml
+```

--- a/metrics/prometheus-agent/README.md
+++ b/metrics/prometheus-agent/README.md
@@ -43,11 +43,11 @@ Depending on your region, you need to configure correct Coralogix endpoint. Here
 
 | Cluster (Region)  | Remote_write URL                                                     |
 |-------------------|----------------------------------------------------------------------|
-| EU (Irland)       | https://prometheus-gateway.coralogix.com/prometheus/api/v1/write?external_labels=CX_LEVE   |
-| EU2 (Sweden)      | https://prometheus-gateway.eu2.coralogix.com/prometheus/api/v1/write?external_labels=CX_LEVE |
-| US                | https://prometheus-gateway.coralogix.us/prometheus/api/v1/write?external_labels=CX_LEVE    |
-| APAC1 (India)     | https://prometheus-gateway.coralogix.in/prometheus/api/v1/write?external_labels=CX_LEVE     |
-| APAC2 (Singapore) | https://prometheus-gateway.coralogixsg.com/prometheus/api/v1/write?external_labels=CX_LEVE   |
+| EU (Irland)       | https://prometheus-gateway.coralogix.com/prometheus/api/v1/write?external_labels=CX_LEVEL   |
+| EU2 (Sweden)      | https://prometheus-gateway.eu2.coralogix.com/prometheus/api/v1/write?external_labels=CX_LEVEL |
+| US                | https://prometheus-gateway.coralogix.us/prometheus/api/v1/write?external_labels=CX_LEVEL    |
+| APAC1 (India)     | https://prometheus-gateway.coralogix.in/prometheus/api/v1/write?external_labels=CX_LEVEL     |
+| APAC2 (Singapore) | https://prometheus-gateway.coralogixsg.com/prometheus/api/v1/write?external_labels=CX_LEVEL   |
 
 ## Installation
 

--- a/metrics/prometheus-agent/README.md
+++ b/metrics/prometheus-agent/README.md
@@ -9,7 +9,11 @@ In addition, it is scalable, enabling easier horizontal scalability for ingestio
 
 ### Prometheus Operator 
 
-The Prometheus Agent collects servicemonitors and podmonitors, which are enabled only when using the Prometheus Operator.
+The Prometheus agent is a Prometheus crd managed by the Promethues operator, meaning the operator must run. 
+The agent collects servicemonitors and podmonitors, which are enabled only when using the Prometheus Operator.
+
+#### Prometheus Operator Version
+The Prometheus operator must be in version 0.59.0 at least in order to support the agent mode.
 
 ###  Secret Key
 

--- a/metrics/prometheus-agent/override.yaml
+++ b/metrics/prometheus-agent/override.yaml
@@ -11,4 +11,4 @@ prometheus:
         maxSamplesPerSend: 1000
         maxShards: 200
       remoteTimeout: 120s
-      url: https://example-gateway.eu2.coralogix.com:9090/prometheus/api/v1/write?external_labels=CX_LEVEL 
+      url: https://example-gateway.eu2.coralogix.com/prometheus/api/v1/write?external_labels=CX_LEVEL 

--- a/metrics/prometheus-agent/override.yaml
+++ b/metrics/prometheus-agent/override.yaml
@@ -1,0 +1,14 @@
+prometheus:
+  prometheusSpec:
+    remoteWrite:
+    - authorization:
+        credentials:
+          name: coralogix-keys
+          key: PRIVATE_KEY
+      name: prometheus-agent-coralogix
+      queueConfig:
+        capacity: 2500
+        maxSamplesPerSend: 1000
+        maxShards: 200
+      remoteTimeout: 120s
+      url: https://example-gateway.eu2.coralogix.com:9090/prometheus/api/v1/write?external_labels=CX_LEVEL 

--- a/metrics/prometheus-agent/override.yaml
+++ b/metrics/prometheus-agent/override.yaml
@@ -11,4 +11,4 @@ prometheus:
         maxSamplesPerSend: 1000
         maxShards: 200
       remoteTimeout: 120s
-      url: https://example-gateway.eu2.coralogix.com/prometheus/api/v1/write?external_labels=CX_LEVEL 
+      url: https://example-gateway.eu2.coralogix.com/prometheus/api/v1/write 

--- a/metrics/prometheus-agent/templates/_helpers.tpl
+++ b/metrics/prometheus-agent/templates/_helpers.tpl
@@ -1,0 +1,38 @@
+
+{{- define "prometheus-agent.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 26 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 26 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 26 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Prometheus custom resource instance name */}}
+{{- define "prometheus-agent.name" -}}
+{{- print (include "prometheus-agent.fullname" .) "" }}
+{{- end }}
+
+{{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts
+*/}}
+{{- define "prometheus-agent.namespace" -}}
+  {{- if .Values.namespace -}}
+    {{- .Values.namespaceOverride -}}
+  {{- else -}}
+    {{- .Release.Namespace -}}
+  {{- end -}}
+{{- end -}}
+
+{{/* Create the name of prometheus service account to use */}}
+{{- define "prometheus-agent.serviceAccountName" -}}
+{{- if .Values.prometheus.prometheusSpec.serviceAccountName -}}
+    {{ default (print (include "prometheus-agent.fullname" .) "") .Values.prometheus.prometheusSpec.serviceAccountName }}
+{{- else -}}
+    {{ default "default" .Values.prometheus.prometheusSpec.serviceAccountName }}
+{{- end -}}
+{{- end -}}

--- a/metrics/prometheus-agent/templates/clusterrole.yaml
+++ b/metrics/prometheus-agent/templates/clusterrole.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.global.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "prometheus-agent.fullname" . }}
+  labels:
+    app: {{ template "prometheus-agent.name" . }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - nodes/metrics
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- nonResourceURLs:
+  - /metrics
+  - /metrics/cadvisor
+  verbs:
+  - get
+{{- if .Values.prometheus.additionalRulesForClusterRole }}
+{{ toYaml .Values.prometheus.additionalRulesForClusterRole | indent 0 }}
+{{- end }}
+{{- end }}

--- a/metrics/prometheus-agent/templates/clusterrolebinding.yaml
+++ b/metrics/prometheus-agent/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.global.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "prometheus-agent.fullname" . }}
+  labels:
+    app: {{ template "prometheus-agent.name" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "prometheus-agent.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "prometheus-agent.serviceAccountName" . }}
+    namespace: {{ template "prometheus-agent.namespace" . }}
+{{- end }}

--- a/metrics/prometheus-agent/templates/prometheus.yaml
+++ b/metrics/prometheus-agent/templates/prometheus.yaml
@@ -1,0 +1,107 @@
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  name: {{ template "prometheus-agent.name" . }} 
+  namespace: {{ template "prometheus-agent.namespace" . }}
+spec:
+  alerting: null
+  ruleNamespaceSelector: null
+  ruleSelector: null
+  walCompression: null
+  disableCompaction: null
+  retention: null
+  containers:
+  - args:
+    - --config.file=/etc/prometheus/config_out/prometheus.env.yaml
+    - --enable-feature=promql-at-modifier,agent
+    - --storage.agent.path=/prometheus
+    - --web.enable-lifecycle
+    - --web.console.templates=/etc/prometheus/consoles
+    - --web.console.libraries=/etc/prometheus/console_libraries
+    - --web.route-prefix=/
+    - --web.config.file=/etc/prometheus/web_config/web-config.yaml
+    name: prometheus
+{{- if .Values.prometheus.prometheusSpec.enableFeatures }}
+  enableFeatures:
+{{- range $enableFeatures := .Values.prometheus.prometheusSpec.enableFeatures }}
+  - {{ tpl $enableFeatures $ }}
+{{- end }}
+{{- end }}
+{{- if .Values.prometheus.prometheusSpec.tolerations }}
+  tolerations:
+{{ toYaml .Values.prometheus.prometheusSpec.tolerations | indent 4 }}
+{{- end }}
+{{- if or .Values.prometheus.prometheusSpec.podAntiAffinity .Values.prometheus.prometheusSpec.affinity }}
+  affinity:
+{{- if .Values.prometheus.prometheusSpec.affinity }}
+{{ toYaml .Values.prometheus.prometheusSpec.affinity | indent 4 }}
+{{- end }}
+{{- if eq .Values.prometheus.prometheusSpec.podAntiAffinity "hard" }}
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - topologyKey: {{ .Values.prometheus.prometheusSpec.podAntiAffinityTopologyKey }}
+        labelSelector:
+          matchExpressions:
+            - {key: app.kubernetes.io/name, operator: In, values: [prometheus]}
+            - {key: prometheus, operator: In, values: [{{ template "prometheus-agent.name" . }}]}
+{{- else if eq .Values.prometheus.prometheusSpec.podAntiAffinity "soft" }}
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          topologyKey: {{ .Values.prometheus.prometheusSpec.podAntiAffinityTopologyKey }}
+          labelSelector:
+            matchExpressions:
+              - {key: app.kubernetes.io/name, operator: In, values: [prometheus]}
+              - {key: prometheus, operator: In, values: [{{ template "prometheus-agent.name" . }}]}
+{{- end }}
+{{- end }}
+{{- if .Values.prometheus.prometheusSpec.scrapeInterval }}
+  scrapeInterval: {{ .Values.prometheus.prometheusSpec.scrapeInterval }}
+{{- end }}
+{{- if .Values.prometheus.prometheusSpec.securityContext }}
+  securityContext:
+{{ toYaml .Values.prometheus.prometheusSpec.securityContext | indent 4 }}
+{{- end }}
+  serviceAccountName: {{ template "prometheus-agent.serviceAccountName" . }}
+{{- if .Values.prometheus.prometheusSpec.remoteWrite }}
+  remoteWrite:
+{{ tpl (toYaml .Values.prometheus.prometheusSpec.remoteWrite | indent 4) . }}
+{{- end }}
+{{- if .Values.prometheus.prometheusSpec.replicaExternalLabelName }}
+  replicaExternalLabelName: "{{ .Values.prometheus.prometheusSpec.replicaExternalLabelName }}"
+{{- else }}
+  replicaExternalLabelName: ""
+{{- end }}
+  replicas: {{ .Values.prometheus.prometheusSpec.replicas }}
+  enableAdminAPI: {{ .Values.prometheus.prometheusSpec.enableAdminAPI }}
+  logLevel: {{ .Values.prometheus.prometheusSpec.logLevel }}
+  logFormat: {{ .Values.prometheus.prometheusSpec.logFormat }}
+{{- if .Values.prometheus.prometheusSpec.resources }}
+  resources:
+{{ toYaml .Values.prometheus.prometheusSpec.resources | indent 4 }}
+{{- end }}
+{{- if .Values.prometheus.prometheusSpec.serviceMonitorSelector }}
+  serviceMonitorSelector:
+{{ toYaml .Values.prometheus.prometheusSpec.serviceMonitorSelector | indent 4 }}
+{{ else }}
+  serviceMonitorSelector: {}
+{{- end }}
+{{- if .Values.prometheus.prometheusSpec.serviceMonitorNamespaceSelector }}
+  serviceMonitorNamespaceSelector:
+{{ toYaml .Values.prometheus.prometheusSpec.serviceMonitorNamespaceSelector | indent 4 }}
+{{ else }}
+  serviceMonitorNamespaceSelector: {}
+{{- end }}
+{{- if .Values.prometheus.prometheusSpec.podMonitorSelector }}
+  podMonitorSelector:
+{{ toYaml .Values.prometheus.prometheusSpec.podMonitorSelector | indent 4 }}
+{{ else }}
+  podMonitorSelector: {}
+{{- end }}
+{{- if .Values.prometheus.prometheusSpec.podMonitorNamespaceSelector }}
+  podMonitorNamespaceSelector:
+{{ toYaml .Values.prometheus.prometheusSpec.podMonitorNamespaceSelector | indent 4 }}
+{{ else }}
+  podMonitorNamespaceSelector: {}
+{{- end }}

--- a/metrics/prometheus-agent/templates/serviceaccount.yaml
+++ b/metrics/prometheus-agent/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.prometheus.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "prometheus-agent.serviceAccountName" . }}
+  namespace: {{ template "prometheus-agent.namespace" . }}
+  labels:
+    app: {{ template "prometheus-agent.name" . }}
+    app.kubernetes.io/name: {{ template "prometheus-agent.name" . }}
+    app.kubernetes.io/component: prometheus
+{{- end }}

--- a/metrics/prometheus-agent/values.yaml
+++ b/metrics/prometheus-agent/values.yaml
@@ -1,0 +1,53 @@
+fullnameOverride: prometheus-agent
+
+global:
+  rbac:
+    create: true
+
+prometheus:
+  prometheusSpec:
+    enableAdminAPI: true
+    logFormat: json
+    logLevel: warn
+    scrapeInterval: 30s
+    serviceAccountName: prometheus-agent
+    remoteWrite:
+    - authorization:
+        credentials:
+          name: coralogix-keys
+          key: PRIVATE_KEY
+      name: prometheus-agent-coralogix
+      queueConfig:
+        capacity: 2500
+        maxSamplesPerSend: 1000
+        maxShards: 200
+      remoteTimeout: 120s
+      url: https://prometheus-gateway.eu2.coralogix.com:9090/prometheus/api/v1/write?external_labels=CX_LEVEL    
+    replicaExternalLabelName: "prometheus_replica"
+    replicas: 1
+    securityContext:
+      fsGroup: 2000
+      runAsGroup: 2000
+      runAsNonRoot: true
+      runAsUser: 1000
+    resources:
+      requests:
+        cpu: "0.3"
+        memory: 500Mi
+    serviceMonitorNamespaceSelector: {}
+    ## Example which selects ServiceMonitors in namespaces with label "prometheus" set to "somelabel"
+    # serviceMonitorNamespaceSelector:
+    #   matchLabels:
+    #     prometheus: somelabel
+    serviceMonitorSelector: {}
+    ## Example which selects ServiceMonitors with label "prometheus" set to "somelabel"
+    # serviceMonitorSelector:
+    #   matchLabels:
+    #     prometheus: somelabel
+    podMonitorNamespaceSelector: {}
+    podMonitorSelector: {}
+  serviceAccount:
+    create: true
+
+
+

--- a/metrics/prometheus-agent/values.yaml
+++ b/metrics/prometheus-agent/values.yaml
@@ -22,7 +22,7 @@ prometheus:
         maxSamplesPerSend: 1000
         maxShards: 200
       remoteTimeout: 120s
-      url: https://prometheus-gateway.eu2.coralogix.com/prometheus/api/v1/write?external_labels=CX_LEVEL    
+      url: https://prometheus-gateway.eu2.coralogix.com/prometheus/api/v1/write 
     replicaExternalLabelName: "prometheus_replica"
     replicas: 1
     securityContext:

--- a/metrics/prometheus-agent/values.yaml
+++ b/metrics/prometheus-agent/values.yaml
@@ -48,6 +48,3 @@ prometheus:
     podMonitorSelector: {}
   serviceAccount:
     create: true
-
-
-

--- a/metrics/prometheus-agent/values.yaml
+++ b/metrics/prometheus-agent/values.yaml
@@ -22,7 +22,7 @@ prometheus:
         maxSamplesPerSend: 1000
         maxShards: 200
       remoteTimeout: 120s
-      url: https://prometheus-gateway.eu2.coralogix.com:443/prometheus/api/v1/write?external_labels=CX_LEVEL    
+      url: https://prometheus-gateway.eu2.coralogix.com/prometheus/api/v1/write?external_labels=CX_LEVEL    
     replicaExternalLabelName: "prometheus_replica"
     replicas: 1
     securityContext:

--- a/metrics/prometheus-agent/values.yaml
+++ b/metrics/prometheus-agent/values.yaml
@@ -22,7 +22,7 @@ prometheus:
         maxSamplesPerSend: 1000
         maxShards: 200
       remoteTimeout: 120s
-      url: https://prometheus-gateway.eu2.coralogix.com:9090/prometheus/api/v1/write?external_labels=CX_LEVEL    
+      url: https://prometheus-gateway.eu2.coralogix.com:443/prometheus/api/v1/write?external_labels=CX_LEVEL    
     replicaExternalLabelName: "prometheus_replica"
     replicas: 1
     securityContext:


### PR DESCRIPTION
### Goal: 
Creating a new helm chart for Prometheus in agent mode. 
The goal here is to enable sending metrics to Coralogix, with focusing only on remote write, on scraping and sending, without having all of the extra components like rules, alerting, querying. 

### Notes:
* Requires to install the Prometheus operator
* Requires to have the privatekey secret
* Requires to create a new override file in order to override the Coralogix url 

### TO DO :
* Add a Grafana dashboard for remote write
