### PR TITLE
[otel-integration] Update Windows image and disable trace pipeline on collector

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.46 / 2024-01-11
+
+- [CHORE] Update Windows collector image to `v0.91.0`
+- [FIX] Disable unsued tracing pipeline in cluster collector
+
 ### v0.0.45 / 2024-01-05
 
 - [FIX] Fix target allocator resources not being applied previously.

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.45
+version: 0.0.46
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/values-windows.yaml
+++ b/otel-integration/k8s-helm/values-windows.yaml
@@ -10,7 +10,7 @@ opentelemetry-agent-windows:
     repository: coralogixrepo/opentelemetry-collector-contrib-windows
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "0.85.0"
+    tag: "0.91.0"
     # When digest is set to a non-empty value, images will be pulled by digest (regardless of tag value).
     digest: ""
   extraVolumes:
@@ -250,9 +250,5 @@ opentelemetry-agent:
     kubernetes.io/os: linux
 
 opentelemetry-cluster-collector:
-  nodeSelector:
-    kubernetes.io/os: linux
-
-kube-state-metrics:
   nodeSelector:
     kubernetes.io/os: linux

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -491,6 +491,7 @@ opentelemetry-cluster-collector:
             - otlp
             - prometheus
             - k8s_cluster
+        traces: null
   tolerations:
     - operator: Exists
 


### PR DESCRIPTION
# Description

 - Bumps Windows agent image to latest (`0.91.0`)
 - Disable trace pipeline in the collector, since it's unused

# How Has This Been Tested?

Locally

# Checklist:
- [X] I have updated the relevant Helm chart(s) version(s)
- [X] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
