### PR TITLE
[CDS-1130] fix add internalTrafficPolicy: Local for service

### DIFF
--- a/otel-integration/k8s-helm/README.md
+++ b/otel-integration/k8s-helm/README.md
@@ -239,8 +239,7 @@ Notable important differences from regular `otel-integration` are:
 - Host metrics receiver is not available, though you still get some metrics about the host through `kubeletstats` receiver.
 - Kubernetes Dashboard does not work, due to missing Host Metrics.
 - Host networking and host ports are not available, users need to send tracing spans through
-  Kubernetes Service. The Service uses `internalTrafficPolicy: Local`, to send traffic to locally
-  running agents.
+  Kubernetes Service.
 - Log Collection works, but does not store check points. Restarting the agent will collect logs from the beginning.
 
 To install otel-integration to GKE/Autopilot follow these steps:

--- a/otel-integration/k8s-helm/gke-autopilot-values.yaml
+++ b/otel-integration/k8s-helm/gke-autopilot-values.yaml
@@ -19,6 +19,7 @@ opentelemetry-agent:
   hostNetwork: false
   service:
     enabled: true
+    internalTrafficPolicy: Local
   presets:
     logsCollection:
       enabled: true


### PR DESCRIPTION
# Description

GKE Autopilot values yaml states that a cluster service should be used as we don't have access to the Node Ports. The gke values yaml already creates a service, and it is trivial to use this service for shipping telemetry to the otel agent on each 'node'.

gke-autopilot-values.yaml setting change only

# How Has This Been Tested?

Tested by SE team as mentioned in ticket

# Checklist:
- [ ] I have updated the relevant Helm chart(s) version(s)
- [ ] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
