### PR TITLE
chore: add warnings to otel-agent and otel-infra-collector

### DIFF
--- a/otel-agent/k8s-helm/README.md
+++ b/otel-agent/k8s-helm/README.md
@@ -1,5 +1,8 @@
 # OpenTelemetry Agent
 
+> [!IMPORTANT]
+> OpenTelemetry Agent is deprecated and in maintenance mode. Please use [OpenTelemetry Integration](https://github.com/coralogix/telemetry-shippers/tree/master/otel-integration/k8s-helm) project, which provides full OpenTelemetry observability solution.
+
 The OpenTelemetry collector offers a vendor-agnostic implementation of how to receive, process and export telemetry data.
 In this chart, the collector will be deployed as a daemonset, meaning the collector will run as an `agent` on each node. Agent runs in host network mode allowing you to easily send application telemetry data.
 

--- a/otel-infrastructure-collector/k8s-helm/README.md
+++ b/otel-infrastructure-collector/k8s-helm/README.md
@@ -1,5 +1,8 @@
 ### K8s
 
+> [!IMPORTANT]
+> OpenTelemetry Infrastructure Collector is deprecated and in maintenance mode. Please use [OpenTelemetry Integration](https://github.com/coralogix/telemetry-shippers/tree/master/otel-integration/k8s-helm) project, which provides full OpenTelemetry observability solution.
+
 This Infrastructure collector provides:
 
 - [Coralogix Exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/coralogixexporter) - Coralogix exporter is preconfigured to enrich data using Kubernetes Attributes, which allows quick correlation of telemetry signals using consistent ApplicationName and SubsytemName fields.


### PR DESCRIPTION
# Description

I think it's time to deprecate otel-agent and otel-infra-collector

This is how it looks rendered -> https://github.com/coralogix/telemetry-shippers/blob/da88c536bfea82ff747216c7370b1821b8ac706e/otel-agent/k8s-helm/README.md

Fixes ES-115

# How Has This Been Tested?

-

# Checklist:
- [ ] I have updated the relevant Helm chart(s) version(s)
- [ ] I have updated the relevant component changelog(s)
- [x] This change does not affect any particular component (e.g. it's CI or docs change)
