### PR TITLE
[otel-integration] fix hostmetrics don't scrape /run/containerd/runc

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.18 / 2023-10-04
+
+* [FIX] hostmetrics don't scrape /run/containerd/runc/* for filesystem metrics
+
 ### v0.0.17 / 2023-09-29
 
 * [FIX] Remove redundant `-agent` from `fullnameOverride` field of `values.yaml`

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.17
+version: 0.0.18
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -11,12 +11,12 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.71.2"
+    version: "0.71.3"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-cluster-collector
-    version: "0.71.2"
+    version: "0.71.3"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-cluster-collector.enabled
   - name: kube-state-metrics


### PR DESCRIPTION


# Description

Fixes https://coralogix.atlassian.net/browse/ES-110

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
