### PR TITLE
[otel-agent] Add MySQL preset

### DIFF
--- a/otel-agent/k8s-helm/CHANGELOG.md
+++ b/otel-agent/k8s-helm/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemtry-Agent
 
+### v0.0.29 / 2023-07-14
+
+* [FEATURE] Add MySQL preset for metrics and extra logs.
+
 ### v0.0.28 / 2023-07-03
 
 * [FEATURE] Add domain validation via `NOTES.txt`.

--- a/otel-agent/k8s-helm/Chart.yaml
+++ b/otel-agent/k8s-helm/Chart.yaml
@@ -1,14 +1,14 @@
 apiVersion: v2
 name: opentelemetry-coralogix
 description: OpenTelemetry agent to which instrumentation libraries export their telemetry data
-version: 0.0.28
+version: 0.0.29
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry agent
   - Coralogix
 dependencies:
   - name: opentelemetry-collector
-    version: "0.62.1"
+    version: "0.63.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
 sources:
   - https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector

--- a/otel-agent/k8s-helm/values-crd.yaml
+++ b/otel-agent/k8s-helm/values-crd.yaml
@@ -38,6 +38,17 @@ opentelemetry-collector:
     kubeletMetrics:
       enabled: true
 
+    mysql:
+      metrics:
+        enabled: false
+        instances:
+        - username: ""
+          password: ""
+      extraLogs:
+        enabled: false
+        volumeMountName: ""
+        mountPath: ""
+
   extraEnvs:
   - name: CORALOGIX_PRIVATE_KEY
     valueFrom:

--- a/otel-agent/k8s-helm/values.yaml
+++ b/otel-agent/k8s-helm/values.yaml
@@ -46,6 +46,17 @@ opentelemetry-collector:
     kubeletMetrics:
       enabled: true
 
+    mysql:
+      metrics:
+        enabled: false
+        instances:
+        - username: ""
+          password: ""
+      extraLogs:
+        enabled: false
+        volumeMountName: ""
+        mountPath: ""
+
   extraEnvs:
   - name: CORALOGIX_PRIVATE_KEY
     valueFrom:


### PR DESCRIPTION
# Description

Resolves ES-29.

This change adds and documents how to use the MySQL presets from the upstream chart with `otel-agent`.
- Adds values for both standard collector and CRD
- Disabled by default
- Documented usage, required parameters etc.

# How Has This Been Tested?

Locally on a test cluster

# Checklist:
- [X] I have updated the relevant Helm chart(s) version(s)
- [X] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
