### PR TITLE
Update the pr name that get created by the sync action

### DIFF
--- a/.github/workflows/Sync-integration-definition.yaml
+++ b/.github/workflows/Sync-integration-definition.yaml
@@ -101,7 +101,7 @@ jobs:
           if [ "${{ github.event_name }}" == 'workflow_dispatch' ] || [ -z "$Pr_name" ]; then
             Pr_name="sync-from-telemetry-shippers"
           fi
-          pr_url=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
+          pr_url=$(curl -s -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" \
             "https://api.github.com/repos/coralogix/telemetry-shippers/pulls?state=closed&base=master&sort=updated&direction=desc" \
             | jq -r '.[0].html_url')
           gh pr create --base master --head "${branch_name}" --title "${Pr_name}" --body "This pull request syncs the changes from the telemetry-shippers repo to this repo. link to the original PR $pr_url"

--- a/.github/workflows/Sync-integration-definition.yaml
+++ b/.github/workflows/Sync-integration-definition.yaml
@@ -95,8 +95,10 @@ jobs:
         if: "${{env.new_version_exist == 'false' || github.event_name == 'workflow_dispatch'}}"
         run: |
           branch_name="sync-telemetry-branch-$(date +"%m-%d-%H-%M")"
-          Pr_name=$(echo "${{ github.event.head_commit.message }}")
-          if [ -z "$Pr_name" ]; then
+          Pr_name=$(curl -s -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" \
+          "https://api.github.com/repos/coralogix/telemetry-shippers/pulls?state=closed&base=master&sort=updated&direction=desc" \
+          | jq -r '.[0].title')
+          if [ "${{ github.event_name }}" == 'workflow_dispatch' ] || [ -z "$Pr_name" ]; then
             Pr_name="sync-from-telemetry-shippers"
           fi
           gh pr create --base master --head "${branch_name}" --title "${Pr_name}" --body "This pull request syncs the changes from the cloudformation repo to this repo."

--- a/.github/workflows/Sync-integration-definition.yaml
+++ b/.github/workflows/Sync-integration-definition.yaml
@@ -101,6 +101,9 @@ jobs:
           if [ "${{ github.event_name }}" == 'workflow_dispatch' ] || [ -z "$Pr_name" ]; then
             Pr_name="sync-from-telemetry-shippers"
           fi
-          gh pr create --base master --head "${branch_name}" --title "${Pr_name}" --body "This pull request syncs the changes from the cloudformation repo to this repo."
+          pr_url=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
+            "https://api.github.com/repos/coralogix/telemetry-shippers/pulls?state=closed&base=master&sort=updated&direction=desc" \
+            | jq -r '.[0].html_url')
+          gh pr create --base master --head "${branch_name}" --title "${Pr_name}" --body "This pull request syncs the changes from the telemetry-shippers repo to this repo. link to the original PR $pr_url"
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
# Description
The sync action creates a PR in the integration-definitions repo using commit message as the name of the PR, in this PR i have changed it so that the name of the PR in integration-definitions repo will be the last PR that was merged into master
<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the relevant Helm chart(s) version(s)
- [ ] I have updated the relevant component changelog(s)
- [x] This change does not affect any particular component (e.g. it's CI or docs change)
