### PR TITLE
[otel-integration] fix logs collection force flush period

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.65 / 2024-03-19
+
+- [FIX] logsCollection preset make force_flush_period configurable and disable it by default.
+
 ### v0.0.64 / 2024-03-15
 
 - [FIX] Add logsCollection fix for empty log lines.

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.64
+version: 0.0.65
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -11,22 +11,22 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.81.2"
+    version: "0.81.4"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-windows
-    version: "0.81.2"
+    version: "0.81.4"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-windows.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-cluster-collector
-    version: "0.81.2"
+    version: "0.81.4"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-cluster-collector.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-gateway
-    version: "0.81.2"
+    version: "0.81.4"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-gateway.enabled
 sources:

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "warn"
   collectionInterval: "30s"
-  version: "0.0.64"
+  version: "0.0.65"
 
   extensions:
     kubernetesDashboard:


### PR DESCRIPTION
# Description

Fixes logsCollection preset to make force flush period configureable, and disable it by default since it causes splitting log issue.


Fixes ES-224

# How Has This Been Tested?

kind

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
