### PR TITLE
[otel-integration] Add allocatable metrics; drop unused version attribute

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.4 / 2023-08-03
+
+* [FEATURE] Add cluster metrics related to allocatable resources (CPU, memory)
+* [CHORE] Remove unused `cx.otel_integration.version` attribute
+* [CHORE] Remove unused `enabled` parameter on `kube-state-metrics` config
+
 ### v0.0.3 / 2023-08-02
 
 * [CHORE] Bump Coralogix OpenTelemetry chart to `0.67.0`

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.3
+version: 0.0.4
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -1,6 +1,6 @@
 global:
-  domain: ""
-  clusterName: ""
+  domain: "coralogix.com"
+  clusterName: "test"
   defaultApplicationName: "otel"
   defaultSubsystemName: "integration"
   logLevel: "warn"
@@ -128,9 +128,6 @@ opentelemetry-agent:
             - action: add_label
               new_label: cx.otel_integration.name
               new_value: "{{ .Chart.Name }}"
-            - action: add_label
-              new_label: cx.otel_integration.version
-              new_value: "{{ .Chart.Version }}"
       k8sattributes:
         filter:
           node_from_env_var: KUBE_NODE_NAME     
@@ -293,6 +290,9 @@ opentelemetry-cluster-collector:
       pprof:
         endpoint: localhost:1777
     receivers:
+      k8s_cluster:
+        collection_interval: 10s
+        allocatable_types_to_report: [cpu, memory]
       prometheus:
         config:
           scrape_configs:
@@ -340,9 +340,6 @@ opentelemetry-cluster-collector:
             - action: add_label
               new_label: cx.otel_integration.name
               new_value: "{{ .Chart.Name }}"
-            - action: add_label
-              new_label: cx.otel_integration.version
-              new_value: "{{ .Chart.Version }}"
       resourcedetection/env:
         detectors: ["system", "env"]
         timeout: 2s
@@ -419,6 +416,7 @@ opentelemetry-cluster-collector:
           receivers:
             - otlp
             - prometheus
+            - k8s_cluster
   
   tolerations:
     - operator: Exists
@@ -457,7 +455,6 @@ opentelemetry-cluster-collector:
   #     enabled: true
 
 kube-state-metrics:
-  enabled: true
   prometheusScrape: false
   collectors:
     - pods

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -1,6 +1,6 @@
 global:
-  domain: "coralogix.com"
-  clusterName: "test"
+  domain: ""
+  clusterName: ""
   defaultApplicationName: "otel"
   defaultSubsystemName: "integration"
   logLevel: "warn"


### PR DESCRIPTION
# Description

Reflects some changes done in `monitoring-shipper`.

- Add some extra metrics regarding allocatable resource on cluster
- Remove unused integration version attribute to lower cardinality

# How Has This Been Tested?

Locally.

# Checklist:
- [X] I have updated the relevant Helm chart(s) version(s)
- [X] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
