### PR TITLE
[otel-integration] Add histogram buckets and bump collector to `0.92.0`

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.48 / 2024-01-17
+
+- [FEATURE] Add support for specifying histogram buckets for span metrics preset.
+- [CHORE] Update collector to `v0.92.0`.
+
 ### v0.0.47 / 2024-01-16
 
 - [FIX] Suppress generation of `service.instance.id` from collector telemetry.

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.47
+version: 0.0.48
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -11,17 +11,17 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.78.1"
+    version: "0.79.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-windows
-    version: "0.78.1"
+    version: "0.79.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-windows.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-cluster-collector
-    version: "0.78.1"
+    version: "0.79.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-cluster-collector.enabled
 sources:

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -104,7 +104,7 @@ opentelemetry-agent:
       enabled: true
     spanMetrics:
       enabled: false
-      histogramBuckets: [10ms, 50ms, 100ms, 200ms, 500ms, 1s, 2s, 5s, 10s]
+      histogramBuckets: [10ms, 20ms, 50ms, 100ms, 200ms, 500ms, 1s, 2s, 5s]
 
   config:
     extensions:

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -104,6 +104,7 @@ opentelemetry-agent:
       enabled: true
     spanMetrics:
       enabled: false
+      histogramBuckets: [10ms, 50ms, 100ms, 200ms, 500ms, 1s, 2s, 5s, 10s]
 
   config:
     extensions:


### PR DESCRIPTION
# Description

Fixes https://coralogix.atlassian.net/browse/ES-173

Adds parameter to specify span metrics histogram buckets and uses fewer buckets as default.

Bumps collector to `0.92.0`.

# How Has This Been Tested?

Locally on `kind`

# Checklist:
- [X] I have updated the relevant Helm chart(s) version(s)
- [X] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
