### PR TITLE
[otel-integration] Fix bump version for target-allocator to 0.101.0

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## OpenTelemtry-Integration
 
 ### v0.0.79 / 2024-06-06
-- [FEAT] Bump Target Allocator to 0.101.0
+- [FEAT] Update Target Allocator version to 0.101.0
 
 ### v0.0.78 / 2024-06-06
 - [FEAT] Bump Collector to 0.102.1

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.78
+version: 0.0.79
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "warn"
   collectionInterval: "30s"
-  version: "0.0.78"
+  version: "0.0.79"
 
   extensions:
     kubernetesDashboard:


### PR DESCRIPTION
# Description

Fixes ES-275

# How Has This Been Tested?

kind

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
