### PR TITLE
[otel-integration] fix support for openshift

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.29 / 2023-10-31
+* Fix support for openshift
+
 ### v0.0.28 / 2023-10-30
 * [CHORE] Update Collector to 0.87.0 (v0.75.0)
 

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.27
+version: 0.0.29
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/templates/agent-cr.yaml
+++ b/otel-integration/k8s-helm/templates/agent-cr.yaml
@@ -2,12 +2,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: system:openshift:scc:{{.Values.global.fullnameOverride }}
+  name: system:openshift:scc:{{ index .Values "opentelemetry-agent" "fullnameOverride" }}
 rules:
 - apiGroups:
   - security.openshift.io
   resourceNames:
-  - {{.Values.global.fullnameOverride }}
+  - {{ index .Values "opentelemetry-agent" "fullnameOverride" }}
   resources:
   - securitycontextconstraints
   verbs:

--- a/otel-integration/k8s-helm/templates/agent-crb.yaml
+++ b/otel-integration/k8s-helm/templates/agent-crb.yaml
@@ -1,0 +1,14 @@
+{{- if eq ((.Values.distribution)) "openshift" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:openshift:scc:{{ index .Values "opentelemetry-agent" "fullnameOverride" }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:{{ index .Values "opentelemetry-agent" "fullnameOverride" }}
+subjects:
+- kind: ServiceAccount
+  name: {{ index .Values "opentelemetry-agent" "fullnameOverride" }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/otel-integration/k8s-helm/templates/ksm-cr.yaml
+++ b/otel-integration/k8s-helm/templates/ksm-cr.yaml
@@ -1,0 +1,15 @@
+{{- if eq ((.Values.distribution)) "openshift" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:openshift:scc:{{ index .Values "kube-state-metrics" "fullnameOverride" }}
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - nonroot-v2
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+{{- end }}

--- a/otel-integration/k8s-helm/templates/ksm-crb.yaml
+++ b/otel-integration/k8s-helm/templates/ksm-crb.yaml
@@ -2,13 +2,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: system:openshift:scc:{{.Values.global.fullnameOverride }}
+  name: system:openshift:scc:{{ index .Values "kube-state-metrics" "fullnameOverride" }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:openshift:scc:{{.Values.global.fullnameOverride }}
+  name: system:openshift:scc:{{ index .Values "kube-state-metrics" "fullnameOverride" }}
 subjects:
 - kind: ServiceAccount
-  name: {{.Values.global.fullnameOverride }}
+  name: {{ index .Values "kube-state-metrics" "fullnameOverride" }}
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/otel-integration/k8s-helm/templates/scc.yaml
+++ b/otel-integration/k8s-helm/templates/scc.yaml
@@ -36,14 +36,14 @@ requiredDropCapabilities:
 kind: SecurityContextConstraints
 apiVersion: security.openshift.io/v1
 metadata:
-  name: {{.Values.global.fullnameOverride }}
+  name: {{ index .Values "opentelemetry-agent" "fullnameOverride" }}
   labels:
-    app: {{ template "opentelemetry-agent.name" . }}
-    chart: {{ template "opentelemetry-agent.chart" . }}
+    app: {{ template "opentelemetry-collector.name" . }}
+    chart: {{ template "opentelemetry-collector.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 users:
-- system:serviceaccount:{{ .Release.Namespace }}:{{.Values.global.fullnameOverride }}
+- system:serviceaccount:{{ .Release.Namespace }}:{{ index .Values "opentelemetry-agent" "fullnameOverride" }}
 {{- $config := include "opentelemetry-coralogix.defaultSecurityContextConstraints" . | fromYaml }}
-{{ .Values.securityContextConstraintsOverwrite | mustMergeOverwrite $config | toYaml }}
+{{ index .Values "opentelemetry-agent" "securityContextConstraintsOverwrite" | mustMergeOverwrite $config | toYaml }}
 {{- end }}

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -467,6 +467,7 @@ opentelemetry-agent-windows:
   enabled: false
 
 kube-state-metrics:
+  fullnameOverride: coralogix-opentelemetry-kube-state-metrics
   prometheusScrape: false
   collectors:
     - pods


### PR DESCRIPTION
# Description

Fixes ES-136

Running otel-integration resulted in a bunch of templating errors, agent / ksm didn't spin up.

This fixes that. 

KSM will use non-rootv2 default SCC (Ref: https://docs.openshift.com/container-platform/4.11/authentication/managing-security-context-constraints.html)

# How Has This Been Tested?

Manually tested using https://crc.dev/crc/getting_started/getting_started/introducing/

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
