### PR TITLE
FEAT - Upgrade all fluentd deployments to use new

### DIFF
--- a/.github/workflows/fluentd-standalone-image.yml
+++ b/.github/workflows/fluentd-standalone-image.yml
@@ -42,4 +42,3 @@ jobs:
           push: true
           tags: |
             ${{ env.DOCKERHUB_REGISTRY }}:${{ steps.get-fluentd-version.outputs.version }}
-            ${{ env.DOCKERHUB_REGISTRY }}:latest

--- a/logs/CHANGELOG.md
+++ b/logs/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Fluentd-http
 
+### v1.15.2 / 2023-06-16
+
+* [UPGRADE] Upgrade Fluentd version to v1.15.2
+
+
 ### v0.0.11 / 2023-03-13
 * [CHANGE] Disable PodSecurityPolicy
 

--- a/logs/CHANGELOG.md
+++ b/logs/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 * [UPGRADE] Upgrade Fluentd version to v1.15.2
 
-
 ### v0.0.11 / 2023-03-13
 * [CHANGE] Disable PodSecurityPolicy
 

--- a/logs/fluentd/k8s-helm/coralogix/values.yaml
+++ b/logs/fluentd/k8s-helm/coralogix/values.yaml
@@ -3,7 +3,7 @@ fluentd:
 
   image:
     repository: coralogixrepo/coralogix-fluentd-multiarch
-    tag: v0.0.7
+    tag: v1.15.2
 
   resources:
     requests:

--- a/logs/fluentd/k8s-helm/http/Chart.yaml
+++ b/logs/fluentd/k8s-helm/http/Chart.yaml
@@ -1,14 +1,14 @@
 apiVersion: v2
 name: fluentd-http
 description: Fluentd Chart with HTTP output plugin
-version: 0.0.11
-appVersion: v1.14.6
+version: 0.0.12
+appVersion: v1.15.2
 keywords:
   - Fluentd
   - HTTP output plugin
 dependencies:
   - name: fluentd
-    version: "0.3.1"
+    version: "0.4.3"
     repository: https://fluent.github.io/helm-charts
     tags:
       - fluentd with http output plugin

--- a/logs/fluentd/k8s-helm/http/values.yaml
+++ b/logs/fluentd/k8s-helm/http/values.yaml
@@ -3,7 +3,7 @@ fluentd:
 
   image:
     repository: coralogixrepo/coralogix-fluentd-multiarch
-    tag: v0.0.9
+    tag: v1.15.2
 
   podSecurityPolicy:
     enabled: false

--- a/logs/fluentd/k8s-manifest/fluentd-ds.yaml
+++ b/logs/fluentd/k8s-manifest/fluentd-ds.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: fluentd-http
       containers:
         - name: fluentd
-          image: "coralogixrepo/coralogix-fluentd-multiarch:v0.0.9"
+          image: "coralogixrepo/coralogix-fluentd-multiarch:v1.15.2"
           imagePullPolicy: IfNotPresent
           env:
             - name: FLUENTD_CONF

--- a/logs/fluentd/standalone-image/README.md
+++ b/logs/fluentd/standalone-image/README.md
@@ -1,6 +1,5 @@
 # ** THIS IMAGE IS DEPRECATED AS WE NO LONGER SUPPORT THE FLUENT-PLUGIN-CORALOGIX PLUGIN, PLEASE USE HTTP WITH THE [OFFICIAL FLUENTD IMAGE](https://hub.docker.com/r/fluent/fluentd) **
 
-
 # Coralogix Fluentd Standalone Image:
 
 This folder contains the docker file for the image including the Coralogix plugin (and others).
@@ -12,13 +11,13 @@ This image is based on the open source image:
 
 Supported plugin List:
 
-| Plugin Name                              | Plugin Project URL                                                       |
-|------------------------------------------|--------------------------------------------------------------------------|
-| fluent-plugin-coralogix                  | (https://rubygems.org/gems/fluent-plugin-coralogix)                      |
-| fluent-plugin-prometheus                 | (https://github.com/fluent/fluent-plugin-prometheus)                     |
-| fluent-plugin-parser-cri                 | (https://github.com/fluent/fluent-plugin-parser-cri)                     |
-| fluent-plugin-sampling-filter            | (https://github.com/tagomoris/fluent-plugin-sampling-filter)             |
-| fluent-plugin-concat                     | (https://github.com/fluent-plugins-nursery/fluent-plugin-concat)         |
-| fluent-plugin-rewrite-tag-filter         | (https://github.com/fluent/fluent-plugin-rewrite-tag-filter)             |
-| fluent-plugin-detect-exceptions          | (https://github.com/GoogleCloudPlatform/fluent-plugin-detect-exceptions) |
-| fluent-plugin-redis-store              | (https://github.com/pokehanai/fluent-plugin-redis-store)                    |
+| Plugin Name                      | Plugin Project URL                                                       |
+|----------------------------------|--------------------------------------------------------------------------|
+| fluent-plugin-coralogix          | (https://rubygems.org/gems/fluent-plugin-coralogix)                      |
+| fluent-plugin-prometheus         | (https://github.com/fluent/fluent-plugin-prometheus)                     |
+| fluent-plugin-parser-cri         | (https://github.com/fluent/fluent-plugin-parser-cri)                     |
+| fluent-plugin-sampling-filter    | (https://github.com/tagomoris/fluent-plugin-sampling-filter)             |
+| fluent-plugin-concat             | (https://github.com/fluent-plugins-nursery/fluent-plugin-concat)         |
+| fluent-plugin-rewrite-tag-filter | (https://github.com/fluent/fluent-plugin-rewrite-tag-filter)             |
+| fluent-plugin-detect-exceptions  | (https://github.com/GoogleCloudPlatform/fluent-plugin-detect-exceptions) |
+| fluent-plugin-redis-store        | (https://github.com/pokehanai/fluent-plugin-redis-store)                 |

--- a/logs/fluentd/standalone-image/README.md
+++ b/logs/fluentd/standalone-image/README.md
@@ -1,0 +1,24 @@
+# ** THIS IMAGE IS DEPRECATED AS WE NO LONGER SUPPORT THE FLUENT-PLUGIN-CORALOGIX PLUGIN, PLEASE USE HTTP WITH THE [OFFICIAL FLUENTD IMAGE](https://hub.docker.com/r/fluent/fluentd) **
+
+
+# Coralogix Fluentd Standalone Image:
+
+This folder contains the docker file for the image including the Coralogix plugin (and others).
+
+## Image base
+
+This image is based on the open source image:
+`fluent/fluentd:v1.14.0-debian-1.0`
+
+Supported plugin List:
+
+| Plugin Name                              | Plugin Project URL                                                       |
+|------------------------------------------|--------------------------------------------------------------------------|
+| fluent-plugin-coralogix                  | (https://rubygems.org/gems/fluent-plugin-coralogix)                      |
+| fluent-plugin-prometheus                 | (https://github.com/fluent/fluent-plugin-prometheus)                     |
+| fluent-plugin-parser-cri                 | (https://github.com/fluent/fluent-plugin-parser-cri)                     |
+| fluent-plugin-sampling-filter            | (https://github.com/tagomoris/fluent-plugin-sampling-filter)             |
+| fluent-plugin-concat                     | (https://github.com/fluent-plugins-nursery/fluent-plugin-concat)         |
+| fluent-plugin-rewrite-tag-filter         | (https://github.com/fluent/fluent-plugin-rewrite-tag-filter)             |
+| fluent-plugin-detect-exceptions          | (https://github.com/GoogleCloudPlatform/fluent-plugin-detect-exceptions) |
+| fluent-plugin-redis-store              | (https://github.com/pokehanai/fluent-plugin-redis-store)                    |


### PR DESCRIPTION
v1.15.2 image

# Description

Updated fluentd deployments to use the previously updated multiarch image based on v1.15.2 of fluentd.
Threw in a deprecation notice for the standalone image as we no longer support the Coralogix fluentd plugin.

Deployed from local helm chart to EKS, ECS via cloudformation and locally.

Installed locally and looked for any install errors. Reviewed pod "logs" to ensure no errors. Reviewed Coralogix platform for ingest of new messages.

# Checklist:
- [X] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [X] This change does not affect any particular component (e.g. it's CI or docs change)
