### PR TITLE
BUG - revert fluentd coralogix version

### DIFF
--- a/logs/CHANGELOG.md
+++ b/logs/CHANGELOG.md
@@ -42,3 +42,7 @@
 * [UPGRADE] Upgrade Fluent-Bit version to 1.9.3
 * [CHANGE] Set Retry_Limit to False [no limit] to keep retrying send the logs and not lose any data
   ([#48](https://github.com/coralogix/eng-integrations/pull/48))
+
+## Fluentd-http
+
+* [DOWNGRADE] Restoring the image version to 0.0.7 in the 'values.yaml' file

--- a/logs/fluentd/k8s-helm/coralogix/values.yaml
+++ b/logs/fluentd/k8s-helm/coralogix/values.yaml
@@ -3,7 +3,7 @@ fluentd:
 
   image:
     repository: coralogixrepo/coralogix-fluentd-multiarch
-    tag: v1.15.2
+    tag: v0.0.7
 
   resources:
     requests:


### PR DESCRIPTION
# Description

Downgraded the 'coralogix' plugin based fluentd deployment to use the old version as it is no longer maintained and no QA testing was performed on the new version of fluentd

It wasn't, restoring to previously tested version.

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [x] This change does not affect any particular component (e.g. it's CI or docs change)
