### PR TITLE
[otel-agent] Remove ballast extension for Windows chart

### DIFF
--- a/otel-agent/k8s-helm-windows/CHANGELOG.md
+++ b/otel-agent/k8s-helm-windows/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## OpenTelemtry Agent for Windows
 
+### v0.0.4 / 2023-08-17
+* Remove memory ballast extension due to extensive memory usage.
+
 ### v0.0.3 / 2023-05-23
 * Use image from Coralogix Docker Hub instead of the test image.
 

--- a/otel-agent/k8s-helm-windows/Chart.yaml
+++ b/otel-agent/k8s-helm-windows/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-coralogix-windows
-version: 0.0.3
+version: 0.0.4
 description: Windows OpenTelemetry agent to which instrumentation libraries export their telemetry data
 type: application
 appVersion: 0.77.0

--- a/otel-agent/k8s-helm-windows/templates/_config.tpl
+++ b/otel-agent/k8s-helm-windows/templates/_config.tpl
@@ -20,10 +20,6 @@ Merge user supplied config into memory limiter config.
 {{- if not $processorsConfig.memory_limiter }}
 {{-   $_ := set $processorsConfig "memory_limiter" (include "opentelemetry-collector.memoryLimiter" . | fromYaml) }}
 {{- end }}
-{{- $memoryBallastConfig := get .Values.config.extensions "memory_ballast" }}
-{{- if or (not $memoryBallastConfig) (not $memoryBallastConfig.size_in_percentage) }}
-{{-   $_ := set $memoryBallastConfig "size_in_percentage" 40 }}
-{{- end }}
 {{- .Values.config | toYaml }}
 {{- end }}
 
@@ -192,7 +188,7 @@ receivers:
     exclude: []
     {{- else }}
     {{- if .Values.isWindows }}
-    exclude:[ "C:\\var\\log\\pods\\{{ .Release.Namespace }}_{{ include "opentelemetry-collector.fullname" . }}*_*\\{{ include "opentelemetry-collector.lowercase_chartname" . }}\\*.log" ]
+    exclude: [ "C:\\var\\log\\pods\\{{ .Release.Namespace }}_{{ include "opentelemetry-collector.fullname" . }}*_*\\{{ include "opentelemetry-collector.lowercase_chartname" . }}\\*.log" ]
     {{- else }}
     # Exclude collector container's logs. The file format is /var/log/pods/<namespace_name>_<pod_name>_<pod_uid>/<container_name>/<run_id>.log
     exclude: [ /var/log/pods/{{ .Release.Namespace }}_{{ include "opentelemetry-collector.fullname" . }}*_*/{{ include "opentelemetry-collector.lowercase_chartname" . }}/*.log ]

--- a/otel-agent/k8s-helm-windows/values.yaml
+++ b/otel-agent/k8s-helm-windows/values.yaml
@@ -104,7 +104,6 @@ config:
     # Without the health_check extension the collector will fail the readiness and liveliness probes.
     # The health_check extension can be modified, but should never be removed.
     health_check: {}
-    memory_ballast: {}
   processors:
     k8sattributes:
       filter:
@@ -162,8 +161,6 @@ config:
             static_configs:
               - targets:
                   - ${env:MY_POD_IP}:8888
-    zipkin:
-      endpoint: ${env:MY_POD_IP}:9411
   service:
     telemetry:
       logs:
@@ -174,7 +171,6 @@ config:
       - zpages
       - pprof
       - health_check
-      - memory_ballast
     pipelines:
       logs:
         exporters:


### PR DESCRIPTION
# Description

Fixes [ES-66](https://coralogix.atlassian.net/browse/ES-66).

This removes the `memory_ballast` extension from the Windows chart. As our investigation has shown, on Windows platforms the extension does not work as a expected and using the memory ballast extension will actually cause the collector to use up all the memory marked as ballast, regardless of resource limits. To prevent this extensive resource usage, we are removing this extension on Windows platforms.

# How Has This Been Tested?

On EKS Windows node.

# Checklist:
- [X] I have updated the relevant Helm chart(s) version(s)
- [X] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)


[ES-66]: https://coralogix.atlassian.net/browse/ES-66?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ