### PR TITLE
[otel-integration] feat support host.id from system resource detector

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.12 / 2023-08-21
+
+* [FEATURE] Support host.id from system resource detector.
+
 ### v0.0.11 / 2023-08-18
 
 * [CHORE] Upgrading upstream chart. (v0.71.0).

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.11
+version: 0.0.12
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -15,6 +15,23 @@ opentelemetry-agent:
   enabled: true
   mode: daemonset
   fullnameOverride: coralogix-opentelemetry-agent
+  extraVolumes:
+    - name: etcmachineid
+      hostPath:
+        path: /etc/machine-id
+    - name: varlibdbusmachineid
+      hostPath:
+        path: /var/lib/dbus/machine-id
+
+  extraVolumeMounts:
+    - mountPath: /etc/machine-id
+      mountPropagation: HostToContainer
+      name: etcmachineid
+      readOnly: true
+    - mountPath: /var/lib/dbus/machine-id
+      mountPropagation: HostToContainer
+      name: varlibdbusmachineid
+      readOnly: true
   extraEnvs:
     - name: CORALOGIX_PRIVATE_KEY
       valueFrom:
@@ -100,6 +117,10 @@ opentelemetry-agent:
         detectors: ["system", "env"]
         timeout: 2s
         override: false
+        system:
+          resource_attributes:
+            host.id:
+              enabled: true
       resourcedetection/region:
         detectors: ["gcp", "ec2"]
         timeout: 2s


### PR DESCRIPTION
# Description

For bare-metal use case we don't have `host.id`, which is required for k8s dashboard. The host.id is only coming from gcp / aws detectors. This PR changes to use the `system` detector's host.id detection.

Fixes #ES-70

# How Has This Been Tested?

- installed on kind cluster

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
