### PR TITLE
FEAT - Document the use of AWS Secrets Manager

### DIFF
--- a/logs/fluent-bit/ecs-fargate/README.md
+++ b/logs/fluent-bit/ecs-fargate/README.md
@@ -98,7 +98,9 @@ To do so, you'd add this "logConfiguration" section to each of your application 
                 }
             }
 ```
+
 **NOTE:** If you wish to store your Coralogix Privatekey in Secrets Manager, you can remove the `"Header"` from `"options"` and create one under `"secretOptions"` and reference the Secret's ARN. Store the secret as plaintext with the same format as above. You will also need to add the secretsmanager:GetSecretValue permission to your ecs Task Execution Role.
+
 ```
 "secretOptions": [
     {

--- a/logs/fluent-bit/ecs-fargate/README.md
+++ b/logs/fluent-bit/ecs-fargate/README.md
@@ -98,3 +98,12 @@ To do so, you'd add this "logConfiguration" section to each of your application 
                 }
             }
 ```
+**NOTE:** If you wish to store your Coralogix Privatekey in Secrets Manager, you can remove the `"Header"` from `"options"` and create one under `"secretOptions"` and reference the Secret's ARN. Store the secret as plaintext with the same format as above. You will also need to add the secretsmanager:GetSecretValue permission to your ecs Task Execution Role.
+```
+"secretOptions": [
+    {
+        "name": "Header",
+        "valueFrom": "arn:aws:secretsmanager:us-east-1:<redacted>:secret:<redacted>"
+    }
+]
+```

--- a/otel-ecs-fargate/README.md
+++ b/otel-ecs-fargate/README.md
@@ -77,6 +77,7 @@ Example container declaration within a Task Definition:
 In the example above, you'll need to set two instances each of `<Coralogix PrivateKey>` and `<Coralogix Domain>`. The logConfiguration section included in the example will forward OTEL logs to the Coralogix platform, as documented in our fluentbit log processing configuration instructions [here](../logs/fluent-bit/ecs-fargate/README.md).
 
 **NOTE:** If you wish to store your Coralogix Privatekey in Secrets Manager, you can remove the `"Header"` from `"options"` and create one under `"secretOptions"` and reference the Secret's ARN. Store the secret as plaintext with the same format as above. You will also need to add the secretsmanager:GetSecretValue permission to your ecs Task Execution Role.
+
 ```
 "secretOptions": [
     {
@@ -85,7 +86,8 @@ In the example above, you'll need to set two instances each of `<Coralogix Priva
     }
 ]
 ```
- If you don't want to have them submitted to the Coralogix platform, you can replace the logConfiguration with whichever logDriver configuration you would prefer. To submit to Cloudwatch, you can configure as so:
+
+If you don't want to have them submitted to the Coralogix platform, you can replace the logConfiguration with whichever logDriver configuration you would prefer. To submit to Cloudwatch, you can configure as so:
 
 ```
 "logConfiguration": {

--- a/otel-ecs-fargate/README.md
+++ b/otel-ecs-fargate/README.md
@@ -60,13 +60,13 @@ Example container declaration within a Task Definition:
                 "logDriver": "awsfirelens",
                 "options": {
                     "Format": "json_lines",
-                    "Header": "private_key <Coralogix PrivateKey>",
+                    "Header": "Authorization Bearer <Coralogix PrivateKey>",
                     "Host": "ingress.<Coralogix Domain>",
                     "Name": "http",
                     "Port": "443",
                     "Retry_Limit": "10",
                     "TLS": "On",
-                    "URI": "/logs/rest/singles",
+                    "URI": "/logs/v1/singles",
                     "compress": "gzip"
                 }
             }
@@ -74,15 +74,18 @@ Example container declaration within a Task Definition:
     ]
 ```
 
-In the example above, you'll need to set two instances each of
+In the example above, you'll need to set two instances each of `<Coralogix PrivateKey>` and `<Coralogix Domain>`. The logConfiguration section included in the example will forward OTEL logs to the Coralogix platform, as documented in our fluentbit log processing configuration instructions [here](../logs/fluent-bit/ecs-fargate/README.md).
 
-<coralogix privatekey="">
-
-and
-
-<coralogix domain="">
-
-. The logConfiguration section included in the example will forward OTEL logs to the Coralogix platform, as documented in our fluentbit log processing configuration instructions [here](../logs/fluent-bit/ecs-fargate/README.md). If you don't want to have them submitted to the Coralogix platform, you can replace the logConfiguration with whichever logDriver configuration you would prefer. To submit to Cloudwatch, you can configure as so:
+**NOTE:** If you wish to store your Coralogix Privatekey in Secrets Manager, you can remove the `"Header"` from `"options"` and create one under `"secretOptions"` and reference the Secret's ARN. Store the secret as plaintext with the same format as above. You will also need to add the secretsmanager:GetSecretValue permission to your ecs Task Execution Role.
+```
+"secretOptions": [
+    {
+        "name": "Header",
+        "valueFrom": "arn:aws:secretsmanager:us-east-1:<redacted>:secret:<redacted>"
+    }
+]
+```
+ If you don't want to have them submitted to the Coralogix platform, you can replace the logConfiguration with whichever logDriver configuration you would prefer. To submit to Cloudwatch, you can configure as so:
 
 ```
 "logConfiguration": {


### PR DESCRIPTION
FEAT - Document the use of AWS Secrets Manager for the API key

# Description

Added steps to use Secrets Manager for the private key instead of exposing it in the task definition.

Fixes CDS-1146

# How Has This Been Tested?

Tested in AWS ECS with OTEL instrumented test applications

# Checklist:
- [ ] I have updated the relevant Helm chart(s) version(s)
- [ ] I have updated the relevant component changelog(s)
- [x] This change does not affect any particular component (e.g. it's CI or docs change)
