### PR TITLE
[eks-fargate-otel] deploy to fargate node when in mixed ec2+fargate cluster

### DIFF
--- a/otel-agent/README.md
+++ b/otel-agent/README.md
@@ -23,7 +23,7 @@ The section contains integrations of the Open Telemetry agent for various platfo
 
 **Agent Implementations:**
 
-1. [ecs-ec2](./ecs-ec2/)
+1. [otel-ecs-ec2](../otel-ecs-ec2/)
 2. [k8s helm](./k8s-helm/)
 
 ## Coralogix's Endpoints

--- a/otel-ecs-ec2/README.md
+++ b/otel-ecs-ec2/README.md
@@ -59,8 +59,8 @@ The image allows you to pass in your configuration files as a Base64 encoded env
 
 This repo provides example of the following configuration files (you can create other configuration with combination for logs/metric/taces) which work directly with the *coralogixrepo/coralogix-otel-collector* docker image for ECS and the cloudformation template provided [here](https://github.com/coralogix/cloudformation-coralogix-aws/blob/master/opentelemetry/ecs-ec2/README.md).
 
-- [logging](https://github.com/coralogix/telemetry-shippers/blob/master/otel-agent/ecs-ec2/logging.yaml)
-- [traces & metrics](https://github.com/coralogix/telemetry-shippers/blob/master/otel-agent/ecs-ec2/config.yaml)
+- [logging](logging.yaml)
+- [traces & metrics](config.yaml)
 
 ### Deploying Open Telemetry
 

--- a/otel-eks-fargate/CHANGELOG.md
+++ b/otel-eks-fargate/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## OpenTelemetry EKS-Fargate
 
+### v0.0.2 / 2023-12-14
+* [FIX] Deploy to and monitors Fargate portion of mixed ec2+fargate cluster
+
 ### v0.0.1 / 2023-08-17
 
 * [NEW] Added EKS Fargate related configuration files

--- a/otel-eks-fargate/cx-eks-fargate-otel-self-monitoring.yaml
+++ b/otel-eks-fargate/cx-eks-fargate-otel-self-monitoring.yaml
@@ -148,3 +148,6 @@ spec:
               - key: cx-otel-collector-monitor-config
                 path: cx-otel-collector-monitor-config.yaml
           name: cx-otel-collector-monitor-config-volume
+      nodeSelector:
+        eks.amazonaws.com/compute-type: fargate
+        kubernetes.io/os: linux

--- a/otel-eks-fargate/cx-eks-fargate-otel.yaml
+++ b/otel-eks-fargate/cx-eks-fargate-otel.yaml
@@ -61,7 +61,7 @@ data:
     # Give execute permissions to kubectl
     chmod +x kubectl
 
-    # Label only the current node as the OTEL-collector-node
+    # Remove any prior label from other nodes. Label only the current node as the single OTEL-collector-node.
     ./kubectl label nodes --all OTEL-collector-node-
     ./kubectl label nodes $K8S_NODE_NAME OTEL-collector-node=true
 ---

--- a/otel-eks-fargate/cx-eks-fargate-otel.yaml
+++ b/otel-eks-fargate/cx-eks-fargate-otel.yaml
@@ -53,15 +53,16 @@ metadata:
 data:
   label-node-script: |
     #!/bin/bash
-
+    set +x
     # Download kubectl
     # If the latest stable version is not compatible with your cluster, adjust accordingly.
-    curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+    curl -LOs "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
 
     # Give execute permissions to kubectl
     chmod +x kubectl
 
-    # Run the command to label nodes
+    # Label only the current node as the OTEL-collector-node
+    ./kubectl label nodes --all OTEL-collector-node-
     ./kubectl label nodes $K8S_NODE_NAME OTEL-collector-node=true
 ---
 # ConfigMap for OTEL collector instance
@@ -280,3 +281,6 @@ spec:
               - key: label-node-script
                 path: label_node.sh
                 mode: 0555
+      nodeSelector:
+        eks.amazonaws.com/compute-type: fargate
+        kubernetes.io/os: linux

--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### v0.0.44 / 2023-12-13
 
 - [CHORE] Update collector to `v0.91.0`.
-- [FEATURE] Remove memoryballast and enable GOMEMLIMIT instead. This should significantly reduce memory footprint. See https://github.com/open-telemetry/opentelemetry-helm-charts/issues/891. 
+- [FEATURE] Remove memoryballast and enable GOMEMLIMIT instead. This should significantly reduce memory footprint. See https://github.com/open-telemetry/opentelemetry-helm-charts/issues/891.
 
 ### v0.0.43 / 2023-12-12
 


### PR DESCRIPTION
# Description

<!-- Please describe the changes you made in a few words or sentences. -->
Add nodeSelector to constrain otel deployment to fargate nodes when in a mixed ec2+fargate eks cluster.

<!-- (provide issue number, if applicable; otherwise remove) --> 
Fixes  [CDS-854](https://coralogix.atlassian.net/browse/CDS-854).

# How Has This Been Tested?
OTEL pods deploy to Fargate nodes only in a mixed EC2+Fargate EKS cluster. 

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)


[CDS-854]: https://coralogix.atlassian.net/browse/CDS-854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ