### PR TITLE
[CDS-337] updated default otel config for ecs agent to support domain key for Coralogix Exporter

### DIFF
--- a/otel-agent/CHANGELOG.md
+++ b/otel-agent/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## OpenTelemtry-Agent
 
-### v0.0.27 / 2023-05-12
+### v0.0.27 / 2023-05-24
 [CHORE] Updated default otel agent config.yaml for ecs to support the new domain key for the Coralogix exporter
 
-### v0.0.26 / 2023-05-12
+### v0.0.26 / 2023-05-24
 * [UPGRADE] coralogixrepo/otel-coralogix-ecs-ec2 container version updated to 0.78.0
 
 ### v0.0.25 / 2023-05-12

--- a/otel-agent/CHANGELOG.md
+++ b/otel-agent/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## OpenTelemtry-Agent
 
+### v0.0.27 / 2023-05-12
+[CHORE] Updated default otel agent config.yaml for ecs to support the new domain key for the Coralogix exporter
+
 ### v0.0.26 / 2023-05-12
 * [UPGRADE] coralogixrepo/otel-coralogix-ecs-ec2 container version updated to 0.78.0
 

--- a/otel-agent/CHANGELOG.md
+++ b/otel-agent/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## OpenTelemtry-Agent
 
 ### v0.0.27 / 2023-05-24
-[CHORE] Updated default otel agent config.yaml for ecs to support the new domain key for the Coralogix exporter
+* [CHORE] Updated default otel agent config.yaml for ecs to support the new domain key for the Coralogix exporter
 
 ### v0.0.26 / 2023-05-24
 * [UPGRADE] coralogixrepo/otel-coralogix-ecs-ec2 container version updated to 0.78.0

--- a/otel-agent/ecs-ec2/config.yaml
+++ b/otel-agent/ecs-ec2/config.yaml
@@ -40,10 +40,6 @@ exporters:
   logging:
   coralogix:
     domain: "$CORALOGIX_DOMAIN"
-    traces:
-      endpoint: "$TRACES_ENDPOINT"
-    metrics:
-      endpoint: "$METRICS_ENDPOINT"
     private_key: "$PRIVATE_KEY"
     application_name: "OTel"
     subsystem_name: "ECS"

--- a/otel-agent/ecs-ec2/logging.yaml
+++ b/otel-agent/ecs-ec2/logging.yaml
@@ -26,8 +26,6 @@ exporters:
   logging:
   coralogix:
     domain: "$CORALOGIX_DOMAIN"
-    logs:
-      endpoint: "$LOGS_ENDPOINT"
     private_key: "$PRIVATE_KEY"
     application_name: "OTel"
     subsystem_name: "ECS"


### PR DESCRIPTION
# Description

updated default otel config for ecs agent to support domain key for Coralogix Exporter

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [x] This change does not affect any particular component (e.g. it's CI or docs change)
