### PR TITLE
Fix a bug in the sync action

### DIFF
--- a/.github/workflows/Sync-integration-definition.yaml
+++ b/.github/workflows/Sync-integration-definition.yaml
@@ -1,11 +1,10 @@
 name: Sync with integration-definitions
-
 on: 
-  pull_request:
-    types: [closed]
+  push:
     branches: [master]
     paths:
     - 'otel-integration/k8s-helm/Chart.yaml'
+  workflow_dispatch:
 jobs:
   Get_vesrion:
     runs-on: ubuntu-latest
@@ -22,13 +21,10 @@ jobs:
         run: |
           Chart_version=$(cat ./otel-integration/k8s-helm/Chart.yaml | grep "^version" | grep -oE '[^ ]+$')
           echo "Chart_version=$Chart_version" >> $GITHUB_OUTPUT
-
-
   create_pr:
     runs-on: ubuntu-latest
     needs: Get_vesrion
     steps:
-
       - name: Checkout destination repository
         uses: actions/checkout@v3
         with:
@@ -38,7 +34,7 @@ jobs:
       - name: Check if version exists
         id: version_exist
         run: | 
-          branch_name="${{ github.event.pull_request.head.ref }}"
+          branch_name="sync-telemetry-branch-$(date +"%m-%d-%H-%M")"
           git fetch origin
           template_version=${{ needs.Get_vesrion.outputs.Chart_version }}
           if [ -d "./integrations/otel-agent-k8s/v$template_version" ] || [ -n "$(git ls-remote origin $branch_name)" ]; then
@@ -51,9 +47,9 @@ jobs:
 
 
       - name: Create files for the new version
-        if: "${{env.new_version_exist == 'false'}}"
+        if: "${{env.new_version_exist == 'false' || github.event_name == 'workflow_dispatch'}}"
         run: |
-          branch_name="${{ github.event.pull_request.head.ref }}"
+          branch_name="sync-telemetry-branch-$(date +"%m-%d-%H-%M")"
           echo $branch_name
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
@@ -85,7 +81,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
       - name: commit change
-        if: "${{env.new_version_exist == 'false'}}"
+        if: "${{env.new_version_exist == 'false' || github.event_name == 'workflow_dispatch'}}"
         uses: planetscale/ghcommit-action@v0.1.19
         with:
           commit_message: "update version to the Chart.yaml"
@@ -96,10 +92,13 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GH_TOKEN}}
 
       - name: Create pull request
-        if: "${{env.new_version_exist == 'false'}}"
+        if: "${{env.new_version_exist == 'false' || github.event_name == 'workflow_dispatch'}}"
         run: |
-          branch_name="${{ github.event.pull_request.head.ref }}"
-          Pr_name=$(echo "${{ github.event.pull_request.title }}")
+          branch_name="sync-telemetry-branch-$(date +"%m-%d-%H-%M")"
+          Pr_name=$(echo "${{ github.event.head_commit.message }}")
+          if [ -z "$Pr_name" ]; then
+            Pr_name="sync-from-telemetry-shippers"
+          fi
           gh pr create --base master --head "${branch_name}" --title "${Pr_name}" --body "This pull request syncs the changes from the cloudformation repo to this repo."
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
# Description
The sync action is not working when it is triggered from a fork branch because it has no access to the repo secrets.
I have changed the action to be triggered when there is a new commit in master so that it will always have access to the repo secrets, also added an option to run the action manually
<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the relevant Helm chart(s) version(s)
- [ ] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
