### PR TITLE
FIX: Add missing storage template to Prometheus agent

### DIFF
--- a/metrics/prometheus-agent/CHANGELOG.md
+++ b/metrics/prometheus-agent/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Prometheus-Agent
+
+### v0.0.2 / 2023-01-18
+ 
+* [FIX] Add Storage to the template

--- a/metrics/prometheus-agent/Chart.yaml
+++ b/metrics/prometheus-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus-agent-coralogix
 namespace: observability
 description: Prometheus running in agent mode
-version: 0.0.1
+version: 0.0.2
 appVersion: 0.61.1
 keywords:
   - prometheus

--- a/metrics/prometheus-agent/override.yaml
+++ b/metrics/prometheus-agent/override.yaml
@@ -1,5 +1,6 @@
 prometheus:
   prometheusSpec:
+
     remoteWrite:
     - authorization:
         credentials:
@@ -11,4 +12,16 @@ prometheus:
         maxSamplesPerSend: 1000
         maxShards: 200
       remoteTimeout: 120s
-      url: https://example-gateway.eu2.coralogix.com/prometheus/api/v1/write 
+      url: https://example-gateway.eu2.coralogix.com/prometheus/api/v1/write
+
+    storageSpec:
+      volumeClaimTemplate:
+        metadata:
+          labels:
+            prometheus: coralogix
+        spec:
+          accessModes: ["ReadWriteOnce"]
+          resources:
+            requests:
+              storage: 100Gi
+          storageClassName: monitoring

--- a/metrics/prometheus-agent/templates/prometheus.yaml
+++ b/metrics/prometheus-agent/templates/prometheus.yaml
@@ -105,3 +105,9 @@ spec:
 {{ else }}
   podMonitorNamespaceSelector: {}
 {{- end }}
+{{- if .Values.prometheus.prometheusSpec.storageSpec }}  
+  storage:
+{{ toYaml .Values.prometheus.prometheusSpec.storageSpec | indent 4 }}
+{{ else }}
+  storage: {}
+{{- end }}

--- a/metrics/prometheus-agent/values.yaml
+++ b/metrics/prometheus-agent/values.yaml
@@ -46,5 +46,17 @@ prometheus:
     #     prometheus: somelabel
     podMonitorNamespaceSelector: {}
     podMonitorSelector: {}
+    storageSpec: {}
+    #  volumeClaimTemplate:
+    #    metadata:
+    #      labels:
+    #        prometheus: coralogix
+    #    spec:
+    #      storageClassName: monitoring
+    #      accessModes: ["ReadWriteOnce"]
+    #      resources:
+    #        requests:
+    #          storage: 50Gi
+    #    selector: {}
   serviceAccount:
     create: true


### PR DESCRIPTION
The Prometheus agent needs a `disk` to keep the data when needed, 
and the storage configuration was not supported in the `template` until now.
So adding to the template , updating the override.yaml example file 