### PR TITLE
FIX: serviceAccountName is taken from fullname and not from defauls

### DIFF
--- a/metrics/prometheus-agent/CHANGELOG.md
+++ b/metrics/prometheus-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Prometheus-Agent
 
+### v0.0.5 / 2023-02-08
+
+* [FIX] Update serviceAccount name template to use the fullName
+
 ### v0.0.4 / 2023-01-22
 
 * [FEATURE] Add Prometheus image to the template so it can be overriden

--- a/metrics/prometheus-agent/Chart.yaml
+++ b/metrics/prometheus-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus-agent-coralogix
 namespace: observability
 description: Prometheus running in agent mode
-version: 0.0.4
+version: 0.0.5
 appVersion: v2.41.0
 keywords:
   - prometheus

--- a/metrics/prometheus-agent/README.md
+++ b/metrics/prometheus-agent/README.md
@@ -55,7 +55,17 @@ Depending on your region, you need to configure correct Coralogix endpoint. Here
 
 ## Installation
 
-In order to override the Coralogix url, a new file must be created, including the following section:
+First make sure to add our Helm charts repository to the local repos list with the following command:
+```bash
+helm repo add coralogix-charts-virtual https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
+```
+
+In order to get the updated Helm charts from the added repository, please run: 
+```bash
+helm repo update
+```
+
+Before installing the chart, in order to override the Coralogix url, a new file must be created, including the following section:
 
 ```yaml
 ---
@@ -76,6 +86,7 @@ prometheus:
       url: https://prometheus-gateway.coralogix.in/prometheus/api/v1/write
 ```
 
+Install the chart:
 ```bash
 helm upgrade prometheus-agent coralogix-charts-virtual/prometheus-agent-coralogix \
   --install \

--- a/metrics/prometheus-agent/templates/_helpers.tpl
+++ b/metrics/prometheus-agent/templates/_helpers.tpl
@@ -31,8 +31,8 @@ Allow the release namespace to be overridden for multi-namespace deployments in 
 {{/* Create the name of prometheus service account to use */}}
 {{- define "prometheus-agent.serviceAccountName" -}}
 {{- if .Values.prometheus.prometheusSpec.serviceAccountName -}}
-    {{ default (print (include "prometheus-agent.fullname" .) "") .Values.prometheus.prometheusSpec.serviceAccountName }}
+    {{ .Values.prometheus.prometheusSpec.serviceAccountName }}
 {{- else -}}
-    {{ default "default" .Values.prometheus.prometheusSpec.serviceAccountName }}
+    {{- print (include "prometheus-agent.fullname" .) "" }}
 {{- end -}}
 {{- end -}}

--- a/metrics/prometheus-agent/values.yaml
+++ b/metrics/prometheus-agent/values.yaml
@@ -13,7 +13,6 @@ prometheus:
     logFormat: json
     logLevel: warn
     scrapeInterval: 30s
-    serviceAccountName: prometheus-agent
     remoteWrite:
     - authorization:
         credentials:


### PR DESCRIPTION
### Updates and Fixes : 
* The serviceaccount name is taken from the default values, otherwise its equal to `default`. 
Im updating the template to take either the fullname template, or if mentioned in the values.
* Updating README - updating the `installation part`, the helm repo add command is missing before the installation command