### PR TITLE
[otel-integration] Fix ports; improve resource attributes

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.2 / 2023-08-02
+
+* [FEATURE] Add `k8s.node.name` resource attribute to cluster collector
+* [FEATURE] Override detection for cloud provider detectors
+* [BUG] Fix ports configuration
+
 ### v0.0.1 / 2023-07-21
 
 * [FEATURE] Add new chart

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.1
+version: 0.0.2
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -442,10 +442,22 @@ opentelemetry-cluster-collector:
       cpu: 1
       memory: 2G
 
+  ports:
+    otlp:
+      enabled: true
+    otlp-http:
+      enabled: false
+    jaeger-compact:
+      enabled: false
+    jaeger-thrift:
+      enabled: false
+    jaeger-grpc:
+      enabled: false
+    zipkin:
+      enabled: false
     # In order to enable serviceMonitor, following part must be enabled in order to expose the required port:
-    # ports:
-    #   metrics:
-    #     enabled: true
+    # metrics:
+    #   enabled: true
 
   # serviceMonitor:
   #   enabled: true

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -103,7 +103,7 @@ opentelemetry-agent:
       resourcedetection/region:
         detectors: ["gcp", "ec2"]
         timeout: 2s
-        override: false
+        override: true
         gcp:
           resource_attributes:
             cloud.region:
@@ -263,19 +263,6 @@ opentelemetry-cluster-collector:
     clusterRoleBinding:
       name: "coralogix-opentelemetry-collector"
   replicaCount: 1
-  ports:
-    otlp:
-      enabled: true
-    otlp-http:
-      enabled: false
-    jaeger-compact:
-      enabled: false
-    jaeger-thrift:
-      enabled: false
-    jaeger-grpc:
-      enabled: false
-    zipkin:
-      enabled: false
   
   presets:
     clusterMetrics:
@@ -291,6 +278,8 @@ opentelemetry-cluster-collector:
         secretKeyRef:
           name: coralogix-keys
           key: PRIVATE_KEY
+    - name: OTEL_RESOURCE_ATTRIBUTES
+      value: "k8s.node.name=$(K8S_NODE_NAME)"
     - name: KUBE_NODE_NAME
       valueFrom:
         fieldRef:
@@ -361,7 +350,7 @@ opentelemetry-cluster-collector:
       resourcedetection/region:
         detectors: ["gcp", "ec2"]
         timeout: 2s
-        override: false
+        override: true
         gcp:
           resource_attributes:
             cloud.region:


### PR DESCRIPTION
# Description

Part of [ES-55](https://coralogix.atlassian.net/browse/ES-55).

- Fixes wrong port configuration
- Adds `k8s.node.name` resource attribute to cluster collector
- Allows override for cloud provider resource detectors over the default system attributes

# How Has This Been Tested?

Locally

# Checklist:
- [X] I have updated the relevant Helm chart(s) version(s)
- [X] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)


[ES-55]: https://coralogix.atlassian.net/browse/ES-55?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ