### PR TITLE
[otel-collector-windows-image] Bump collector to 0.81.0

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -40,8 +40,6 @@ jobs:
             - 'logs/fluentd/k8s-helm/http/**'
           ec2-otel-agent:
             - 'otel-agent/ecs-ec2/**'
-          windows-image:
-            - 'otel-agent/otel-collector-windows-image/**'
           k8s-otel-agent:
             - 'otel-agent/k8s-helm/**'
           otel-infrastructure-collector:
@@ -65,9 +63,6 @@ jobs:
     - name: OpenTelemetry Agent EC2 Changelog
       if: steps.filter.outputs.ec2-otel-agent == 'true'
       run: scripts/changelog_check.sh otel-agent/ecs-ec2
-    - name: OpenTelemetry Collector Windows Image
-      if: steps.filter.outputs.windows-image== 'true'
-      run: scripts/changelog_check.sh otel-agent/otel-collector-windows-image
     - name: OpenTelemetry Infrastructure Collector Changelog
       if: steps.filter.outputs.otel-infrastructure-collector == 'true'
       run: scripts/changelog_check.sh otel-infrastructure-collector

--- a/otel-agent/otel-collector-windows-image/Dockerfile
+++ b/otel-agent/otel-collector-windows-image/Dockerfile
@@ -3,7 +3,7 @@ ARG WIN_BASE_IMAGE
 
 FROM --platform=$BUILDPLATFORM curlimages/curl AS build
 WORKDIR /src
-RUN curl -Lo otelcol.tar.gz https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.77.0/otelcol-contrib_0.77.0_windows_amd64.tar.gz
+RUN curl -Lo otelcol.tar.gz https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.81.0/otelcol-contrib_0.81.0_windows_amd64.tar.gz
 RUN tar -xzvf otelcol.tar.gz
 
 ##


### PR DESCRIPTION
# Description

Bumps collector version to `0.81.0` (corresponds to current version on our other charts).

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the relevant Helm chart(s) version(s)
- [ ] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
