### PR TITLE
[agent] remove default value for domain field

### DIFF
--- a/otel-agent/k8s-helm/values.yaml
+++ b/otel-agent/k8s-helm/values.yaml
@@ -1,5 +1,5 @@
 global:
-  domain: "<domain-here>"
+  domain: ""
   defaultApplicationName: "default"
   defaultSubsystemName: "nodes"
 


### PR DESCRIPTION
Since this was accidentally released as patch version, I want to change default value to empty so it doesn't break any users (it will fall-through and use endpoint based config instead)