### PR TITLE
[FEAT] upgrading fluenbit http charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@
 
 ## Fluent-Bit
 
+### v0.1.0 / 2023-02-03
+
+* [UPGRADE] Upgrade Fluent-bit version to 2.0.8
+* [CHANGE] Enable by default the new storage metrics plugins which gives more information about fluent bit ingestion.
+
 ### v0.0.4 / 2023-01-23
 
 * Updating fluent-bit to the 2.0.5 version
@@ -30,8 +35,3 @@
 * [UPGRADE] Upgrade Fluent-Bit version to 1.9.3
 * [CHANGE] Set Retry_Limit to False [no limit] to keep retrying send the logs and not lose any data
   ([#48](https://github.com/coralogix/eng-integrations/pull/48))
-
-### v0.1.0 / 2023-02-03
-
-* [UPGRADE] Upgrade Fluent-bit version to 2.0.8
-* [CHANGE] Enable by default the new storage metrics plugins which gives more information about fluent bit ingestion.

--- a/logs/fluent-bit/k8s-helm/http/Chart.yaml
+++ b/logs/fluent-bit/k8s-helm/http/Chart.yaml
@@ -1,14 +1,14 @@
 apiVersion: v2
 name: fluent-bit-http
 description: Fluent-Bit Chart with HTTP output plugin
-version: 0.0.4
-appVersion: 1.9.3
+version: 0.1.0
+appVersion: 2.0.8
 keywords:
   - Fluent-Bit
   - HTTP output plugin
 dependencies:
   - name: fluent-bit
-    version: "0.19.20"
+    version: "0.23.0"
     repository: https://fluent.github.io/helm-charts
 sources:
   - https://github.com/fluent/fluent-bit/

--- a/logs/fluent-bit/k8s-helm/http/values.yaml
+++ b/logs/fluent-bit/k8s-helm/http/values.yaml
@@ -3,10 +3,13 @@ fluent-bit:
 
   image:
     repository: coralogixrepo/coralogix-fluent-bit-multiarch
-    tag: v0.0.2
+    tag: v0.0.3
 
   serviceMonitor:
     enabled: true
+    additionalEndpoints:
+      - port: storage-metrics
+        path: /metrics
 
   resources:
     limits:
@@ -23,6 +26,12 @@ fluent-bit:
   envFrom:
     - secretRef:
         name: coralogix-keys
+
+  extraPorts:
+    - port: 2021
+      containerPort: 2021
+      protocol: TCP
+      name: storage-metrics
 
   #prometheusRule:
   #  enabled: true
@@ -107,6 +116,7 @@ fluent-bit:
           DB /var/log/fluentbit-tail.db
 
       @INCLUDE input-systemd.conf
+      @INCLUDE input-fluentbit-metrics.conf
 
     filters: |-
       [FILTER]
@@ -153,6 +163,7 @@ fluent-bit:
           net.keepalive         off
 
       @INCLUDE output-systemd.conf
+      @INCLUDE output-fluentbit-metrics.conf
     
     extraFiles:
       input-systemd.conf: |-
@@ -162,6 +173,13 @@ fluent-bit:
           Systemd_Filter _SYSTEMD_UNIT=kubelet.service
           Read_From_Tail On
           Mem_Buf_Limit 5MB
+
+      input-fluentbit-metrics.conf: |-
+        [INPUT]
+          name            fluentbit_metrics
+          tag             internal_metrics
+          scrape_interval 5
+          scrape_on_start true
 
       filters-systemd.conf: |-
         [FILTER]
@@ -179,6 +197,13 @@ fluent-bit:
           Wildcard    _CMDLINE 
           Wildcard    MESSAGE
           Nest_under  json
+
+      output-fluentbit-metrics.conf: |-
+        [OUTPUT]
+          name            prometheus_exporter
+          match           internal_metrics
+          host            0.0.0.0
+          port            2021
 
       output-systemd.conf: |-
         [OUTPUT]


### PR DESCRIPTION
I'm upgrading the fluent-bit version to 2.0.8 since we have new features like the new internal metrics plugin as described [here](https://docs.fluentbit.io/manual/pipeline/inputs/fluentbit-metrics) and also because this version has available features which can improve the performance on high volume environments such as the threaded mechanism allows input plugins to run in a separate thread which helps to desaturate the main pipeline and move certain loads to a different CPU core.

Because we want to enable the storage metrics by default, we also need to upgrade to the latest helm chart version which allows the configuration of `additionalEndpoints` on the ServiceMonitor and also the VPA manifest of non-enabled features.

Signed-off-by: Nicolas Takashi <nicolas.takashi@coralogix.com>