### PR TITLE
[otel-integration] improve otlp server limit for tail-sampling

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.57 / 2024-02-21
+
+- [Fix] Bump otel-gateway's otlp server grpc request size limit to 20 mib
+
 ### v0.0.56 / 2024-02-13
 
 - [CHORE] Bump windows image to 0.93.0 for windows values files.

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.56
+version: 0.0.57
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -614,6 +614,8 @@ opentelemetry-gateway:
         protocols:
           grpc:
             endpoint: ${MY_POD_IP}:4317
+            # Default otlp grpc server message size limit is 4mib, which might be too low.
+            max_recv_msg_size_mib: 20
     service:
       telemetry:
         resource:


### PR DESCRIPTION
# Description

Bump default request limit to 20 mib for gateway otlp server.

Fixes ES-199

# How Has This Been Tested?

kind cluster

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
