### PR TITLE
[otel-integration] change statsd port to 8125

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.36 / 2023-11-15
+* [FIX] Change statsd receiver port to 8125 instead of 8127
+
 ### v0.0.35 / 2023-11-14
 * [FEATURE] Adds statsd receiver to listen for metrics on 8125 port.
 

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.35
+version: 0.0.36
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -99,7 +99,7 @@ opentelemetry-agent:
 
     receivers:
       statsd:
-        endpoint: ${MY_POD_IP}:8127
+        endpoint: ${MY_POD_IP}:8125
       otlp:
         protocols:
           grpc:


### PR DESCRIPTION
# Description

Fixes https://coralogix.atlassian.net/browse/ES-142

Previous PR incorrectly set wrong port, for statsd we should use 8125 
# How Has This Been Tested?



# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
