### PR TITLE
[CDS-305] Fix initialisation delay for metadata on ecsattributes processor

### DIFF
--- a/otel-agent/ecs-ec2/CHANGELOG.md
+++ b/otel-agent/ecs-ec2/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## OpenTelemtry-Agent
 
+### v0.0.28 / 2023-07-14
+* [FIX] fixed issue with ecsattributes processor not initialising correctly
+
 ### v0.0.28 / 2023-07-05
 * [UPGRADE] coralogixrepo/otel-coralogix-ecs-ec2 container version updated to 0.80.0
 * [UPGRADE] added custom ecsattributes processor to the container

--- a/otel-agent/ecs-ec2/CHANGELOG.md
+++ b/otel-agent/ecs-ec2/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## OpenTelemtry-Agent
 
-### v0.0.28 / 2023-07-14
+### v0.0.29 / 2023-07-14
 * [FIX] fixed issue with ecsattributes processor not initialising correctly
 
 ### v0.0.28 / 2023-07-05


### PR DESCRIPTION
# Description

<!-- Please describe the changes you made in a few words or sentences. -->

This PR fixes an issue with the ecsattributes processor where it does not sync metadata until 60 seconds after the processor has been started.

<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [x] This change does not affect any particular component (e.g. it's CI or docs change)
