### PR TITLE
Disable PodSecurityPolicy for Fluentd

### DIFF
--- a/logs/CHANGELOG.md
+++ b/logs/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Fluentd-http
 
 ### v0.0.11 / 2023-03-13
-* [CHANGE] 
+* [CHANGE] Disable PodSecurityPolicy
 
 ### v0.0.3 / 2022-04-26
 

--- a/logs/CHANGELOG.md
+++ b/logs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Fluentd-http
 
+### v0.0.11 / 2023-03-13
+* [CHANGE] 
+
 ### v0.0.3 / 2022-04-26
 
 * [UPGRADE] Upgrade Fluentd version to v1.14.6 

--- a/logs/fluentd/k8s-helm/http/Chart.yaml
+++ b/logs/fluentd/k8s-helm/http/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: fluentd-http
 description: Fluentd Chart with HTTP output plugin
-version: 0.0.10
+version: 0.0.11
 appVersion: v1.14.6
 keywords:
   - Fluentd

--- a/logs/fluentd/k8s-helm/http/README.md
+++ b/logs/fluentd/k8s-helm/http/README.md
@@ -42,6 +42,10 @@ helm upgrade fluentd-http coralogix-charts-virtual/fluentd-http \
   -f override.yaml
 ```
 
+## Kubernetes Version 1.25+
+PodSecurityPolicy is deprecated in Kubernetes v1.21+, and unavailable in Kubernetes v1.25+.
+Therefore, the PodSecurityPolicy is disabled in this chart since version 0.0.11.
+
 ## Coralogix Endpoints
 
 | Region  | Logs Endpoint

--- a/logs/fluentd/k8s-helm/http/values.yaml
+++ b/logs/fluentd/k8s-helm/http/values.yaml
@@ -5,6 +5,9 @@ fluentd:
     repository: coralogixrepo/coralogix-fluentd-multiarch
     tag: v0.0.9
 
+  podSecurityPolicy:
+    enabled: false
+
   resources:
     requests:
       cpu: 800m


### PR DESCRIPTION
`PodSecurityPolicy` is deprecated in Kubernetes v1.21+, and unavailable in Kubernetes v1.25+, 
therefore - Im disabling the PodSecurityPolicy by default [in fluentbit its already disabled by default]. 
* Also moved the changelog to the logs directory because it was at the root path but its only related to fluentd fluentbit 