### PR TITLE
Corrected referenced configmap name

### DIFF
--- a/logs/fluent-bit/k8s-manifest/fluentbit-ds.yaml
+++ b/logs/fluent-bit/k8s-manifest/fluentbit-ds.yaml
@@ -33,7 +33,7 @@ spec:
             - secretRef:
                 name: coralogix-keys
             - configMapRef:
-                name: fluent-bit-env
+                name: fluent-bit
           ports:
             - name: http
               containerPort: 2020


### PR DESCRIPTION
The created configmap name is fluent-bit not fluent-bit-env