### PR TITLE
[otel-integration] Fix typo and instructions in the integration chart

### DIFF
--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: otel-ingegration
+name: otel-integration
 description: OpenTelemetry Integration
 version: 0.0.1
 keywords:
@@ -24,7 +24,7 @@ dependencies:
     repository: https://prometheus-community.github.io/helm-charts
     condition: global.extensions.kubernetesDashboard.enabled
 sources:
-  - https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector
+  - https://github.com/coralogix/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector
 maintainers:
   - name: Coralogix
     email: platform@coralogix.com

--- a/otel-integration/k8s-helm/README.md
+++ b/otel-integration/k8s-helm/README.md
@@ -88,7 +88,7 @@ helm repo update
 Install the chart:
 
 ```bash
-helm upgrade --install otel-integration coralogix-charts-virtual/opentelemetry-coralogix \
+helm upgrade --install otel-coralogix-integration coralogix-charts-virtual/otel-integration \
   -f values.yaml
 ```
 


### PR DESCRIPTION
# Description

Part of [ES-55](https://coralogix.atlassian.net/browse/ES-55).

This PR fixes a typo in the chart name which caused the chart to not be uploaded. Also fixes incorrect instruction in the README.

# How Has This Been Tested?

Locally.

# Checklist:
- [ ] I have updated the relevant Helm chart(s) version(s)
- [ ] I have updated the relevant component changelog(s)
- [X] This change does not affect any particular component (e.g. it's CI or docs change)


[ES-55]: https://coralogix.atlassian.net/browse/ES-55?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ