### PR TITLE
[otel-integration] Bump dependency chart to 0.67.0

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.3 / 2023-08-02
+
+* [CHORE] Bump Coralogix OpenTelemetry chart to `0.67.0`
+
 ### v0.0.2 / 2023-08-02
 
 * [FEATURE] Add `k8s.node.name` resource attribute to cluster collector

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.2
+version: 0.0.3
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -11,12 +11,12 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.65.0"
+    version: "0.67.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-cluster-collector
-    version: "0.65.0"
+    version: "0.67.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-cluster-collector.enabled
   - name: kube-state-metrics


### PR DESCRIPTION
# Description

Bump fork to `0.67.0` to bring in latest preset changes.

# How Has This Been Tested?

Locally

# Checklist:
- [X] I have updated the relevant Helm chart(s) version(s)
- [X] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
