### PR TITLE
fix issue with prometheus agent and operator

### DIFF
--- a/metrics/prometheus-agent/CHANGELOG.md
+++ b/metrics/prometheus-agent/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Prometheus-Agent
 
+### v0.0.14 / 2023-05-22
+* [FIX] Remove non required objects from Prometheus object
+
 ### v0.0.13 / 2023-05-22
 * [FIX] Provide default values for prometheus.monitoring.coreos.com since null values are not allowed
 

--- a/metrics/prometheus-agent/Chart.yaml
+++ b/metrics/prometheus-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus-agent-coralogix
 description: Prometheus running in agent mode
-version: 0.0.13
+version: 0.0.14
 appVersion: v2.42.0
 keywords:
   - prometheus

--- a/metrics/prometheus-agent/templates/prometheus.yaml
+++ b/metrics/prometheus-agent/templates/prometheus.yaml
@@ -9,9 +9,6 @@ metadata:
     app.kubernetes.io/component: prometheus
     release: {{ $.Release.Name | quote }}
 spec:
-  alerting: {}
-  ruleNamespaceSelector: {}
-  ruleSelector: {}
   walCompression: true
   disableCompaction: false
   retention: 2h

--- a/metrics/prometheus/operator/Chart.yaml
+++ b/metrics/prometheus/operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: prometheus-operator-coralogix
 description: Prometheus operator for coralogix
-version: 0.0.2
+version: 0.0.3
 appVersion: 0.60.1
 keywords:
   - Prometheus

--- a/metrics/prometheus/operator/values.yaml
+++ b/metrics/prometheus/operator/values.yaml
@@ -3,8 +3,13 @@ global:
 
 kube-prometheus-stack:
   fullnameOverride: prometheus-coralogix
-  prometheus: 
-    prometheusSpec: 
+  # hack in order to bypass issue with kube-prometheus-stack chart which always prints empty labels if not adding this
+  # https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node-exporter.yaml#L47
+  defaultRules:
+    additionalRuleLabels:
+      app: prometheus-coralogix
+  prometheus:
+    prometheusSpec:
       ## disable the extra label added to the monitors
       ## to allow monitors to be added outside of the chart
       podMonitorSelectorNilUsesHelmValues: false


### PR DESCRIPTION
# Description

<!-- Please describe the changes you made in a few words or sentences. -->
Since upgrading to kube-prometheus-stack 45.30.0 there is an issue with the chart which causes empty labels to always be printed in prometheus.rules, for example [here](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/node-exporter.yaml#L47)

this will be rendered as follows:
<img width="607" alt="image" src="https://github.com/coralogix/telemetry-shippers/assets/132813522/79f80b39-ef49-439c-bd9c-19b8ce761553">

adding new values fixes the issue and renders the rules correcly.
I couldn't find a valid reason for this to happen so had to use this workaround.

In addition removed non required values from prometheus-agent which caused it crash
<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #

# How Has This Been Tested?

deployed locally
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [x] This change does not affect any particular component (e.g. it's CI or docs change)
