### PR TITLE
Introduce CRD generation

### DIFF
--- a/otel-agent/k8s-helm/CHANGELOG.md
+++ b/otel-agent/k8s-helm/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemtry-Agent
 
+### v0.0.27 / 2023-06-30
+
+* [FEATURE] Add support for deploying `otel-agent` as OpenTelemetry Operator CRD.
+
 ### v0.0.26 / 2023-06-26
 
 * [CHORE] Update OpenTelemetry Collector to v0.77.0

--- a/otel-agent/k8s-helm/Chart.yaml
+++ b/otel-agent/k8s-helm/Chart.yaml
@@ -1,14 +1,14 @@
 apiVersion: v2
 name: opentelemetry-coralogix
 description: OpenTelemetry agent to which instrumentation libraries export their telemetry data
-version: 0.0.26
+version: 0.0.27
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry agent
   - Coralogix
 dependencies:
   - name: opentelemetry-collector
-    version: "0.61.2"
+    version: "0.62.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
 sources:
   - https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector

--- a/otel-agent/k8s-helm/README.md
+++ b/otel-agent/k8s-helm/README.md
@@ -72,9 +72,9 @@ helm upgrade --install otel-coralogix-agent coralogix-charts-virtual/opentelemet
 
 If you wish to deploy the `otel-agent` using the OpenTelemetry Operator, you can generate an `OpenTelemetryCollector` CRD. You might want to do this if you'd like to take advantage of some advanced features provided by the operator, such as automatic collector upgrade or CRD-defined auto-instrumentation.
 
- For full details on how to install and use the operator, please refer to the [OpenTelemetry Operator documentation](https://github.com/open-telemetry/opentelemetry-operator/blob/main/README.md).
+For full details on how to install and use the operator, please refer to the [OpenTelemetry Operator documentation](https://github.com/open-telemetry/opentelemetry-operator/blob/main/README.md).
 
- First make sure to add our Helm charts repository to the local repos list with the following command:
+First make sure to add our Helm charts repository to the local repos list with the following command:
 
 ```bash
 helm repo add coralogix-charts-virtual https://cgx.jfrog.io/artifactory/coralogix-charts-virtual

--- a/otel-agent/k8s-helm/README.md
+++ b/otel-agent/k8s-helm/README.md
@@ -41,6 +41,12 @@ metadata:
 type: Opaque 
 ```
 
+### OpenTelemetry Operator (for CRD users)
+
+If you wish to use the Helm chart as an `OpenTelemetryCollector` CRD, you will need to have the OpenTelemetry Operator installed in your cluster. Please refer to the [OpenTelemetry Operator documentation](https://github.com/open-telemetry/opentelemetry-operator/blob/main/README.md) for full details.
+
+We recommend to install the operator with the help of the community Helm charts from the [OpenTelemetry Helm Charts](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-operator) repository.
+
 ## Installation
 
 First make sure to add our Helm charts repository to the local repos list with the following command:
@@ -60,6 +66,31 @@ Install the chart:
 ```bash
 helm upgrade --install otel-coralogix-agent coralogix-charts-virtual/opentelemetry-coralogix \
   -f values.yaml
+```
+
+### Generating OpenTelemetryCollector CRD for OpenTelemetry Operator users
+
+If you wish to deploy the `otel-agent` using the OpenTelemetry Operator, you can generate an `OpenTelemetryCollector` CRD. You might want to do this if you'd like to take advantage of some advanced features provided by the operator, such as automatic collector upgrade or CRD-defined auto-instrumentation.
+
+ For full details on how to install and use the operator, please refer to the [OpenTelemetry Operator documentation](https://github.com/open-telemetry/opentelemetry-operator/blob/main/README.md).
+
+ First make sure to add our Helm charts repository to the local repos list with the following command:
+
+```bash
+helm repo add coralogix-charts-virtual https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
+```
+
+In order to get the updated Helm charts from the added repository, please run:
+
+```bash
+helm repo update
+```
+
+Install the chart with the CRD `values.yaml` file:
+
+```bash
+helm upgrade --install otel-coralogix-agent coralogix-charts-virtual/opentelemetry-coralogix \
+  -f values-crd.yaml
 ```
 
 # How to use it

--- a/otel-agent/k8s-helm/values-crd.yaml
+++ b/otel-agent/k8s-helm/values-crd.yaml
@@ -1,0 +1,210 @@
+global:
+  domain: "coralogix.com"
+  defaultApplicationName: "default"
+  defaultSubsystemName: "nodes"
+  fullnameOverride: otel-coralogix
+
+  # Old endpoint based configuration, 
+  # please use domain instead.
+  traces:
+    endpoint: ""
+  metrics:
+    endpoint: ""
+  logs:
+    endpoint: ""
+
+# set distribution to openshift for openshift clusters
+distribution: ""
+opentelemetry-collector:
+  mode: daemonset
+  collectorCRD:
+    generate: true
+  configMap:
+    create: false
+  hostNetwork: true
+  dnsPolicy: "ClusterFirstWithHostNet"
+  fullnameOverride: "otel-coralogix"
+  presets:
+    logsCollection:
+      enabled: true
+      storeCheckpoints: true
+      maxRecombineLogSize: 1048576
+      extraFilelogOperators: []
+
+    kubernetesAttributes:
+      enabled: true
+    hostMetrics:
+      enabled: true
+    kubeletMetrics:
+      enabled: true
+
+  extraEnvs:
+  - name: CORALOGIX_PRIVATE_KEY
+    valueFrom:
+      secretKeyRef:
+        name: coralogix-keys
+        key: PRIVATE_KEY
+  - name: OTEL_RESOURCE_ATTRIBUTES
+    value: "k8s.node.name=$(K8S_NODE_NAME)"
+  - name: KUBE_NODE_NAME
+    valueFrom:
+      fieldRef:
+        apiVersion: v1
+        fieldPath: spec.nodeName
+  config:
+    extensions:
+      zpages:
+        endpoint: localhost:55679
+      pprof:
+        endpoint: localhost:1777
+    exporters:
+      coralogix:
+        timeout: "30s"
+        private_key: "${CORALOGIX_PRIVATE_KEY}"
+        domain: "{{.Values.global.domain}}"
+        traces:
+          endpoint: "{{ .Values.global.traces.endpoint }}"
+        metrics:
+          endpoint: "{{ .Values.global.metrics.endpoint }}"
+        logs:
+          endpoint: "{{ .Values.global.logs.endpoint }}"
+        application_name_attributes:
+        - "k8s.namespace.name" 
+        - "service.namespace"
+        subsystem_name_attributes:
+        - "k8s.deployment.name"
+        - "k8s.statefulset.name"
+        - "k8s.daemonset.name"
+        - "k8s.cronjob.name"
+        - "k8s.job.name"
+        - "k8s.container.name"
+        - "k8s.node.name"
+        - "service.name"
+        application_name: "{{.Values.global.defaultApplicationName }}"
+        subsystem_name: "{{.Values.global.defaultSubsystemName }}"
+    processors:
+      k8sattributes:
+        filter:
+          node_from_env_var: KUBE_NODE_NAME     
+        extract:
+          metadata:
+            - "k8s.namespace.name"
+            - "k8s.deployment.name"
+            - "k8s.statefulset.name"
+            - "k8s.daemonset.name"
+            - "k8s.cronjob.name"
+            - "k8s.job.name"
+            - "k8s.pod.name"
+            - "k8s.node.name"
+      memory_limiter: null # Will get the k8s resource limits
+      resourcedetection/env:
+        detectors: ["system","env"]
+        timeout: 2s
+        override: false
+      spanmetrics:
+        metrics_exporter: coralogix
+        dimensions:
+          - name: "k8s.deployment.name"
+          - name: "k8s.statefulset.name"
+          - name: "k8s.daemonset.name"
+          - name: "k8s.cronjob.name"
+          - name: "k8s.job.name"
+          - name: "k8s.container.name"
+          - name: "k8s.node.name"
+          - name: "k8s.namespace.name" 
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: ${MY_POD_IP}:4317
+          http:
+            endpoint: ${MY_POD_IP}:4318
+      zipkin:
+        endpoint: ${MY_POD_IP}:9411
+      jaeger:
+        protocols:
+          grpc:
+            endpoint: ${MY_POD_IP}:14250
+          thrift_http:
+            endpoint: ${MY_POD_IP}:14268
+          thrift_compact:
+            endpoint: ${MY_POD_IP}:6831
+          thrift_binary:
+            endpoint: ${MY_POD_IP}:6832
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: opentelemetry-collector
+              scrape_interval: 30s
+              static_configs:
+                - targets:
+                    - ${MY_POD_IP}:8888
+    service:
+      extensions:
+      - zpages
+      - pprof
+      - health_check
+      - memory_ballast
+      telemetry:
+        logs:
+          encoding: json
+        metrics:
+          address: ${MY_POD_IP}:8888
+      pipelines:
+        traces:
+          exporters:
+            - coralogix
+          processors:
+            - memory_limiter
+            - spanmetrics
+            - batch
+          receivers:
+            - otlp
+            - zipkin
+            - jaeger
+        metrics:
+          exporters:
+            - coralogix
+          processors:
+            - memory_limiter
+            - resourcedetection/env
+            - batch
+          receivers:
+            - prometheus
+            - otlp
+        logs:
+          exporters:
+            - coralogix
+          processors:
+            - batch
+          receivers:
+            - otlp
+  tolerations: 
+    - operator: Exists
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 1
+      memory: 2G
+
+  ports:
+    jaeger-binary:
+      enabled: true
+      containerPort: 6832
+      servicePort: 6832
+      hostPort: 6832
+      protocol: TCP
+    # In order to enable podMonitor, following part must be enabled in order to expose the required port:
+    # metrics:
+    #   enabled: true
+
+  # podMonitor:
+  #   enabled: true
+
+  # prometheusRule:
+  #   enabled: true
+  #   defaultRules:
+  #     enabled: true


### PR DESCRIPTION
# Description

Part of ES-29.

This PR adds feature to generate the `otel-agent` as the OpenTelemetry Operator CRD. The feature is explained and documented in the README.

# How Has This Been Tested?

Manually tested on local cluster

# Checklist:
- [ ] I have updated the relevant Helm chart(s) version(s)
- [ ] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
