### PR TITLE
[FEAT] upgrading fluent-bit helm chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,3 +30,8 @@
 * [UPGRADE] Upgrade Fluent-Bit version to 1.9.3
 * [CHANGE] Set Retry_Limit to False [no limit] to keep retrying send the logs and not lose any data
   ([#48](https://github.com/coralogix/eng-integrations/pull/48))
+
+### v0.1.0 / 2023-02-03
+
+* [UPGRADE] Upgrade Fluent-bit version to 2.0.8
+* [CHANGE] Enable by default the new storage metrics plugins which gives more information about fluent bit ingestion.

--- a/logs/fluent-bit/k8s-helm/coralogix/Chart.yaml
+++ b/logs/fluent-bit/k8s-helm/coralogix/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
   - Coralogix output plugin
 dependencies:
   - name: fluent-bit
-    version: "0.19.20"
+    version: "0.23.0"
     repository: https://fluent.github.io/helm-charts
 sources:
   - https://github.com/fluent/fluent-bit/

--- a/logs/fluent-bit/k8s-helm/coralogix/Chart.yaml
+++ b/logs/fluent-bit/k8s-helm/coralogix/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: fluent-bit-coralogix
 description: Fluent-Bit Chart with Coralogix output plugin
-version: 0.0.3
-appVersion: 1.9.3
+version: 0.1.0
+appVersion: 2.0.8
 keywords:
   - Fluent-Bit
   - Coralogix output plugin

--- a/logs/fluent-bit/k8s-helm/coralogix/values.yaml
+++ b/logs/fluent-bit/k8s-helm/coralogix/values.yaml
@@ -3,10 +3,13 @@ fluent-bit:
 
   image:
     repository: coralogixrepo/coralogix-fluent-bit-multiarch
-    tag: v0.0.2
+    tag: v0.0.3
 
   serviceMonitor:
     enabled: true
+    additionalEndpoints:
+      - port: metrics
+        path: /metrics
 
   resources:
     limits:
@@ -23,6 +26,12 @@ fluent-bit:
   envFrom:
     - secretRef:
         name: coralogix-keys
+
+  extraPorts:
+    - port: 2021
+      containerPort: 2021
+      protocol: TCP
+      name: metrics
 
   #prometheusRule:
   #  enabled: true
@@ -114,6 +123,7 @@ fluent-bit:
           DB /var/log/fluentbit-tail.db
 
       @INCLUDE input-systemd.conf
+      @INCLUDE input-fluentbit-metrics.conf
 
     filters: |-
       [FILTER]
@@ -139,12 +149,20 @@ fluent-bit:
           Sub_Name_Key  ${SUB_SYSTEM}
 
       @INCLUDE output-systemd.conf
+      @INCLUDE output-fluentbit-metrics.conf
 
     extraFiles:
       plugins.conf: |-
         [PLUGINS]
             Path /fluent-bit/plugins/out_coralogix.so
-      
+
+      input-fluentbit-metrics.conf: |-
+        [INPUT]
+            name            fluentbit_metrics
+            tag             internal_metrics
+            scrape_interval 5
+            scrape_on_start true
+
       input-systemd.conf: |-    
         [INPUT]
             Name systemd
@@ -152,6 +170,13 @@ fluent-bit:
             Systemd_Filter _SYSTEMD_UNIT=kubelet.service
             Read_From_Tail On
             Mem_Buf_Limit 5MB
+
+      output-fluentbit-metrics.conf: |-
+        [OUTPUT]
+            name            prometheus_exporter
+            match           internal_metrics
+            host            0.0.0.0
+            port            2021
 
       output-systemd.conf: |-
         [OUTPUT]

--- a/logs/fluent-bit/k8s-helm/coralogix/values.yaml
+++ b/logs/fluent-bit/k8s-helm/coralogix/values.yaml
@@ -8,7 +8,7 @@ fluent-bit:
   serviceMonitor:
     enabled: true
     additionalEndpoints:
-      - port: metrics
+      - port: storage-metrics
         path: /metrics
 
   resources:
@@ -31,7 +31,7 @@ fluent-bit:
     - port: 2021
       containerPort: 2021
       protocol: TCP
-      name: metrics
+      name: storage-metrics
 
   #prometheusRule:
   #  enabled: true

--- a/logs/fluent-bit/k8s-manifest/fluentbit-cm.yaml
+++ b/logs/fluent-bit/k8s-manifest/fluentbit-cm.yaml
@@ -37,6 +37,8 @@ data:
         DB /var/log/fluentbit-tail.db
 
     @INCLUDE input-systemd.conf
+    @INCLUDE input-fluentbit-metrics.conf
+    
     [FILTER]
         Name kubernetes
         Match kube.*
@@ -79,6 +81,8 @@ data:
         net.keepalive         off
 
     @INCLUDE output-systemd.conf
+    @INCLUDE output-fluentbit-metrics.conf
+
   filters-systemd.conf: |
     [FILTER]
       Name    modify
@@ -95,6 +99,14 @@ data:
       Wildcard    _CMDLINE
       Wildcard    MESSAGE
       Nest_under  json
+
+  input-fluentbit-metrics.conf: |-
+    [INPUT]
+      name            fluentbit_metrics
+      tag             internal_metrics
+      scrape_interval 5
+      scrape_on_start true
+
   input-systemd.conf: |
     [INPUT]
       Name systemd
@@ -102,6 +114,7 @@ data:
       Systemd_Filter _SYSTEMD_UNIT=kubelet.service
       Read_From_Tail On
       Mem_Buf_Limit 5MB
+
   output-systemd.conf: |
     [OUTPUT]
       Name                  http
@@ -115,6 +128,14 @@ data:
       compress              gzip
       Retry_Limit           False
       net.keepalive         off
+
+  output-fluentbit-metrics.conf: |-
+    [OUTPUT]
+      name            prometheus_exporter
+      match           internal_metrics
+      host            0.0.0.0
+      port            2021
+
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/logs/fluent-bit/k8s-manifest/fluentbit-ds.yaml
+++ b/logs/fluent-bit/k8s-manifest/fluentbit-ds.yaml
@@ -38,7 +38,7 @@ spec:
             - name: http
               containerPort: 2020
               protocol: TCP
-            - name: metrics
+            - name: storage-metrics
               containerPort: 2021
               protocol: TCP
           livenessProbe:

--- a/logs/fluent-bit/k8s-manifest/fluentbit-ds.yaml
+++ b/logs/fluent-bit/k8s-manifest/fluentbit-ds.yaml
@@ -38,6 +38,9 @@ spec:
             - name: http
               containerPort: 2020
               protocol: TCP
+            - name: metrics
+              containerPort: 2021
+              protocol: TCP
           livenessProbe:
             httpGet:
               path: /
@@ -69,6 +72,12 @@ spec:
             - name: config
               mountPath: /fluent-bit/etc/output-systemd.conf
               subPath: output-systemd.conf
+            - name: config
+              mountPath: /fluent-bit/etc/input-fluentbit-metrics.conf
+              subPath: input-fluentbit-metrics.conf
+            - name: config
+              mountPath: /fluent-bit/etc/output-fluentbit-metrics.conf
+              subPath: output-fluentbit-metrics.conf
             - mountPath: /var/log
               name: varlog
             - mountPath: /var/lib/docker/containers

--- a/logs/fluent-bit/k8s-manifest/fluentbit-svc-monitor.yaml
+++ b/logs/fluent-bit/k8s-manifest/fluentbit-svc-monitor.yaml
@@ -9,7 +9,7 @@ spec:
   endpoints:
     - port: http
       path: /api/v1/metrics/prometheus
-    - port: metrics
+    - port: storage-metrics
       path: /metrics
   namespaceSelector:
     matchNames:

--- a/logs/fluent-bit/k8s-manifest/fluentbit-svc-monitor.yaml
+++ b/logs/fluent-bit/k8s-manifest/fluentbit-svc-monitor.yaml
@@ -9,6 +9,8 @@ spec:
   endpoints:
     - port: http
       path: /api/v1/metrics/prometheus
+    - port: metrics
+      path: /metrics
   namespaceSelector:
     matchNames:
       - monitoring

--- a/logs/fluent-bit/k8s-manifest/fluentbit-svc.yaml
+++ b/logs/fluent-bit/k8s-manifest/fluentbit-svc.yaml
@@ -15,7 +15,7 @@ spec:
     - port: 2021
       targetPort: http
       protocol: TCP
-      name: metrics
+      name: storage-metrics
   selector:
     app.kubernetes.io/name: fluent-bit
     app.kubernetes.io/instance: fluent-bit-http

--- a/logs/fluent-bit/k8s-manifest/fluentbit-svc.yaml
+++ b/logs/fluent-bit/k8s-manifest/fluentbit-svc.yaml
@@ -12,6 +12,10 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    - port: 2021
+      targetPort: http
+      protocol: TCP
+      name: metrics
   selector:
     app.kubernetes.io/name: fluent-bit
     app.kubernetes.io/instance: fluent-bit-http


### PR DESCRIPTION
I'm upgrading the fluent-bit version to 2.0.8 since we have new features like the new internal metrics plugin as described [here](https://docs.fluentbit.io/manual/pipeline/inputs/fluentbit-metrics) and also because this version has available features which can improve the performance on high volume environments such as the threaded mechanism allows input plugins to run in a separate thread which helps to desaturate the main pipeline and move certain loads to a different CPU core.

Because we want to enable the storage metrics by default, we also need to upgrade to the latest helm chart version which allows the configuration of `additionalEndpoints` on the ServiceMonitor and also the VPA manifest of non-enabled features.

Signed-off-by: Nicolas Takashi <nicolas.takashi@coralogix.com>