### PR TITLE
[UPDATE] otel helmchart version

### DIFF
--- a/otel-agent/CHANGELOG.md
+++ b/otel-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemtry-Agent
 
+### v0.0.20 / 2023-02-13
+
+* [UPRADE] Upgrading chart version from 0.47.0 to 0.48.1
+
 ### v0.0.19 / 2023-01-26
 
 * [CHORE] Update OpenTelemetry Collector to v0.70.0

--- a/otel-agent/k8s-helm/Chart.yaml
+++ b/otel-agent/k8s-helm/Chart.yaml
@@ -1,14 +1,14 @@
 apiVersion: v2
 name: opentelemetry-coralogix
 description: OpenTelemetry agent to which instrumentation libraries export their telemetry data
-version: 0.0.19
+version: 0.0.20
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry agent
   - Coralogix
 dependencies:
   - name: opentelemetry-collector
-    version: "0.47.0"
+    version: "0.48.1"
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
 sources:
   - https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector


### PR DESCRIPTION
I'm upgrading OTEL helm chart version to be able to use the latest OTEL version and leverage k8sobjectreceiver 