### PR TITLE
[otel-agent] Bump Windows collector image version

### DIFF
--- a/otel-agent/k8s-helm-windows/CHANGELOG.md
+++ b/otel-agent/k8s-helm-windows/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## OpenTelemtry Agent for Windows
 
-### v0.0.5 / 2023-09-28
+### v0.0.6 / 2023-10-04
+* Use image version based on the `appVersion` parameter.
+* Bump image collector image version to `0.83.0`.
 
-* [FIX] Remove `k8s.container.name`,`k8s.job.name` and `k8s.node.name` from subsystem attribute list
+### v0.0.5 / 2023-09-28
+* Remove `k8s.container.name`,`k8s.job.name` and `k8s.node.name` from subsystem attribute list
 
 ### v0.0.4 / 2023-08-17
 * Remove memory ballast extension due to extensive memory usage.

--- a/otel-agent/k8s-helm-windows/Chart.yaml
+++ b/otel-agent/k8s-helm-windows/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: opentelemetry-coralogix-windows
-version: 0.0.5
+version: 0.0.6
 description: Windows OpenTelemetry agent to which instrumentation libraries export their telemetry data
 type: application
 appVersion: 0.83.0

--- a/otel-agent/k8s-helm-windows/Chart.yaml
+++ b/otel-agent/k8s-helm-windows/Chart.yaml
@@ -3,4 +3,4 @@ name: opentelemetry-coralogix-windows
 version: 0.0.5
 description: Windows OpenTelemetry agent to which instrumentation libraries export their telemetry data
 type: application
-appVersion: 0.77.0
+appVersion: 0.83.0

--- a/otel-agent/k8s-helm-windows/values.yaml
+++ b/otel-agent/k8s-helm-windows/values.yaml
@@ -203,7 +203,7 @@ image:
   repository: coralogixrepo/opentelemetry-collector-contrib-windows
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "latest"
+  tag: ""
   # When digest is set to a non-empty value, images will be pulled by digest (regardless of tag value).
   digest: ""
 imagePullSecrets: []


### PR DESCRIPTION
# Description

Bumps Windows collector version and uses version specified in Chart file.

# How Has This Been Tested?

Locally.

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [X] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
