### PR TITLE
feat: fix kube-state-metrics and upgrade

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -11,14 +11,14 @@ runs:
     - name: Set up Helm
       uses: azure/setup-helm@v3.5
       with:
-        version: v3.9.0
+        version: v3.12.1
 
     - uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: '3.10'
 
     - name: Set up chart-testing
-      uses: helm/chart-testing-action@v2.4.0
+      uses: helm/chart-testing-action@v2.6.0
 
     - name: Create kind cluster
       uses: helm/kind-action@v1.5.0

--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.31 / 2023-11-03
+
+* [FIX] Fix scraping Kube State Metrics
+* [CHORE] Update Collector to 0.88.0 (v0.76.0)
+* [FIX] Fix consistent k8s.deployment.name attribute
+
 ### v0.0.30 / 2023-10-31
 * [FEATURE] Add support for defining priority class
 

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.30
+version: 0.0.31
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -11,17 +11,17 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.75.2"
+    version: "0.76.2"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-windows
-    version: "0.75.2"
+    version: "0.76.2"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-windows.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-cluster-collector
-    version: "0.75.2"
+    version: "0.76.2"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-cluster-collector.enabled
   - name: kube-state-metrics

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -286,6 +286,7 @@ opentelemetry-cluster-collector:
       enabled: true
     kubernetesExtraMetrics:
       enabled: true
+      kubeStateMetricsName: "coralogix-opentelemetry-kube-state-metrics"
     kubernetesAttributes:
       enabled: true
     mysql:


### PR DESCRIPTION
# Description

* [FIX] Fix scraping Kube State Metrics
* [CHORE] Update Collector to 0.88.0 (v0.76.0)
* [FIX] Fix consistent k8s.deployment.name attribute

Fixes ES--13

# How Has This Been Tested?

- kind cluster, watched k8s dashboard.

# Checklist:
- [x ] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
