### PR TITLE
[otel-agent] change dns policy and update collector

### DIFF
--- a/otel-agent/CHANGELOG.md
+++ b/otel-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## OpenTelemtry-Agent
 
+### v0.0.23 / 2023-03-29
+
+* [CHORE] Update OpenTelemetry Collector to v0.74.0
+* [FIX] Change DNS policy to ClusterFirstWithHostNet,
+
 ### v0.0.22 / 2023-02-24
 
 * [CHORE] Update OpenTelemetry Collector to v0.72.0

--- a/otel-agent/k8s-helm/Chart.yaml
+++ b/otel-agent/k8s-helm/Chart.yaml
@@ -1,14 +1,14 @@
 apiVersion: v2
 name: opentelemetry-coralogix
 description: OpenTelemetry agent to which instrumentation libraries export their telemetry data
-version: 0.0.22
+version: 0.0.23
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry agent
   - Coralogix
 dependencies:
   - name: opentelemetry-collector
-    version: "0.49.0"
+    version: "0.51.2"
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
 sources:
   - https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector

--- a/otel-agent/k8s-helm/values.yaml
+++ b/otel-agent/k8s-helm/values.yaml
@@ -12,6 +12,7 @@ global:
 opentelemetry-collector:
   mode: daemonset
   hostNetwork: true
+  dnsPolicy: "ClusterFirstWithHostNet"
   fullnameOverride: otel-coralogix
   clusterRole:
     name: "otel-coralogix"


### PR DESCRIPTION
Updating the DNS Policy based on K8s recommendations -> https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy

and bumping collector version