### PR TITLE
chore: deprecate otel-agent windows and otel-infra collector

### DIFF
--- a/otel-agent/k8s-helm-windows/README.md
+++ b/otel-agent/k8s-helm-windows/README.md
@@ -1,5 +1,8 @@
 # OpenTelemetry Collector Helm Chart
 
+> [!IMPORTANT]
+> OpenTelemetry Agent is deprecated and in maintenance mode. Please use [OpenTelemetry Integration](https://github.com/coralogix/telemetry-shippers/tree/master/otel-integration/k8s-helm) project, which provides full OpenTelemetry observability solution.
+
 ## Description
 
 Temporary fork of [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector) to add support for Windows containers.

--- a/otel-infrastructure-collector/README.md
+++ b/otel-infrastructure-collector/README.md
@@ -1,5 +1,8 @@
 # OpenTelemetry Infrastructure Collector
 
+> [!IMPORTANT]
+> OpenTelemetry Infrastructure Collector is deprecated and in maintenance mode. Please use [OpenTelemetry Integration](https://github.com/coralogix/telemetry-shippers/tree/master/otel-integration/k8s-helm) project, which provides full OpenTelemetry observability solution.
+
 The OpenTelemetry collector offers a vendor-agnostic implementation of how to receive, process and export telemetry data.
 In this chart, the collector will be deployed as a single replica deployment.
 


### PR DESCRIPTION
# Description

We are missing a couple of deprecations on READMEs, sofixing that.

 Fixes https://coralogix.atlassian.net/browse/ES-170

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the relevant Helm chart(s) version(s)
- [ ] I have updated the relevant component changelog(s)
- [x] This change does not affect any particular component (e.g. it's CI or docs change)
