### PR TITLE
[otel-integration] add k8s metadata to opentelemetry collector metrics

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.76 / 2024-06-03
+- [FEAT] Add Kubernetes metadata to otel collector metrics
+
 ### v0.0.75 / 2024-06-03
 - [FEAT] Add status_code to spanmetrics preset
 

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.75
+version: 0.0.76
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/e2e-test/expected_test.go
+++ b/otel-integration/k8s-helm/e2e-test/expected_test.go
@@ -54,6 +54,11 @@ var expectedResourceAttributesPrometheusreceiver = map[string]string{
 	"k8s.node.name":            "otel-integration-agent-e2e-control-plane",
 	"host.name":                "otel-integration-agent-e2e-control-plane",
 	"host.id":                  "",
+	"k8s.pod.ip":               "",
+	"k8s.pod.name":             "",
+	"k8s.deployment.name":      "",
+	"k8s.namespace.name":       "",
+	"k8s.daemonset.name":       "",
 	"os.type":                  "linux",
 }
 

--- a/otel-integration/k8s-helm/e2e-test/main_test.go
+++ b/otel-integration/k8s-helm/e2e-test/main_test.go
@@ -134,7 +134,7 @@ func checkResourceAttributes(t *testing.T, attributes pcommon.Map, scopeName str
 
 	attributes.Range(func(k string, v pcommon.Value) bool {
 		val, ok := compareMap[k]
-		require.True(t, ok, "unexpected attribute %v", k)
+		require.True(t, ok, "unexpected attribute %v - scopeName: %s", k, scopeName)
 		if val != "" {
 			require.Equal(t, val, v.AsString(), "unexpected value for attribute %v", k)
 		}

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "warn"
   collectionInterval: "30s"
-  version: "0.0.75"
+  version: "0.0.76"
 
   extensions:
     kubernetesDashboard:
@@ -206,6 +206,12 @@ opentelemetry-agent:
         detectors: ["gcp", "ec2"]
         timeout: 2s
         override: true
+      transform/prometheus:
+        error_mode: ignore
+        metric_statements:
+          - context: resource
+            statements:
+              - set(attributes["k8s.pod.ip"], attributes["net.host.name"]) where attributes["service.name"] == "opentelemetry-collector"
       k8sattributes:
         filter:
           node_from_env_var: KUBE_NODE_NAME
@@ -270,6 +276,7 @@ opentelemetry-agent:
           exporters:
             - coralogix
           processors:
+            - transform/prometheus
             - k8sattributes
             - resourcedetection/env
             - resourcedetection/region
@@ -444,6 +451,12 @@ opentelemetry-cluster-collector:
             - "k8s.job.name"
             - "k8s.pod.name"
             - "k8s.node.name"
+      transform/prometheus:
+        error_mode: ignore
+        metric_statements:
+          - context: resource
+            statements:
+              - set(attributes["k8s.pod.ip"], attributes["net.host.name"]) where attributes["service.name"] == "opentelemetry-infrastructure-collector"
       resource/kube-events:
         attributes:
           - key: service.name
@@ -581,6 +594,7 @@ opentelemetry-cluster-collector:
           exporters:
             - coralogix
           processors:
+            - transform/prometheus
             - k8sattributes
             - metricstransform/k8s-dashboard
             - transform/k8s-dashboard


### PR DESCRIPTION
# Description

Fixes ES-221

Currently otel collector metrics are missing metadata because they are statically scraped by ip address, which makes it hard to identify / build dashboard for them.

This makes adjustment to resource attributes before k8sattributes is run, making k8s attributes appear.

```

otelcol_exporter_queue_size{
cx_application_name="default",
cx_otel_integration_name="coralogix-integration-helm",
cx_subsystem_name="coralogix-opentelemetry-agent",
exporter="coralogix",
host_id="e1429cc2d6d74c80b61d6663fd614ab4",
host_name="172.19.0.2",
http_scheme="http",
job="opentelemetry-collector",
k8s_cluster_name="kind",
k8s_daemonset_name="coralogix-opentelemetry-agent",
k8s_namespace_name="default",
k8s_node_name="kind-control-plane",
k8s_pod_name="coralogix-opentelemetry-agent-5khbh",
net_host_name="172.19.0.2",
net_host_port="8888",
os_type="linux",
service_instance_id="172.19.0.2:8888",
service_name="opentelemetry-collector",
service_version="0.101.0"
}
```
vs
```
otelcol_exporter_queue_size{
cx_application_name="otel",
cx_otel_integration_name="coralogix-integration-helm",
cx_subsystem_name="opentelemetry-collector",
exporter="coralogix",
host_id="e1429cc2d6d74c80b61d6663fd614ab4",
host_name="172.19.0.2",
http_scheme="http",
job="opentelemetry-collector",
k8s_cluster_name="kind",
k8s_node_name="kind-control-plane",
net_host_name="172.19.0.2",
net_host_port="8888",
os_type="linux",
service_instance_id="172.19.0.2:8888",
service_name="opentelemetry-collector",
service_version="0.101.0"
}
```

# How Has This Been Tested?

kind cluster

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [ ] I have updated the relevant component changelog(s)
- [x] This change does not affect any particular component (e.g. it's CI or docs change)
