### PR TITLE
[otel-integration] fix: enable agent service for gke/autopilot

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.41 / 2023-12-06
+
+- [FIX] Enable Agent Service for GKE Autopilot clusters.
+
 ### v0.0.40 / 2023-12-01
 
 - [FEATURE] Add support for GKE Autopilot clusters.

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.40
+version: 0.0.41
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/gke-autopilot-values.yaml
+++ b/otel-integration/k8s-helm/gke-autopilot-values.yaml
@@ -17,6 +17,8 @@ opentelemetry-agent:
   extraVolumes: []
   extraVolumeMounts: []
   hostNetwork: false
+  service:
+    enabled: true
   presets:
     logsCollection:
       enabled: true


### PR DESCRIPTION
# Description

This enables service agent with Internal traffic policy for gke autopilot  clusters

FIX ES-162

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
