### PR TITLE
[otel-agent] allow setting cluster name

### DIFF
--- a/otel-agent/k8s-helm/CHANGELOG.md
+++ b/otel-agent/k8s-helm/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## OpenTelemtry-Agent
 
+### v0.0.34 / 2023-09-13
+
+* [FEATURE] Allow setting clusterName in global variable
+* [FEATURE] Set integrationName as resource attribute
+* [CHORE] Upgrading upstream chart. (v0.71.2)
+
+
 ### v0.0.33 / 2023-09-04
 
 * [CHORE] Upgrading upstream chart. (v0.71.1)

--- a/otel-agent/k8s-helm/Chart.yaml
+++ b/otel-agent/k8s-helm/Chart.yaml
@@ -1,14 +1,14 @@
 apiVersion: v2
 name: opentelemetry-coralogix
 description: OpenTelemetry agent to which instrumentation libraries export their telemetry data
-version: 0.0.33
+version: 0.0.34
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry agent
   - Coralogix
 dependencies:
   - name: opentelemetry-collector
-    version: "0.71.1"
+    version: "0.71.2"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
 sources:
   - https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector

--- a/otel-agent/k8s-helm/values.yaml
+++ b/otel-agent/k8s-helm/values.yaml
@@ -1,5 +1,6 @@
 global:
   domain: ""
+  clusterName: ""
   defaultApplicationName: "default"
   defaultSubsystemName: "nodes"
   fullnameOverride: otel-coralogix
@@ -48,6 +49,10 @@ opentelemetry-collector:
       enabled: true
     kubeletMetrics:
       enabled: true
+    metadata:
+      enabled: true
+      clusterName: "{{.Values.global.clusterName}}"
+      integrationName: "coralogix-otel-agent-helm"
 
   extraEnvs:
   - name: CORALOGIX_PRIVATE_KEY


### PR DESCRIPTION
# Description

Allow users to easily set clusterName.

Tested with kind cluster:
```
helm install --values new-values.yaml otel-agent .  
```

My example generated:
```
        resource/metadata:
          attributes:
          - action: upsert
            key: k8s.cluster.name
            value: 'kind'
          - action: upsert
            key: cx.otel_integration.name
            value: coralogix-otel-agent-helm
```

Fixes https://coralogix.atlassian.net/browse/ES-21

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
