### PR TITLE
fix default values for prometheus.monitoring.coreos.com/v1

### DIFF
--- a/metrics/prometheus-agent/CHANGELOG.md
+++ b/metrics/prometheus-agent/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Prometheus-Agent
 
+### v0.0.13 / 2023-05-22
+* [FIX] Provide default values for prometheus.monitoring.coreos.com since null values are not allowed
+
 ### v0.0.12 / 2023-02-20
 * [UPGRADE] Upgrade prometheus version to 2.43.0-stringlabels
 

--- a/metrics/prometheus-agent/Chart.yaml
+++ b/metrics/prometheus-agent/Chart.yaml
@@ -1,8 +1,7 @@
 apiVersion: v2
 name: prometheus-agent-coralogix
-namespace: observability
 description: Prometheus running in agent mode
-version: 0.0.12
+version: 0.0.13
 appVersion: v2.42.0
 keywords:
   - prometheus

--- a/metrics/prometheus-agent/templates/prometheus.yaml
+++ b/metrics/prometheus-agent/templates/prometheus.yaml
@@ -14,7 +14,7 @@ spec:
   ruleSelector: {}
   walCompression: true
   disableCompaction: false
-  retention: 10d
+  retention: 2h
   containers:
   - args:
     - --config.file=/etc/prometheus/config_out/prometheus.env.yaml

--- a/metrics/prometheus-agent/templates/prometheus.yaml
+++ b/metrics/prometheus-agent/templates/prometheus.yaml
@@ -1,7 +1,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: Prometheus
 metadata:
-  name: {{ template "prometheus-agent.name" . }} 
+  name: {{ template "prometheus-agent.name" . }}
   namespace: {{ template "prometheus-agent.namespace" . }}
   labels:
     app: {{ template "prometheus-agent.name" . }}
@@ -9,12 +9,12 @@ metadata:
     app.kubernetes.io/component: prometheus
     release: {{ $.Release.Name | quote }}
 spec:
-  alerting: null
-  ruleNamespaceSelector: null
-  ruleSelector: null
-  walCompression: null
-  disableCompaction: null
-  retention: null
+  alerting: {}
+  ruleNamespaceSelector: {}
+  ruleSelector: {}
+  walCompression: true
+  disableCompaction: false
+  retention: 10d
   containers:
   - args:
     - --config.file=/etc/prometheus/config_out/prometheus.env.yaml
@@ -114,7 +114,7 @@ spec:
 {{ else }}
   podMonitorNamespaceSelector: {}
 {{- end }}
-{{- if .Values.prometheus.prometheusSpec.storageSpec }}  
+{{- if .Values.prometheus.prometheusSpec.storageSpec }}
   storage:
 {{ toYaml .Values.prometheus.prometheusSpec.storageSpec | indent 4 }}
 {{- end }}


### PR DESCRIPTION
# Description

<!-- Please describe the changes you made in a few words or sentences. -->
Providing null values is not allowed for this object thus I provided default values as per the [official prometheus community repo](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml)

error received when trying to apply:
```
Prometheus.monitoring.coreos.com "prometheus-agent" is invalid: [spec.disableCompaction: Invalid value: "null": spec.disableCompaction in body must be of type boolean: "null", spec.retention: Invalid value: "null": spec.retention in body must be of type string: "null", spec.alerting: Invalid value: "null": spec.alerting in body must be of type object: "null", spec.ruleNamespaceSelector: Invalid value: "null": spec.ruleNamespaceSelector in body must be of type object: "null", spec.walCompression: Invalid value: "null": spec.walCompression in body must be of type boolean: "null", spec.ruleSelector: Invalid value: "null": spec.ruleSelector in body must be of type object: "null"]
```

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [x] This change does not affect any particular component (e.g. it's CI or docs change)
