### PR TITLE
Add batch size limit

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.60 / 2024-03-01
+
+- [FEAT] Configure batch processor sizes with hard limit 2048 units
+- [FIX] Ensure batch processors is always last in the pipeline
+
 ### v0.0.59 / 2024-03-01
 
 - [CHORE] Add otel-integration version header to coralogix exporter

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.59
+version: 0.0.60
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -11,22 +11,22 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.80.1"
+    version: "0.80.2"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-windows
-    version: "0.80.1"
+    version: "0.80.2"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-windows.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-cluster-collector
-    version: "0.80.1"
+    version: "0.80.2"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-cluster-collector.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-gateway
-    version: "0.80.1"
+    version: "0.80.2"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-gateway.enabled
 sources:

--- a/otel-integration/k8s-helm/README.md
+++ b/otel-integration/k8s-helm/README.md
@@ -308,6 +308,23 @@ The global collection interval (`global.collectionInterval`) is the interval in 
 
 Beware that using lower interval will result in more metric data points being sent to the backend, thus resulting in more costs. Note that the choise of the interval also has an effect on behavior of rate functions, for more see [here](https://www.robustperception.io/what-range-should-i-use-with-rate/).
 
+#### About batch sizing
+
+[Batch processor](https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/batchprocessor) ensures that the telemetry being sent to Coralogix backend is batched into bigger requests, ensuring lower networking overhead and better performance. The batching processor is enabled by default and we strongly recommend to use it. By default, the `otel-integration` chart uses the following recommended settings for batch processors in all collectors:
+  
+  ```yaml
+      batch:
+        send_batch_size: 1024
+        send_batch_max_size: 2048
+        timeout: "1s"
+  ```
+
+These settings imposes a hard limit of 2048 units (spans, metrics, logs) on the batch size, ensuring a balance between the recommended size of the batches and networking overhead. 
+
+You may adjust these settings according to your needs, but when configuring the batch processor by yourself, it is important to be mindful of the size limites imposed by the Coraloigx endpoints (currently **max. 10 MB** after decompression - see [documentation](https://coralogix.com/docs/opentelemetry/#limits--quotas)). 
+
+More information on how to configure the batch processor can be found [here](https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/batchprocessor#batch-processor).
+
 ### About span metrics
 
 The collector provides a possibility to synthesize R.E.D (Request, Error, Duration) metrics based on the incoming span data. This can be useful to obtain extra metrics about the operations you have instrumented for tracing. For more information, please refer to the [OpenTelemetry Collector documentation](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/connector/spanmetricsconnector/README.md).

--- a/otel-integration/k8s-helm/values-windows-tailsampling.yaml
+++ b/otel-integration/k8s-helm/values-windows-tailsampling.yaml
@@ -145,6 +145,10 @@ opentelemetry-agent-windows:
               - targets:
                   - ${MY_POD_IP}:8888
     processors:
+      batch:
+        send_batch_size: 1024
+        send_batch_max_size: 2048
+        timeout: "1s"
       resourcedetection/env:
         detectors: ["system", "env"]
         timeout: 2s

--- a/otel-integration/k8s-helm/values-windows.yaml
+++ b/otel-integration/k8s-helm/values-windows.yaml
@@ -141,6 +141,10 @@ opentelemetry-agent-windows:
               - targets:
                   - ${MY_POD_IP}:8888
     processors:
+      batch:
+        send_batch_size: 1024
+        send_batch_max_size: 2048
+        timeout: "1s"
       resourcedetection/env:
         detectors: ["system", "env"]
         timeout: 2s

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "warn"
   collectionInterval: "30s"
-  version: "0.0.59"
+  version: "0.0.60"
 
   extensions:
     kubernetesDashboard:

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -152,6 +152,10 @@ opentelemetry-agent:
               - targets:
                   - ${MY_POD_IP}:8888
     processors:
+      batch:
+        send_batch_size: 1024
+        send_batch_max_size: 2048
+        timeout: "1s"
       resourcedetection/env:
         detectors: ["system", "env"]
         timeout: 2s
@@ -380,6 +384,10 @@ opentelemetry-cluster-collector:
                 - targets:
                     - ${MY_POD_IP}:8888
     processors:
+      batch:
+        send_batch_size: 1024
+        send_batch_max_size: 2048
+        timeout: "1s"
       k8sattributes:
         extract:
           metadata:
@@ -510,10 +518,10 @@ opentelemetry-cluster-collector:
           exporters:
             - coralogix
           processors:
-            - memory_limiter
-            - batch
             - resource/kube-events
             - transform/kube-events
+            - memory_limiter
+            - batch
         metrics:
           exporters:
             - coralogix
@@ -613,6 +621,10 @@ opentelemetry-gateway:
           - "k8s.cronjob.name"
           - "service.name"
     processors:
+      batch:
+        send_batch_size: 1024
+        send_batch_max_size: 2048
+        timeout: "1s"
       tail_sampling:
         # Update configuration here, with your tail sampling policies
         # Docs: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor


### PR DESCRIPTION
# Description

<!-- Please describe the changes you made in a few words or sentences. -->

Fixes https://coralogix.atlassian.net/browse/ES-53

Adds limit to batch processors by default, to prevent customers having issues with the limit imposed by our endpoints (https://coralogix.com/docs/opentelemetry/#limits--quotas). Also documents this.

# How Has This Been Tested?

Locally.

# Checklist:
- [X] I have updated the relevant Helm chart(s) version(s)
- [X] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
