### PR TITLE
[otel-integration] add statsd receiver

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.35 / 2023-11-14
+* [FEATURE] Adds statsd receiver to listen for metrics on 8125 port.
+
 ### v0.0.34 / 2023-11-13
 * [FIX] Remove Kube-State-Metrics receive_creator, which generated unnecessary configuration.
 

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.34
+version: 0.0.35
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -98,6 +98,8 @@ opentelemetry-agent:
         endpoint: localhost:1777
 
     receivers:
+      statsd:
+        endpoint: ${MY_POD_IP}:8127
       otlp:
         protocols:
           grpc:
@@ -209,6 +211,7 @@ opentelemetry-agent:
             - otlp
             - prometheus
             - hostmetrics
+            - statsd
         traces:
           exporters:
             - coralogix
@@ -245,6 +248,12 @@ opentelemetry-agent:
       memory: 2G
 
   ports:
+    statsd:
+      enabled: true
+      containerPort: 8125
+      servicePort: 8125
+      hostPort: 8125
+      protocol: UDP
     jaeger-binary:
       enabled: true
       containerPort: 6832


### PR DESCRIPTION
# Description

Adds default statsd receiver

Fixes [ES-142](https://coralogix.atlassian.net/browse/ES-142)

# How Has This Been Tested?

kind cluster

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)


[ES-142]: https://coralogix.atlassian.net/browse/ES-142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ