### PR TITLE
Remove unneeded config from cloud provider resource detectors

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.24 / 2023-10-26
+* [CHORE] Remove unnecessary cloud resource detector configuration.
+
 ### v0.0.23 / 2023-10-26
 * [FEATURE] Add k8sattributes and resourcedetecion processor for logs and traces in agent.
 

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.23
+version: 0.0.25
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/values-windows.yaml
+++ b/otel-integration/k8s-helm/values-windows.yaml
@@ -127,18 +127,6 @@ opentelemetry-agent-windows:
         detectors: ["gcp", "ec2"]
         timeout: 2s
         override: true
-        gcp:
-          resource_attributes:
-            cloud.region:
-              enabled: true
-            cloud.availability_zone:
-              enabled: true
-        ec2:
-          resource_attributes:
-            cloud.region:
-              enabled: true
-            cloud.availability_zone:
-              enabled: true
       k8sattributes:
         filter:
           node_from_env_var: KUBE_NODE_NAME

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -129,18 +129,6 @@ opentelemetry-agent:
         detectors: ["gcp", "ec2"]
         timeout: 2s
         override: true
-        gcp:
-          resource_attributes:
-            cloud.region:
-              enabled: true
-            cloud.availability_zone:
-              enabled: true
-        ec2:
-          resource_attributes:
-            cloud.region:
-              enabled: true
-            cloud.availability_zone:
-              enabled: true
       k8sattributes:
         filter:
           node_from_env_var: KUBE_NODE_NAME
@@ -377,18 +365,6 @@ opentelemetry-cluster-collector:
         detectors: ["gcp", "ec2"]
         timeout: 2s
         override: true
-        gcp:
-          resource_attributes:
-            cloud.region:
-              enabled: true
-            cloud.availability_zone:
-              enabled: true
-        ec2:
-          resource_attributes:
-            cloud.region:
-              enabled: true
-            cloud.availability_zone:
-              enabled: true
       # Will get the k8s resource limits
       memory_limiter: null
 


### PR DESCRIPTION
# Description

Removes unnecessary configuration from cloud provider resource detectors, since the specified attributes are already enabled by default.

# How Has This Been Tested?

N/A

# Checklist:
- [X] I have updated the relevant Helm chart(s) version(s)
- [X] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
