### PR TITLE
[otel-integration] set cluster name for all signals

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.15 / 2023-09-15
+
+* [FIX] Set k8s.cluster.name to all signals.
+* [CHORE] Upgrading upstream chart. (v0.71.2)
+
 ### v0.0.14 / 2023-09-04
 
 * [CHORE] Upgrading upstream chart. (v0.71.1)

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.14
+version: 0.0.15
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -11,12 +11,12 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.71.1"
+    version: "0.71.2"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-cluster-collector
-    version: "0.71.1"
+    version: "0.71.2"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-cluster-collector.enabled
   - name: kube-state-metrics

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -62,6 +62,10 @@ opentelemetry-agent:
   dnsPolicy: "ClusterFirstWithHostNet"
 
   presets:
+    metadata:
+      enabled: true
+      clusterName: "{{.Values.global.clusterName}}"
+      integrationName: "coralogix-integration-helm"
     logsCollection:
       enabled: true
       storeCheckpoints: true
@@ -137,18 +141,6 @@ opentelemetry-agent:
               enabled: true
             cloud.availability_zone:
               enabled: true
-      metricstransform:
-        transforms:
-          include: .*
-          match_type: regexp
-          action: update
-          operations:
-            - action: add_label
-              new_label: k8s.cluster.name
-              new_value: "{{ .Values.global.clusterName }}"
-            - action: add_label
-              new_label: cx.otel_integration.name
-              new_value: "coralogix-integration-helm"
       k8sattributes:
         filter:
           node_from_env_var: KUBE_NODE_NAME     
@@ -215,7 +207,6 @@ opentelemetry-agent:
             - k8sattributes
             - resourcedetection/env
             - resourcedetection/region
-            - metricstransform
             - memory_limiter
             - batch
           receivers:
@@ -298,6 +289,10 @@ opentelemetry-cluster-collector:
         - username: ""
           password: ""
           port: 3306
+    metadata:
+      enabled: true
+      clusterName: "{{.Values.global.clusterName}}"
+      integrationName: "coralogix-integration-helm"
 
   extraEnvs:
     - name: CORALOGIX_PRIVATE_KEY
@@ -360,16 +355,6 @@ opentelemetry-cluster-collector:
               - keep_keys(body["object"]["regarding"], ["kind", "name", "namespace"])
       metricstransform/kube-extra-metrics:
         transforms:
-        - include: .*
-          match_type: regexp
-          action: update
-          operations:
-            - action: add_label
-              new_label: k8s.cluster.name
-              new_value: "{{ .Values.global.clusterName }}"
-            - action: add_label
-              new_label: cx.otel_integration.name
-              new_value: "coralogix-integration-helm"
           # Replace node name for kube node info with the name of the target node.
         - include: kube_node_info
           match_type: strict


### PR DESCRIPTION
# Description

Use metadata preset to push k8s.cluster.name for all signals

Fixes ES-93, CDS-631.



# How Has This Been Tested?

Tested on kind cluster and checked k8s dashboard

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [X] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
