### PR TITLE
FIX: update prometheus agent storage template to allow empty value

### DIFF
--- a/metrics/prometheus-agent/CHANGELOG.md
+++ b/metrics/prometheus-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Prometheus-Agent
 
+### v0.0.6 / 2023-02-15
+
+* [FIX] Fix storage template to enable an empty storage field    
+
 ### v0.0.5 / 2023-02-08
 
 * [FIX] Update serviceAccount name template to use the fullName

--- a/metrics/prometheus-agent/Chart.yaml
+++ b/metrics/prometheus-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus-agent-coralogix
 namespace: observability
 description: Prometheus running in agent mode
-version: 0.0.5
+version: 0.0.6
 appVersion: v2.41.0
 keywords:
   - prometheus

--- a/metrics/prometheus-agent/templates/prometheus.yaml
+++ b/metrics/prometheus-agent/templates/prometheus.yaml
@@ -108,8 +108,6 @@ spec:
 {{- if .Values.prometheus.prometheusSpec.storageSpec }}  
   storage:
 {{ toYaml .Values.prometheus.prometheusSpec.storageSpec | indent 4 }}
-{{ else }}
-  storage: {}
 {{- end }}
 {{- if .Values.prometheus.prometheusSpec.externalLabels }}
   externalLabels:


### PR DESCRIPTION
### FIX: 
When using the default values which include `storageSpec: {}`,
it set the storage as {} inside the final yaml file, which is causing the following error:  
`PersistentVolumeClaim "prometheus-agent-0" is invalid: spec.resources[storage]: Required value` .

Therefore im changing it - if the storageSpec is not empty, is takes the values, otherwise, the storage field won't appear at all 