### PR TITLE
[otel-integration] Bump collector version to 0.96.0 and use upstream target allocator

### DIFF
--- a/otel-collector-windows-image/Dockerfile
+++ b/otel-collector-windows-image/Dockerfile
@@ -3,7 +3,7 @@ ARG WIN_BASE_IMAGE
 
 FROM --platform=$BUILDPLATFORM curlimages/curl AS build
 WORKDIR /src
-RUN curl -Lo otelcol.tar.gz https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.93.0/otelcol-contrib_0.93.0_windows_amd64.tar.gz
+RUN curl -Lo otelcol.tar.gz https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.96.0/otelcol-contrib_0.96.0_windows_amd64.tar.gz
 RUN tar -xzvf otelcol.tar.gz
 
 ##

--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.62 / 2024-03-07
+- [CHORE] Update collector to version `0.96.0`
+- [CHORE] Update Windows collector image and version `0.96.0`
+- [CHORE] Use the upstream image of target allocator instead of custom fork
+
 ### v0.0.61 / 2024-03-06
 
 - [FEAT] Add support for multiline configs based on namespace name / pod name / container name.

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.61
+version: 0.0.62
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -11,22 +11,22 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.80.3"
+    version: "0.81.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-windows
-    version: "0.80.3"
+    version: "0.81.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-windows.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-cluster-collector
-    version: "0.80.3"
+    version: "0.81.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-cluster-collector.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-gateway
-    version: "0.80.3"
+    version: "0.81.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-gateway.enabled
 sources:

--- a/otel-integration/k8s-helm/values-windows-tailsampling.yaml
+++ b/otel-integration/k8s-helm/values-windows-tailsampling.yaml
@@ -23,7 +23,7 @@ opentelemetry-agent-windows:
     repository: coralogixrepo/opentelemetry-collector-contrib-windows
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "0.93.0"
+    tag: "0.96.0"
     # When digest is set to a non-empty value, images will be pulled by digest (regardless of tag value).
     digest: ""
   extraVolumes:

--- a/otel-integration/k8s-helm/values-windows.yaml
+++ b/otel-integration/k8s-helm/values-windows.yaml
@@ -23,7 +23,7 @@ opentelemetry-agent-windows:
     repository: coralogixrepo/opentelemetry-collector-contrib-windows
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "0.93.0"
+    tag: "0.96.0"
     # When digest is set to a non-empty value, images will be pulled by digest (regardless of tag value).
     digest: ""
   extraVolumes:

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "warn"
   collectionInterval: "30s"
-  version: "0.0.61"
+  version: "0.0.62"
 
   extensions:
     kubernetesDashboard:

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -55,11 +55,8 @@ opentelemetry-agent:
     prometheusCR:
       enabled: true
     image:
-      # Use custom image for target allocator until
-      # the official image is updated with the "per node" strategy
-      # https://github.com/open-telemetry/opentelemetry-operator/pull/2430
-      repository: coralogixrepo/target-allocator
-      tag: sha-abe05c5
+      repository: ghcr.io/open-telemetry/opentelemetry-operator/target-allocator
+      tag: v0.95.0
 
   serviceAccount:
     # Specifies whether a service account should be created


### PR DESCRIPTION
# Description

Fixes https://coralogix.atlassian.net/browse/ES-215 and https://coralogix.atlassian.net/browse/ES-189

- Bump collector to 0.96.0, including the Windows image
- Use upstream target allocator image, removing the need for us to have our custom fork 🥳 

# How Has This Been Tested?

Locally with `kind`

# Checklist:
- [X] I have updated the relevant Helm chart(s) version(s)
- [X] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
