### PR TITLE
Bump Windows image Dockerfile to 0.83.0

### DIFF
--- a/otel-agent/otel-collector-windows-image/Dockerfile
+++ b/otel-agent/otel-collector-windows-image/Dockerfile
@@ -3,7 +3,7 @@ ARG WIN_BASE_IMAGE
 
 FROM --platform=$BUILDPLATFORM curlimages/curl AS build
 WORKDIR /src
-RUN curl -Lo otelcol.tar.gz https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.81.0/otelcol-contrib_0.81.0_windows_amd64.tar.gz
+RUN curl -Lo otelcol.tar.gz https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.83.0/otelcol-contrib_0.83.0_windows_amd64.tar.gz
 RUN tar -xzvf otelcol.tar.gz
 
 ##


### PR DESCRIPTION
# Description

Build Windows Docker image with latest collector version we use in other charts.

# How Has This Been Tested?

N/A

# Checklist:
- [ ] I have updated the relevant Helm chart(s) version(s)
- [ ] I have updated the relevant component changelog(s)
- [X] This change does not affect any particular component (e.g. it's CI or docs change)
