### PR TITLE
Align integration name attribute with internal requirements

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.7 / 2023-08-11
+
+* [FEATURE] Align `cx.otel_integration.name` with the new internal requirements
+
 ### v0.0.6 / 2023-08-08
 
 * [CHORE] Bump Coralogix OpenTelemetry chart to `0.68.0`

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.6
+version: 0.0.7
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -127,7 +127,7 @@ opentelemetry-agent:
               new_value: "{{ .Values.global.clusterName }}"
             - action: add_label
               new_label: cx.otel_integration.name
-              new_value: "{{ .Chart.Name }}"
+              new_value: "coralogix-integration-helm"
       k8sattributes:
         filter:
           node_from_env_var: KUBE_NODE_NAME     
@@ -339,7 +339,7 @@ opentelemetry-cluster-collector:
               new_value: "{{ .Values.global.clusterName }}"
             - action: add_label
               new_label: cx.otel_integration.name
-              new_value: "{{ .Chart.Name }}"
+              new_value: "coralogix-integration-helm"
           # Replace node name for kube node info with the name of the target node.
         - include: kube_node_info
           match_type: strict


### PR DESCRIPTION
# Description

The K8s dash-boarding feature requires us to have a uniform integration name attribute. This change is in order to align our integration name attributes to be `coralogix-integration-helm`.

# How Has This Been Tested?

Locally

# Checklist:
- [X] I have updated the relevant Helm chart(s) version(s)
- [X] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
