### PR TITLE
[otel-agent] Add domain validation via `NOTES.txt`

### DIFF
--- a/otel-agent/k8s-helm/CHANGELOG.md
+++ b/otel-agent/k8s-helm/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## OpenTelemtry-Agent
 
+### v0.0.28 / 2023-07-03
+
+* [FEATURE] Add domain validation via `NOTES.txt`.
+* [FIX] Remove mistakenly added default domain in `values-crd.yaml` file.
+
 ### v0.0.27 / 2023-06-30
 
-* [FEATURE] Add support for deploying `otel-agent` as OpenTelemetry Operator CRD.
+* [FEATURE] Add support for deploying `otel-agent` as OpenTelemetry Operator
 
 ### v0.0.26 / 2023-06-26
 

--- a/otel-agent/k8s-helm/Chart.yaml
+++ b/otel-agent/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: opentelemetry-coralogix
 description: OpenTelemetry agent to which instrumentation libraries export their telemetry data
-version: 0.0.27
+version: 0.0.28
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry agent

--- a/otel-agent/k8s-helm/templates/NOTES.txt
+++ b/otel-agent/k8s-helm/templates/NOTES.txt
@@ -1,0 +1,3 @@
+{{- if and (eq .Values.global.domain "") (and (eq .Values.global.traces.endpoint "") (eq .Values.global.metrics.endpoint "") (eq .Values.global.logs.endpoint "")) }}
+{{- fail "[ERROR] Either domain or one of the traces.endpoint, metrics.endpoint or logs.endpoint must be specified." }}
+{{ end }}

--- a/otel-agent/k8s-helm/values-crd.yaml
+++ b/otel-agent/k8s-helm/values-crd.yaml
@@ -1,5 +1,5 @@
 global:
-  domain: "coralogix.com"
+  domain: ""
   defaultApplicationName: "default"
   defaultSubsystemName: "nodes"
   fullnameOverride: otel-coralogix


### PR DESCRIPTION
# Description

Adds validation to our `otel-agent` chart to check if domain (or endpoint(s)) is set. This will prevent the user from accidentally installing the chart without providing domain, which results in collector crashing with error message about missing configuration. Stopping the chart installation will provide a better user experience.

Additionally, removes the default domain for the CRD chart, which was added accidentally.

# How Has This Been Tested?
Manually on local cluster.

# Checklist:
- [X] I have updated the relevant Helm chart(s) version(s)
- [X] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
