### PR TITLE
Update prometheus-agent version to `v2.43.0-stringlabels`

### DIFF
--- a/metrics/prometheus-agent/values.yaml
+++ b/metrics/prometheus-agent/values.yaml
@@ -33,7 +33,7 @@ prometheus:
       - new-service-discovery-manager
     image: 
       repository: quay.io/prometheus/prometheus
-      tag: v2.42.0
+      tag: v2.43.0-stringlabels
     enableAdminAPI: true
     logFormat: json
     logLevel: warn


### PR DESCRIPTION
As part of my onboarding, I'm attempting a small change to the observability stack 😅.

This PR aims to update the image version of Prometheus Agent and [bring memory improvements with it](https://github.com/prometheus/prometheus/releases/tag/v2.43.0).

The memory improvements are mostly on how Labels are indexed. Since we're using Agents, the storage layers is not used that much, so I don't expect to see a huuuuuge improvement. The main reason for this PR is for me to experience how deployments work at Coralogix 😛 