### PR TITLE
[FIX] Prometheus Agent logs configuration

### DIFF
--- a/metrics/prometheus-agent/CHANGELOG.md
+++ b/metrics/prometheus-agent/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Prometheus-Agent
 
 ### v0.0.10 / 2023-02-20
+* [FIX] Prometheus Agent logs config
+
+### v0.0.10 / 2023-02-20
 * [FEATURE] Adding shard support
 
 ### v0.0.9 / 2023-02-20

--- a/metrics/prometheus-agent/Chart.yaml
+++ b/metrics/prometheus-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: prometheus-agent-coralogix
 namespace: observability
 description: Prometheus running in agent mode
-version: 0.0.10
+version: 0.0.11
 appVersion: v2.42.0
 keywords:
   - prometheus

--- a/metrics/prometheus-agent/templates/prometheus.yaml
+++ b/metrics/prometheus-agent/templates/prometheus.yaml
@@ -29,6 +29,8 @@ spec:
     - --web.console.libraries=/etc/prometheus/console_libraries
     - --web.route-prefix=/
     - --web.config.file=/etc/prometheus/web_config/web-config.yaml
+    - --log.level={{ .Values.prometheus.prometheusSpec.logLevel }}
+    - --log.format={{ .Values.prometheus.prometheusSpec.logFormat }}
     name: prometheus
     startupProbe:
       failureThreshold: {{ .Values.prometheus.prometheusSpec.startupProbe.failureThreshold }}
@@ -84,8 +86,6 @@ spec:
   shards: {{ .Values.prometheus.prometheusSpec.shards }}
   replicas: {{ .Values.prometheus.prometheusSpec.replicas }}
   enableAdminAPI: {{ .Values.prometheus.prometheusSpec.enableAdminAPI }}
-  logLevel: {{ .Values.prometheus.prometheusSpec.logLevel }}
-  logFormat: {{ .Values.prometheus.prometheusSpec.logFormat }}
 {{- if .Values.prometheus.prometheusSpec.resources }}
   resources:
 {{ toYaml .Values.prometheus.prometheusSpec.resources | indent 4 }}


### PR DESCRIPTION
Since we're creating our own Prometheus CRD, because Prometheus Operator still doesn't have Prometheus Agent Available, we need to change the logs config from the CRD Properties to the container flags