### PR TITLE
[otel-integration] Fix kube events transform

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.5 / 2023-08-04
+
+* [FIX] Fix `kube-event` transfrom processor configuration to correctly filter log body keys
+
 ### v0.0.4 / 2023-08-03
 
 * [FEATURE] Add cluster metrics related to allocatable resources (CPU, memory)

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.4
+version: 0.0.5
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -327,7 +327,9 @@ opentelemetry-cluster-collector:
         log_statements:
           - context: log
             statements:
-              - keep_keys(body, ["type", "action", "eventTime", "reason", "regarding", "reportingController", "note", "series", "metadata", "deprecatedFirstTimestamp", "deprecatedLastTimestamp"])
+              - keep_keys(body["object"], ["type", "eventTime", "reason", "regarding", "note", "metadata", "deprecatedFirstTimestamp", "deprecatedLastTimestamp"])
+              - keep_keys(body["object"]["metadata"], ["creationTimestamp"])
+              - keep_keys(body["object"]["regarding"], ["kind", "name", "namespace"])
       metricstransform/kube-extra-metrics:
         transforms:
           include: .*


### PR DESCRIPTION
# Description

The transform processor for `kube-event` does not currently work as expected. This change fixes it's configuration to properly filter the log `body` and retaining only fields required for the K8s dashboard feature.

# How Has This Been Tested?

Locally

# Checklist:
- [X] I have updated the relevant Helm chart(s) version(s)
- [X] I have updated the relevant component changelog(s)
- [] This change does not affect any particular component (e.g. it's CI or docs change)
