### PR TITLE
[CDS-305] stop ecsattributes processor adding empty attributes 

### DIFF
--- a/otel-agent/ecs-ec2/CHANGELOG.md
+++ b/otel-agent/ecs-ec2/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### v0.0.30 / 2023-07-18
 * [FIX] fixed issue with ecsattributes processor adding empty labels/attributes
+* [UPGRADE] add feature to ecsattribute processor to record custom docker labels
 
 ### v0.0.29 / 2023-07-14
 * [FIX] fixed issue with ecsattributes processor not initialising correctly

--- a/otel-agent/ecs-ec2/CHANGELOG.md
+++ b/otel-agent/ecs-ec2/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### v0.0.30 / 2023-07-18
 * [FIX] fixed issue with ecsattributes processor adding empty labels/attributes
 
-
 ### v0.0.29 / 2023-07-14
 * [FIX] fixed issue with ecsattributes processor not initialising correctly
 

--- a/otel-agent/ecs-ec2/CHANGELOG.md
+++ b/otel-agent/ecs-ec2/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemtry-Agent
 
+### v0.0.30 / 2023-07-18
+* [FIX] fixed issue with ecsattributes processor adding empty labels/attributes
+
+
 ### v0.0.29 / 2023-07-14
 * [FIX] fixed issue with ecsattributes processor not initialising correctly
 

--- a/otel-agent/ecs-ec2/ecsattributesprocessor/README.md
+++ b/otel-agent/ecs-ec2/ecsattributesprocessor/README.md
@@ -35,6 +35,7 @@ The coralogixrepo/otel-coralogix-ecs-ec2 docker image includes an Open Telemetry
 | created.at                      | The time the container was created                                                  |         |
 | `networks.*.ipv4.addresses.*`   | An expression that matches the IP address(s) assigned to a container                |         |
 | `networks.*.network.mode`       | An expression that matches the network mode(s) associated with the container        |         |
+| labels.*                        | An expression that matches the docker labels associated with the container          |         |
 
 Only containers with a valid ECS metadata endpoint will have attributes assigned, all others will be ignored.
 

--- a/otel-agent/ecs-ec2/ecsattributesprocessor/README.md
+++ b/otel-agent/ecs-ec2/ecsattributesprocessor/README.md
@@ -84,5 +84,7 @@ processors:
 
 - The `ecsattributesprocessor` uses the Docker API to collect metadata for each container. It refreshes the metadata every 60 seconds as well as everytime a new container is detected via Docker events. If the processor is unable to collect metadata for a container or if there are errors during the refresh process, the processor will log the error and continue processing the next log record. **It will not halt/crash the open telemetry process**. If you notice metadata not being added to your logs, please check the logs for the collector for any errors related to the `ecsattributesprocessor`.
 
+- If logs are received with no attributes, it is possible that these logs are from the ECS Agent; the agent responsible for managing containers on an ECS Node. This container does not have a metadata endpoint. Also, logs from rogue containers that are run on ECS outside the control of the ECS Agent will not be assigned a metadata endpoint and will not have attributes added.
+
 **TODO:**
 - Implement a configuration option that allows the user to specify what action to take on error. For example, `continue` or `halt`.

--- a/otel-agent/ecs-ec2/ecsattributesprocessor/ecsattributes.go
+++ b/otel-agent/ecs-ec2/ecsattributesprocessor/ecsattributes.go
@@ -30,6 +30,7 @@ func processLogsFunc(logger *zap.Logger, c *Config) processorhelper.ProcessLogsF
 				logger.Debug("metadata not found",
 					zap.String("container.id", containerID),
 					zap.String("processor", metadata.Type))
+				return ld, nil
 			}
 
 			// flatten the data

--- a/otel-agent/ecs-ec2/ecsattributesprocessor/ecsattributes.go
+++ b/otel-agent/ecs-ec2/ecsattributesprocessor/ecsattributes.go
@@ -36,10 +36,14 @@ func processLogsFunc(logger *zap.Logger, c *Config) processorhelper.ProcessLogsF
 			flattened := metadata.Flat()
 
 			for k, v := range flattened {
-				if c.allowAttr(k) {
-					rlog.Resource().Attributes().
-						PutStr(k, fmt.Sprintf("%v", v))
+				val := fmt.Sprintf("%v", v)
+				// if not allowed or empty value, skip
+				if !c.allowAttr(k) || val == "" {
+					continue
 				}
+
+				rlog.Resource().Attributes().
+					PutStr(k, val)
 			}
 		}
 		return ld, nil

--- a/otel-agent/ecs-ec2/ecsattributesprocessor/ecsattributes_test.go
+++ b/otel-agent/ecs-ec2/ecsattributesprocessor/ecsattributes_test.go
@@ -26,6 +26,7 @@ const payload = `{
 	"ImageID": "sha256:68c29634fe49724f94ed34f18224336f776392f7a5a4014969ac5798a2ec96dc",
 	"KnownStatus": "RUNNING",
 	"Labels": {
+	  "com.custom.app": "go-test-app",
 	  "com.amazonaws.ecs.cluster": "cds-305",
 	  "com.amazonaws.ecs.container-name": "cadvisor",
 	  "com.amazonaws.ecs.task-arn": "arn:aws:ecs:eu-west-1:035955823396:task/cds-305/ec7ff82b7a3a44a5bbbe9bcf11daee33",
@@ -110,6 +111,7 @@ var (
 		"volumes.0.source":                "/var",
 		"volumes.1.destination":           "/etc",
 		"volumes.1.source":                "/etc",
+		"labels.com.custom.app":           "go-test-app",
 	}
 )
 
@@ -186,7 +188,7 @@ func TestProcessLogFunc(t *testing.T) {
 		},
 		{
 			name: "fetch all attributes",
-			len:  33,
+			len:  34,
 			config: &Config{
 				Attributes: []string{
 					".*",
@@ -201,14 +203,14 @@ func TestProcessLogFunc(t *testing.T) {
 		},
 		{
 			name: "fetch default attributes",
-			len:  11,
+			len:  12,
 			config: func() *Config {
 				c := createDefaultConfig().(*Config)
 				c.ContainerID.Sources = append(c.ContainerID.Sources, "container.id")
 				return c
 			}(),
 			wantErr: false,
-			match:   "^aws.*|^image.*|^docker.*",
+			match:   "^aws.*|^image.*|^docker.*|^labels.*",
 			record:  defaultRecord,
 		},
 		{
@@ -222,7 +224,7 @@ func TestProcessLogFunc(t *testing.T) {
 
 		{
 			name: "specify container id as as log.file.name",
-			len:  33,
+			len:  34,
 			config: &Config{
 				Attributes: []string{
 					".*",
@@ -281,7 +283,7 @@ func TestProcessLogFunc(t *testing.T) {
 
 			assert.Equal(t, tt.len, matches)
 			numOfAttributes := result.ResourceLogs().At(0).Resource().Attributes().Len()
-			if numOfAttributes < 33 {
+			if numOfAttributes < 34 {
 				assert.Equal(t, tt.len+1, numOfAttributes)
 			}
 

--- a/otel-agent/ecs-ec2/ecsattributesprocessor/factory.go
+++ b/otel-agent/ecs-ec2/ecsattributesprocessor/factory.go
@@ -41,7 +41,7 @@ func createDefaultConfig() component.Config {
 		Attributes: []string{
 			// by default, we collect all tribute nameaå that start with:
 			// ecs, name, image or docker
-			"^aws.ecs.*|^image.*|^docker.*",
+			"^aws.ecs.*|^image.*|^docker.*|^labels.*",
 		},
 	}
 }


### PR DESCRIPTION
# Description

<!-- Please describe the changes you made in a few words or sentences. -->

This PR fixes:
- An issue with the `ecsattributes processor` adding empty labels when no metadata is detected.

Implements:
- Support for retrieving and adding custom docker labels to log attributes.


<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the relevant Helm chart(s) version(s)
- [ ] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
