### PR TITLE
[FEATURE] changing prometheus agent to use default configs

### DIFF
--- a/metrics/prometheus-agent/CHANGELOG.md
+++ b/metrics/prometheus-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Prometheus-Agent
 
+### v0.0.8 / 2023-02-20
+
+* [FEATURE] Adding Self Monitor
+* [FEATURE] Adding extra features to improve restarts
+
 ### v0.0.7 / 2023-02-20
 
 * [UPGRADE] Upgrade prometheus version to 2.42.0

--- a/metrics/prometheus-agent/Chart.yaml
+++ b/metrics/prometheus-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus-agent-coralogix
 namespace: observability
 description: Prometheus running in agent mode
-version: 0.0.7
+version: 0.0.8
 appVersion: v2.42.0
 keywords:
   - prometheus

--- a/metrics/prometheus-agent/templates/_helpers.tpl
+++ b/metrics/prometheus-agent/templates/_helpers.tpl
@@ -36,3 +36,22 @@ Allow the release namespace to be overridden for multi-namespace deployments in 
     {{- print (include "prometheus-agent.fullname" .) "" }}
 {{- end -}}
 {{- end -}}
+
+{{/* Sets default scrape limits for servicemonitor */}}
+{{- define "servicemonitor.scrapeLimits" -}}
+{{- with .sampleLimit }}
+sampleLimit: {{ . }}
+{{- end }}
+{{- with .targetLimit }}
+targetLimit: {{ . }}
+{{- end }}
+{{- with .labelLimit }}
+labelLimit: {{ . }}
+{{- end }}
+{{- with .labelNameLengthLimit }}
+labelNameLengthLimit: {{ . }}
+{{- end }}
+{{- with .labelValueLengthLimit }}
+labelValueLengthLimit: {{ . }}
+{{- end }}
+{{- end -}}

--- a/metrics/prometheus-agent/templates/prometheus.yaml
+++ b/metrics/prometheus-agent/templates/prometheus.yaml
@@ -3,6 +3,12 @@ kind: Prometheus
 metadata:
   name: {{ template "prometheus-agent.name" . }} 
   namespace: {{ template "prometheus-agent.namespace" . }}
+  labels:
+    app: {{ template "prometheus-agent.name" . }}
+    app.kubernetes.io/name: {{ template "prometheus-agent.name" . }}
+    app.kubernetes.io/component: prometheus
+    release: {{ $.Release.Name | quote }}
+    self-monitor: {{ .Values.prometheus.serviceMonitor.selfMonitor | quote}}
 spec:
   alerting: null
   ruleNamespaceSelector: null
@@ -13,7 +19,11 @@ spec:
   containers:
   - args:
     - --config.file=/etc/prometheus/config_out/prometheus.env.yaml
-    - --enable-feature=promql-at-modifier,agent
+    {{- if .Values.prometheus.prometheusSpec.enableFeatures }}
+    - --enable-feature=agent,{{ join "," .Values.prometheus.prometheusSpec.enableFeatures }}
+    {{- else }}
+    - --enable-feature=agent
+    {{- end }}
     - --storage.agent.path=/prometheus
     - --web.enable-lifecycle
     - --web.console.templates=/etc/prometheus/consoles
@@ -21,12 +31,6 @@ spec:
     - --web.route-prefix=/
     - --web.config.file=/etc/prometheus/web_config/web-config.yaml
     name: prometheus
-{{- if .Values.prometheus.prometheusSpec.enableFeatures }}
-  enableFeatures:
-{{- range $enableFeatures := .Values.prometheus.prometheusSpec.enableFeatures }}
-  - {{ tpl $enableFeatures $ }}
-{{- end }}
-{{- end }}
 {{- if .Values.prometheus.prometheusSpec.tolerations }}
   tolerations:
 {{ toYaml .Values.prometheus.prometheusSpec.tolerations | indent 4 }}

--- a/metrics/prometheus-agent/templates/serviceMonitor.yaml
+++ b/metrics/prometheus-agent/templates/serviceMonitor.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.prometheus.serviceMonitor.selfMonitor }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "prometheus-agent.name" . }}
+  namespace: {{ template "prometheus-agent.namespace" . }}
+  labels:
+    app: {{ template "prometheus-agent.name" . }}
+spec:
+  {{- include "servicemonitor.scrapeLimits" .Values.prometheus.serviceMonitor | nindent 2 }}
+  selector:
+    matchLabels:
+      app: {{ template "prometheus-agent.name" . }}
+      release: {{ $.Release.Name | quote }}
+      self-monitor: "true"
+  namespaceSelector:
+    matchNames:
+      - {{ printf "%s" (include "prometheus-agent.namespace" .) | quote }}
+  endpoints:
+  - port: {{ .Values.prometheus.prometheusSpec.portName }}
+    {{- if .Values.prometheus.serviceMonitor.interval }}
+    interval: {{ .Values.prometheus.serviceMonitor.interval }}
+    {{- end }}
+    {{- if .Values.prometheus.serviceMonitor.scheme }}
+    scheme: {{ .Values.prometheus.serviceMonitor.scheme }}
+    {{- end }}
+    {{- if .Values.prometheus.serviceMonitor.tlsConfig }}
+    tlsConfig: {{ toYaml .Values.prometheus.serviceMonitor.tlsConfig | nindent 6 }}
+    {{- end }}
+    {{- if .Values.prometheus.serviceMonitor.bearerTokenFile }}
+    bearerTokenFile: {{ .Values.prometheus.serviceMonitor.bearerTokenFile }}
+    {{- end }}
+    path: "{{ trimSuffix "/" .Values.prometheus.prometheusSpec.routePrefix }}/metrics"
+{{- if .Values.prometheus.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+{{ tpl (toYaml .Values.prometheus.serviceMonitor.metricRelabelings | indent 6) . }}
+{{- end }}
+{{- if .Values.prometheus.serviceMonitor.relabelings }}
+    relabelings:
+{{ toYaml .Values.prometheus.serviceMonitor.relabelings | indent 6 }}
+{{- end }}
+{{- end }}

--- a/metrics/prometheus-agent/values.yaml
+++ b/metrics/prometheus-agent/values.yaml
@@ -6,6 +6,10 @@ global:
 
 prometheus:
   prometheusSpec:
+    routePrefix: /
+    enableFeatures:
+      - memory-snapshot-on-shutdown
+      - new-service-discovery-manager
     image: 
       repository: quay.io/prometheus/prometheus
       tag: v2.42.0
@@ -21,7 +25,7 @@ prometheus:
       name: prometheus-agent-coralogix
       queueConfig:
         capacity: 2500
-        maxSamplesPerSend: 1000
+        maxSamplesPerSend: 500
         maxShards: 200
       remoteTimeout: 120s
       url: https://prometheus-gateway.eu2.coralogix.com/prometheus/api/v1/write 
@@ -62,3 +66,17 @@ prometheus:
     externalLabels: {}
   serviceAccount:
     create: true
+  serviceMonitor:
+    interval: ""
+    selfMonitor: true
+    sampleLimit: 0
+    targetLimit: 0
+    labelLimit: 0
+    labelNameLengthLimit: 0
+    labelValueLengthLimit: 0
+    scheme: ""
+    tlsConfig: {}
+    bearerTokenFile:
+    metricRelabelings: []
+    relabelings: []
+


### PR DESCRIPTION
I'm changing the Prometheus agent to use default values in terms of shards and max samples sent and also adding a self-monitor feature as well as a snapshot on WAL to improve restarts.