### PR TITLE
[otel-integration] fix operator and add new preset

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.67 / 2024-04-02
+
+- [FIX] Operator generate CRD missing environment variables
+- [FEAT] Add new reduceResourceAttributes preset, which removes uids and other unnecessary resource attributes from metrics.
+
 ### v0.0.66 / 2024-03-26
 
 - [FEAT] add spanMetricsMulti preset, which allows to specify histogram buckets per application.

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.66
+version: 0.0.67
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -11,22 +11,22 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.81.6"
+    version: "0.81.8"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-windows
-    version: "0.81.6"
+    version: "0.81.8"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-windows.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-cluster-collector
-    version: "0.81.6"
+    version: "0.81.8"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-cluster-collector.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-gateway
-    version: "0.81.6"
+    version: "0.81.8"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-gateway.enabled
 sources:

--- a/otel-integration/k8s-helm/values-crd-override.yaml
+++ b/otel-integration/k8s-helm/values-crd-override.yaml
@@ -3,6 +3,16 @@ opentelemetry-agent:
     generate: true
   configMap:
     create: false
+  # for some reason Operator automatically adds
+  # 4317, 6831, 14268 ports, which leads to duplicate errors
+  # Workaround - we remove them manually.
+  ports:
+    otlp:
+      enabled: false
+    jaeger-compact:
+      enabled: false
+    jaeger-thrift:
+      enabled: false
 
 opentelemetry-cluster-collector:
   collectorCRD:

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "warn"
   collectionInterval: "30s"
-  version: "0.0.66"
+  version: "0.0.67"
 
   extensions:
     kubernetesDashboard:
@@ -139,6 +139,10 @@ opentelemetry-agent:
       #    histogramBuckets: [1s, 2s]
       #  - selector: route() where attributes["service.name"] == "two"
       #    histogramBuckets: [5s, 10s]
+    # Removes uids and other uneeded attributes from metric resources.
+    # This reduces target_info cardinality.
+    reduceResourceAttributes:
+      enabled: false
   config:
     extensions:
       zpages:


### PR DESCRIPTION
# Description

- [FIX] Operator generate CRD missing environment variables
- [FEAT] Add new reduceResourceAttributes preset, which removes uids and other unnecessary resource attributes from metrics.


 Fixes #
ES-143
ES-220

# How Has This Been Tested?

kind cluster with operator installed.

K8s dashboard works

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
