### PR TITLE
Fix trace pipeline warning during install

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.53 / 2024-02-07
+
+- [FIX] Fix warning about overwrite in traces pipeline in cluster collector sub-chart.
+
 ### v0.0.52 / 2024-02-05
 
 - [FEAT] Optionally allow users to use tail sampling for traces.

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.52
+version: 0.0.53
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -506,7 +506,6 @@ opentelemetry-cluster-collector:
             - otlp
             - prometheus
             - k8s_cluster
-        traces: null
   tolerations:
     - operator: Exists
 


### PR DESCRIPTION
# Description

Fixes https://coralogix.atlassian.net/browse/ES-203.

Fix warning that shows up when installing the chart - this is due to mismatch between the value types (null vs object). Simply removing the tracing pipeline from config here, since it's not needed (upstream chart will still add a dummy trace pipeline that exports to debug).

# How Has This Been Tested?

Locally with `kind`.

# Checklist:
- [X] I have updated the relevant Helm chart(s) version(s)
- [X] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
