### PR TITLE
[CHORE] upgrading otel helm chart

### DIFF
--- a/otel-infrastructure-collector/k8s-helm/CHANGELOG.md
+++ b/otel-infrastructure-collector/k8s-helm/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemtry-Infrastructure-Collector
 
+### v0.0.4 / 2023-02-24
+
+* [UPRADE] Upgrading chart version from 0.48.1 to 0.49.0
+
 ### v0.0.3 / 2023-02-14
 
 * [UPRADE] Upgrading chart version from 0.40.7 to 0.48.1

--- a/otel-infrastructure-collector/k8s-helm/Chart.yaml
+++ b/otel-infrastructure-collector/k8s-helm/Chart.yaml
@@ -1,14 +1,14 @@
 apiVersion: v2
 name: otel-infrastructure-collector
 description: OpenTelemetry Infrastructure collector
-version: 0.0.3
+version: 0.0.4
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Infrastructure Collector
   - Coralogix
 dependencies:
   - name: opentelemetry-collector
-    version: "0.48.1"
+    version: "0.49.0"
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
 sources:
   - https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector


### PR DESCRIPTION
Upgrading the upstream helm chart to the latest version, so that we can leverage the upgrades on k8sobjects receiver and watch events instead of pull.