### PR TITLE
Add externallabels support to the prometheus template

### DIFF
--- a/metrics/prometheus-agent/CHANGELOG.md
+++ b/metrics/prometheus-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Prometheus-Agent
 
+### v0.0.3 / 2023-01-19
+
+* [FEATURE] Add template support for external labels 
+
 ### v0.0.2 / 2023-01-18
  
 * [FIX] Add Storage to the template

--- a/metrics/prometheus-agent/Chart.yaml
+++ b/metrics/prometheus-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus-agent-coralogix
 namespace: observability
 description: Prometheus running in agent mode
-version: 0.0.2
+version: 0.0.3
 appVersion: 0.61.1
 keywords:
   - prometheus

--- a/metrics/prometheus-agent/override.yaml
+++ b/metrics/prometheus-agent/override.yaml
@@ -1,6 +1,7 @@
 prometheus:
   prometheusSpec:
-
+    externalLabels:
+      prometheus: coralogix
     remoteWrite:
     - authorization:
         credentials:
@@ -13,7 +14,6 @@ prometheus:
         maxShards: 200
       remoteTimeout: 120s
       url: https://example-gateway.eu2.coralogix.com/prometheus/api/v1/write
-
     storageSpec:
       volumeClaimTemplate:
         metadata:

--- a/metrics/prometheus-agent/templates/prometheus.yaml
+++ b/metrics/prometheus-agent/templates/prometheus.yaml
@@ -111,3 +111,7 @@ spec:
 {{ else }}
   storage: {}
 {{- end }}
+{{- if .Values.prometheus.prometheusSpec.externalLabels }}
+  externalLabels:
+{{ tpl (toYaml .Values.prometheus.prometheusSpec.externalLabels | indent 4) . }}
+{{- end }}

--- a/metrics/prometheus-agent/values.yaml
+++ b/metrics/prometheus-agent/values.yaml
@@ -58,5 +58,6 @@ prometheus:
     #        requests:
     #          storage: 50Gi
     #    selector: {}
+    externalLabels: {}
   serviceAccount:
     create: true


### PR DESCRIPTION
In order to use externalLabels in remoteWrite, we need to be able to specify the external labels , which was not supoprted until now 