### PR TITLE
[otel-integration] add otel-integration version header

### DIFF
--- a/.github/workflows/otel-integration-version-check.yml
+++ b/.github/workflows/otel-integration-version-check.yml
@@ -1,0 +1,26 @@
+name: Otel Integration Version Check
+
+on:
+  pull_request:
+    paths:
+    - 'otel-integration/k8s-helm/**'
+
+jobs:
+  collector-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Compare versions
+        run: |
+          chart_version=$(yq '.version' otel-integration/k8s-helm/Chart.yaml)
+          values_version=$(yq '.global.version' otel-integration/k8s-helm/values.yaml)
+
+          if [[ "$chart_version" != "$values_version" ]]; then
+            echo "Chart.yaml version ($chart_version) does not match values.yaml version ($values_version)"
+            exit 1
+          fi
+
+          echo "Versions match!"

--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.59 / 2024-03-01
+
+- [CHORE] Add otel-integration version header to coralogix exporter
+
 ### v0.0.58 / 2024-02-21
 
 - [Fix] Change default spanmetrics connector's buckets and extra dimensions.

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.58
+version: 0.0.59
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,6 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "warn"
   collectionInterval: "30s"
+  version: "0.0.59"
 
   extensions:
     kubernetesDashboard:
@@ -185,6 +186,15 @@ opentelemetry-agent:
         timeout: "30s"
         private_key: "${CORALOGIX_PRIVATE_KEY}"
         domain: "{{ .Values.global.domain }}"
+        logs:
+          headers:
+            X-Coralogix-Distribution: "helm-otel-integration/{{ .Values.global.version }}"
+        metrics:
+          headers:
+            X-Coralogix-Distribution: "helm-otel-integration/{{ .Values.global.version }}"
+        traces:
+          headers:
+            X-Coralogix-Distribution: "helm-otel-integration/{{ .Values.global.version }}"
         application_name: "{{ .Values.global.defaultApplicationName }}"
         subsystem_name: "{{ .Values.global.defaultSubsystemName }}"
         application_name_attributes:
@@ -458,6 +468,15 @@ opentelemetry-cluster-collector:
         timeout: "30s"
         private_key: "${CORALOGIX_PRIVATE_KEY}"
         domain: "{{ .Values.global.domain }}"
+        logs:
+          headers:
+            X-Coralogix-Distribution: "helm-otel-integration/{{ .Values.global.version }}"
+        metrics:
+          headers:
+            X-Coralogix-Distribution: "helm-otel-integration/{{ .Values.global.version }}"
+        traces:
+          headers:
+            X-Coralogix-Distribution: "helm-otel-integration/{{ .Values.global.version }}"
         application_name: "{{ .Values.global.defaultApplicationName }}"
         subsystem_name: "{{ .Values.global.defaultSubsystemName }}"
         application_name_attributes:
@@ -573,6 +592,15 @@ opentelemetry-gateway:
         timeout: "30s"
         private_key: "${CORALOGIX_PRIVATE_KEY}"
         domain: "{{ .Values.global.domain }}"
+        logs:
+          headers:
+            X-Coralogix-Distribution: "helm-otel-integration/{{ .Values.global.version }}"
+        metrics:
+          headers:
+            X-Coralogix-Distribution: "helm-otel-integration/{{ .Values.global.version }}"
+        traces:
+          headers:
+            X-Coralogix-Distribution: "helm-otel-integration/{{ .Values.global.version }}"
         application_name: "{{ .Values.global.defaultApplicationName }}"
         subsystem_name: "{{ .Values.global.defaultSubsystemName }}"
         application_name_attributes:


### PR DESCRIPTION
# Description

Adding a new global field that will have otel-integration version and then passes it via header.  We will need to maintain Chart.yaml with this global value.

In helm it looks like it is not possible to pass the  parent chart version. {{Chart.Version}} always renders subchart version. I tried to hack around it with tpl and other ways but didnt find a solution.

Also added a CI job to verify that this value matches the Chart.yaml. Example CI failure -> https://github.com/coralogix/telemetry-shippers/actions/runs/8108799144/job/22162697146?pr=376


Fixes ES-212

# How Has This Been Tested?

- kind cluster

# Checklist:
- [X] I have updated the relevant Helm chart(s) version(s)
- [X] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
