### PR TITLE
[otel-integration] Bump target-allocator to 0.101.0

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.79 / 2024-06-06
+- [FEAT] Bump Target Allocator to 0.101.0
+
 ### v0.0.78 / 2024-06-06
 - [FEAT] Bump Collector to 0.102.1
 - [FIX] Important: This version contains fix for cve-2024-36129. For more information see https://opentelemetry.io/blog/2024/cve-2024-36129/

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -56,7 +56,7 @@ opentelemetry-agent:
       enabled: true
     image:
       repository: ghcr.io/open-telemetry/opentelemetry-operator/target-allocator
-      tag: v0.95.0
+      tag: v0.101.0
 
   serviceAccount:
     # Specifies whether a service account should be created


### PR DESCRIPTION
# Description

 Fixes ES-272

# How Has This Been Tested?

kind

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
