### PR TITLE
[otel-integration] Bump fork version and fix node label

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.6 / 2023-08-08
+
+* [CHORE] Bump Coralogix OpenTelemetry chart to `0.68.0`
+* [FEATURE] Make `k8s.node.name` label the target node for Kubernetes node info metric
+
 ### v0.0.5 / 2023-08-04
 
 * [FIX] Fix `kube-event` transfrom processor configuration to correctly filter log body keys

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.5
+version: 0.0.6
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -11,12 +11,12 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.67.0"
+    version: "0.68.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-cluster-collector
-    version: "0.67.0"
+    version: "0.68.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-cluster-collector.enabled
   - name: kube-state-metrics

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -275,8 +275,6 @@ opentelemetry-cluster-collector:
         secretKeyRef:
           name: coralogix-keys
           key: PRIVATE_KEY
-    - name: OTEL_RESOURCE_ATTRIBUTES
-      value: "k8s.node.name=$(K8S_NODE_NAME)"
     - name: KUBE_NODE_NAME
       valueFrom:
         fieldRef:
@@ -332,7 +330,7 @@ opentelemetry-cluster-collector:
               - keep_keys(body["object"]["regarding"], ["kind", "name", "namespace"])
       metricstransform/kube-extra-metrics:
         transforms:
-          include: .*
+        - include: .*
           match_type: regexp
           action: update
           operations:
@@ -342,6 +340,14 @@ opentelemetry-cluster-collector:
             - action: add_label
               new_label: cx.otel_integration.name
               new_value: "{{ .Chart.Name }}"
+          # Replace node name for kube node info with the name of the target node.
+        - include: kube_node_info
+          match_type: strict
+          action: update
+          operations:
+            - action: update_label
+              label: node
+              new_label: k8s.node.name
       resourcedetection/env:
         detectors: ["system", "env"]
         timeout: 2s


### PR DESCRIPTION
# Description

Fixes mainly moving extra Kubernetes to collector instead of agent by bumping the fork version. 

Also improves KSM instance filtering and adjusts the node label for node info metrics.

# How Has This Been Tested?

Locally on a multi-node setup.

# Checklist:
- [X] I have updated the relevant Helm chart(s) version(s)
- [X] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
