### PR TITLE
Fix otel exporter otlp endpoint example value

### DIFF
--- a/otel-integration/k8s-helm/README.md
+++ b/otel-integration/k8s-helm/README.md
@@ -227,7 +227,7 @@ env:
       fieldRef:
         fieldPath: status.hostIP
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
-    value: "$(NODE):4317"
+    value: "http://$(NODE):4317"
 ```
 
 ### About span metrics


### PR DESCRIPTION
# Description

The environment variable default value should contain a prefix of `http` or `https`.
Once using an internal k8s value, the most common usage would be a `http` prefix

# How Has This Been Tested?

Deployed the chart with and without the change;
- without the agent's failure to report data

# Checklist:
- [ ] I have updated the relevant Helm chart(s) version(s) --> No need, it's docs change
- [ ] I have updated the relevant component changelog(s) --> No need, it's docs change
- [x] This change does not affect any particular component (e.g. it's CI or docs change)
