### PR TITLE
[FEATURE] adding startup probe override

### DIFF
--- a/metrics/prometheus-agent/CHANGELOG.md
+++ b/metrics/prometheus-agent/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Prometheus-Agent
 
 ### v0.0.9 / 2023-02-20
+* [FEATURE] Adding Prometheus Startup Probe Override
+
+### v0.0.9 / 2023-02-20
 * [FEATURE] Adding Prometheus Service
 
 ### v0.0.8 / 2023-02-20

--- a/metrics/prometheus-agent/Chart.yaml
+++ b/metrics/prometheus-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus-agent-coralogix
 namespace: observability
 description: Prometheus running in agent mode
-version: 0.0.9
+version: 0.0.10
 appVersion: v2.42.0
 keywords:
   - prometheus

--- a/metrics/prometheus-agent/templates/prometheus.yaml
+++ b/metrics/prometheus-agent/templates/prometheus.yaml
@@ -30,6 +30,11 @@ spec:
     - --web.route-prefix=/
     - --web.config.file=/etc/prometheus/web_config/web-config.yaml
     name: prometheus
+    startupProbe:
+      failureThreshold: {{ .Values.prometheus.prometheusSpec.startupProbe.failureThreshold }}
+      periodSeconds: {{ .Values.prometheus.prometheusSpec.startupProbe.periodSeconds }}
+      successThreshold: {{ .Values.prometheus.prometheusSpec.startupProbe.successThreshold }}
+      timeoutSeconds: {{ .Values.prometheus.prometheusSpec.startupProbe.timeoutSeconds }}
 {{- if .Values.prometheus.prometheusSpec.tolerations }}
   tolerations:
 {{ toYaml .Values.prometheus.prometheusSpec.tolerations | indent 4 }}

--- a/metrics/prometheus-agent/values.yaml
+++ b/metrics/prometheus-agent/values.yaml
@@ -23,6 +23,11 @@ prometheus:
   prometheusSpec:
     portName: "http-web"
     routePrefix: /
+    startupProbe:
+      failureThreshold: 60
+      periodSeconds: 15
+      successThreshold: 1
+      timeoutSeconds: 3
     enableFeatures:
       - memory-snapshot-on-shutdown
       - new-service-discovery-manager


### PR DESCRIPTION
I'm adding the ability to override default values for the startup probe, this is useful when Prometheus is getting too long to be ready due to WAL replay.