### PR TITLE
[otel-integration] Fix tail sampling configuration

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -3,10 +3,12 @@
 ## OpenTelemtry-Integration
 
 ### v0.0.63 / 2024-03-12
+
 - [FIX] Use default processing values for `tailsamplingprocessor`
 - [FIX] Remove duplicated `tailsamplingprocessor` configuration; keep it only in the `tail-sampling-values.yaml` file
 
 ### v0.0.62 / 2024-03-07
+
 - [:warning: CHANGE] [CHORE] Update collector to version `0.96.0`. If you are using the deprecated `spanmetricsprocessor`, please note it is no longer available in version `0.96.0`. Please use `spanmetricsconnector` instead or use our [span metrics preset](https://github.com/coralogix/telemetry-shippers/tree/master/otel-integration/k8s-helm#about-span-metrics)
 - [CHORE] Update Windows collector image and version `0.96.0`
 - [CHORE] Use the upstream image of target allocator instead of custom fork

--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.63 / 2024-03-12
+- [FIX] Use default processing values for `tailsamplingprocessor`
+- [FIX] Remove duplicated `tailsamplingprocessor` configuration; keep it only in the `tail-sampling-values.yaml` file
+
 ### v0.0.62 / 2024-03-07
 - [:warning: CHANGE] [CHORE] Update collector to version `0.96.0`. If you are using the deprecated `spanmetricsprocessor`, please note it is no longer available in version `0.96.0`. Please use `spanmetricsconnector` instead or use our [span metrics preset](https://github.com/coralogix/telemetry-shippers/tree/master/otel-integration/k8s-helm#about-span-metrics)
 - [CHORE] Update Windows collector image and version `0.96.0`

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.62
+version: 0.0.63
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/tail-sampling-values.yaml
+++ b/otel-integration/k8s-helm/tail-sampling-values.yaml
@@ -38,11 +38,8 @@ opentelemetry-gateway:
   config:
     processors:
       tail_sampling:
-        # Update configuration here, with your tail sampling policies
+        # Update configuration here, with your settings and tail sampling policies
         # Docs: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor
-        decision_wait: 10s
-        num_traces: 100
-        expected_new_traces_per_sec: 10
         policies:
           [
             {

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "warn"
   collectionInterval: "30s"
-  version: "0.0.62"
+  version: "0.0.63"
 
   extensions:
     kubernetesDashboard:

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -636,25 +636,6 @@ opentelemetry-gateway:
         send_batch_size: 1024
         send_batch_max_size: 2048
         timeout: "1s"
-      tail_sampling:
-        # Update configuration here, with your tail sampling policies
-        # Docs: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor
-        decision_wait: 10s
-        num_traces: 100
-        expected_new_traces_per_sec: 10
-        policies:
-          [
-            {
-              name: errors-policy,
-              type: status_code,
-              status_code: {status_codes: [ERROR]}
-            },
-            {
-              name: randomized-policy,
-              type: probabilistic,
-              probabilistic: {sampling_percentage: 10}
-            },
-          ]
     receivers:
       prometheus:
         config:


### PR DESCRIPTION
# Description

Fixes https://coralogix.atlassian.net/browse/ES-219

Fixes the problem with inability to override tail sampling processor configuration and the default values that are too low.

# How Has This Been Tested?

Locally with `kind`

# Checklist:
- [X] I have updated the relevant Helm chart(s) version(s)
- [X] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
