### PR TITLE
[prometheus-operator-coralogix] Update prometheus-kube-stack chart version

### DIFF
--- a/metrics/prometheus/operator/Chart.yaml
+++ b/metrics/prometheus/operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus-operator-coralogix
 description: Prometheus operator for coralogix
-version: 0.0.1
+version: 0.0.2
 appVersion: 0.60.1
 keywords:
   - Prometheus

--- a/metrics/prometheus/operator/Chart.yaml
+++ b/metrics/prometheus/operator/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
   - Prometheus operator
   - Coralogix
 dependencies:
-  - name: kube-prometheus-stack 
-    version: "41.7.3"
+  - name: kube-prometheus-stack
+    version: "45.30.0"
     repository: https://prometheus-community.github.io/helm-charts
 sources:
   - https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack

--- a/metrics/prometheus/operator/README.md
+++ b/metrics/prometheus/operator/README.md
@@ -32,7 +32,7 @@ kind: Secret
 metadata:
   name: coralogix-keys
   namespace: <the-release-namespace>
-type: Opaque 
+type: Opaque
 ```
 
 ### Coralogix's Endpoints
@@ -60,14 +60,14 @@ global:
 #values.yaml:
 ---
 kube-prometheus-stack:
-  prometheus: 
-    prometheusSpec: 
+  prometheus:
+    prometheusSpec:
       secrets: [] ## important when not using a secret
       remoteWrite:
         - url: '<remote_write_endpoint>'
           name: 'crx'
           remoteTimeout: 120s
-          bearerToken: '<private_key>' 
+          bearerToken: '<private_key>'
 ```
 
 ## Installation
@@ -239,6 +239,10 @@ helm uninstall prometheus-coralogix \
 # Dependencies
 
 This chart uses [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) chart.
+
+<!---
+since version 0.0.2 the Chart was updated to use prometheus-kube-stack v45.30.0 due to deprecation of autoscaling/v1beta object in Kubernetes v1.23+
+-->
 
 ## Example App with Pod Selector:
 


### PR DESCRIPTION
# Description

<!-- Please describe the changes you made in a few words or sentences. -->
Update dependency `prometheus-kube-stack` to use latest version due to previous versions using `autoscaler/v1beta` which is now deprecated since v1.23+
Fixed on this [PR](https://github.com/prometheus-community/helm-charts/pull/3413) (also by me :) )
Above PR will pull the latest image tag of kube-state-metrics which already uses `autoscaler/v1`

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s) (There is no Changelog for this component)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
