### PR TITLE
[ecs-fargate] Fixed IAM permissions required by fluent-bit to access s3

### DIFF
--- a/logs/fluent-bit/ecs-fargate/README.md
+++ b/logs/fluent-bit/ecs-fargate/README.md
@@ -61,12 +61,16 @@ In order to allow container access to the S3 object, you'll need to provide the 
 		{
 			"Effect": "Allow",
 			"Action": [
-				"s3:GetObject",
 				"s3:GetBucketLocation"
 			],
 			"Resource": "<Your specific bucket ARN>"
-            #or
-            "Resource": "*"
+		},
+		{
+			"Effect": "Allow",
+			"Action": [
+				"s3:GetObject"
+			],
+			"Resource": "<Your specific bucket ARN>/*"
 		}
 	]
 }


### PR DESCRIPTION
# Description

Updated the IAM policy required to access the s3 bucket

# How Has This Been Tested?

Deployed the integration with the updated IAM permission.