### PR TITLE
[k8s-helm-windows] Use image from Docker Hub 

### DIFF
--- a/otel-agent/k8s-helm-windows/CHANGELOG.md
+++ b/otel-agent/k8s-helm-windows/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## OpenTelemtry Agent for Windows
 
+### v0.0.3 / 2023-05-23
+* Use image from Coralogix Docker Hub instead of the test image.
+
 ### v0.0.2 / 2023-05-23
 * Add Service for DaemonSet, since windows does not support hostnetworking
 * Fix includeCollectorLogs=true breaks configuration.

--- a/otel-agent/k8s-helm-windows/Chart.yaml
+++ b/otel-agent/k8s-helm-windows/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-coralogix-windows
-version: 0.0.2
+version: 0.0.3
 description: Windows OpenTelemetry agent to which instrumentation libraries export their telemetry data
 type: application
 appVersion: 0.77.0

--- a/otel-agent/k8s-helm-windows/README.md
+++ b/otel-agent/k8s-helm-windows/README.md
@@ -17,4 +17,4 @@ helm upgrade --install otel-coralogix-agent-windows coralogix-charts-virtual/ope
 
 ## Docker image
 
-To build OpenTelemetry Collector Contrib use [the Dockerfile available in here](https://github.com/coralogix/telemetry-shippers/tree/collector-win-image/otel-agent/windows).
+To build OpenTelemetry Collector Contrib use [the Dockerfile available in here](https://github.com/coralogix/telemetry-shippers/tree/master/otel-agent/otel-collector-windows-image).

--- a/otel-agent/k8s-helm-windows/values.yaml
+++ b/otel-agent/k8s-helm-windows/values.yaml
@@ -207,7 +207,7 @@ config:
           - zipkin
 image:
   # If you want to use the core image `otel/opentelemetry-collector`, you also need to change `command.name` value to `otelcol`.
-  repository: quay.io/gmat90/otel-collector-contrib-windows
+  repository: coralogixrepo/opentelemetry-collector-contrib-windows
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: "latest"

--- a/otel-agent/otel-collector-windows-image/README.md
+++ b/otel-agent/otel-collector-windows-image/README.md
@@ -2,7 +2,7 @@
 
 This is an (unofficial) Docker image for the OpenTelemetry Collector Contrib distribution, based on the [official OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector-releases/releases) Windows releases.
 
-These images are published on Docker Hub. The tag version always corresponds to the official OpenTelemetry Collector release version.
+These images are published on [Docker Hub](https://hub.docker.com/r/coralogixrepo/opentelemetry-collector-contrib-windows). The tag version always corresponds to the official OpenTelemetry Collector release version.
 
 Depending on your Windows server version you can use images:
 - For Windows 2019: `coralogixrepo/opentelemetry-collector-contrib-windows:latest`, `coralogixrepo/opentelemetry-collector-contrib-windows:<semantic_version>`


### PR DESCRIPTION
# Description

[SC-18267]

Use the "official" Coralogix image instead of the testing one.

# How Has This Been Tested?

N/A.

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
