### PR TITLE
CHORE Updated fluentbit deployments to new image

### DIFF
--- a/logs/CHANGELOG.md
+++ b/logs/CHANGELOG.md
@@ -46,7 +46,6 @@
 * [UPGRADE] Upgrade Fluentbit version to v3.0.2
 * [UPGRADE] Upgrade Fluentbit Helm chart dependency to 0.46.2
 
-
 ### v2.2.0 / 2023-11-23
 
 * [CHANGE] Update the coralogix API

--- a/logs/CHANGELOG.md
+++ b/logs/CHANGELOG.md
@@ -44,6 +44,8 @@
 ### v3.0.2 / 2024-04-24
 
 * [UPGRADE] Upgrade Fluentbit version to v3.0.2
+* [UPGRADE] Upgrade Fluentbit Helm chart dependency to 0.46.2
+
 
 ### v2.2.0 / 2023-11-23
 

--- a/logs/fluent-bit/k8s-helm/http/Chart.yaml
+++ b/logs/fluent-bit/k8s-helm/http/Chart.yaml
@@ -1,14 +1,14 @@
 apiVersion: v2
 name: fluent-bit-http
 description: Fluent-Bit Chart with HTTP output plugin
-version: 2.2.0
-appVersion: 2.2.0
+version: 3.0.2
+appVersion: 3.0.2
 keywords:
   - Fluent-Bit
   - HTTP output plugin
 dependencies:
   - name: fluent-bit
-    version: "0.40.0"
+    version: "0.46.2"
     repository: https://fluent.github.io/helm-charts
 sources:
   - https://github.com/fluent/fluent-bit/

--- a/logs/fluent-bit/k8s-helm/http/values.yaml
+++ b/logs/fluent-bit/k8s-helm/http/values.yaml
@@ -3,7 +3,7 @@ fluent-bit:
 
   image:
     repository: coralogixrepo/coralogix-fluent-bit-multiarch
-    tag: v2.2.0
+    tag: v3.0.2
 
   serviceMonitor:
     enabled: true

--- a/logs/fluent-bit/k8s-manifest/fluentbit-ds.yaml
+++ b/logs/fluent-bit/k8s-manifest/fluentbit-ds.yaml
@@ -21,7 +21,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: fluent-bit
-          image: "coralogixrepo/coralogix-fluent-bit-multiarch:v2.1.3"
+          image: "coralogixrepo/coralogix-fluent-bit-multiarch:v3.0.2"
           imagePullPolicy: Always
           env:
             - name: HOSTNAME


### PR DESCRIPTION
# Description

Updated the fluentbit helm and kubernetes manifests to use the new 3.0.2 image.

# How Has This Been Tested?

Deployed into EKS via Helm and via manifest per documentation steps.

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
