### PR TITLE
[FIX] Remove redundant `-agent` from `fullnameOverride` field of `values.yaml`

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.17 / 2023-09-29
+
+* [FIX] Remove redundant `-agent` from `fullnameOverride` field of `values.yaml`
+
 ### v0.0.16 / 2023-09-28
 
 * [FIX] Remove `k8s.pod.name`,`k8s.job.name` and `k8s.node.name` from subsystem attribute list

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.16
+version: 0.0.17
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -14,7 +14,7 @@ distribution: ""
 opentelemetry-agent:
   enabled: true
   mode: daemonset
-  fullnameOverride: coralogix-opentelemetry-agent
+  fullnameOverride: coralogix-opentelemetry
   extraVolumes:
     - name: etcmachineid
       hostPath:


### PR DESCRIPTION
# Description

The `fullnameOverride` in the Values file has a redundant "-agent" at the end. When following the default installation pattern this yields pods that have names like `coralogix-opentelemetry-agent-agent-xxxxx`. 

# How Has This Been Tested?

Yes, I deployed the default configuration, as-is, and you will see it as the attache screenshot. After deleting everything and trying it again without the redundant "-agent" everything is name correctly. No functional difference between either scenario. 

# Checklist:
- [X] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
![Screenshot 2023-09-29 at 1 55 30 PM](https://github.com/coralogix/telemetry-shippers/assets/3058771/9ffab66d-c47d-4cd9-8b8b-dc7f07bfd6a2)
