### PR TITLE
Update prometheus job_name and serviceMonitor

### DIFF
--- a/otel-infrastructure-collector/CHANGELOG.md
+++ b/otel-infrastructure-collector/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## OpenTelemtry-Infrastructure-Collector
+
+### v0.0.2 / 2023-01-09
+ 
+* [CHANGE] Change Prometheus job name for the collector itself
+* [FIX] Change PodMonitor to ServiceMonitor since PodMonitor is not enabled in Deployment mode

--- a/otel-infrastructure-collector/Chart.yaml
+++ b/otel-infrastructure-collector/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-infrastructure-collector
 description: OpenTelemetry Infrastructure collector
-version: 0.0.1
+version: 0.0.2
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Infrastructure Collector

--- a/otel-infrastructure-collector/values.yaml
+++ b/otel-infrastructure-collector/values.yaml
@@ -47,7 +47,7 @@ opentelemetry-collector:
       prometheus:
         config:
           scrape_configs:
-            - job_name: opentelemetry-collector
+            - job_name: opentelemetry-infrastructure-collector
               scrape_interval: 30s
               static_configs:
                 - targets:
@@ -104,12 +104,12 @@ opentelemetry-collector:
       cpu: 1
       memory: 2G
 
-  # In order to enable podMonitor, following part must be enabled in order to expose the required port:
+  # In order to enable serviceMonitor, following part must be enabled in order to expose the required port:
   # ports:
   #   metrics:
   #     enabled: true
 
-  # podMonitor:
+  # serviceMonitor:
   #   enabled: true
 
   # prometheusRule:


### PR DESCRIPTION
### Updates and Fixes:  
* When using both the `otel-agent` and the `infrastructure-collector` we need to separate the **prometheus jobs** in order to be able to monitor both and have separate alerts on both collectors. 
* PodMonitor cant be enabled in deployment mode so changing to `ServiceMonitor`
* Added `CHANGELOG`