### PR TITLE
[otel-integration] Add k8s attributes to otel collector gateway

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.82 / 2024-06-26
+- [Fix] Add k8s labels to gateway-collector metrics
+
 ### v0.0.81 / 2024-06-26
 - [Fix] Allow configuring max_unmatched_batch_size in multilineConfigs. Default is changed to max_unmatched_batch_size=1.
 - [Fix] Fix spanMetrics.spanNameReplacePattern preset does not work

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.81
+version: 0.0.82
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "warn"
   collectionInterval: "30s"
-  version: "0.0.81"
+  version: "0.0.82"
 
   extensions:
     kubernetesDashboard:
@@ -659,6 +659,14 @@ opentelemetry-gateway:
         secretKeyRef:
           name: coralogix-keys
           key: PRIVATE_KEY
+    - name: KUBE_NODE_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: spec.nodeName
+  presets:
+    kubernetesAttributes:
+      enabled: true
 
   config:
     extensions:
@@ -692,10 +700,31 @@ opentelemetry-gateway:
           - "k8s.cronjob.name"
           - "service.name"
     processors:
+      # needed for self-monitored otel colector metrics
+      k8sattributes:
+        filter:
+          node_from_env_var: KUBE_NODE_NAME
+        extract:
+          metadata:
+            - "k8s.namespace.name"
+            # replace the below by `k8s.deployment.name` after https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/23067
+            - "k8s.replicaset.name"
+            - "k8s.statefulset.name"
+            - "k8s.daemonset.name"
+            - "k8s.cronjob.name"
+            - "k8s.job.name"
+            - "k8s.pod.name"
+            - "k8s.node.name"
       batch:
         send_batch_size: 1024
         send_batch_max_size: 2048
         timeout: "1s"
+      transform/prometheus:
+        error_mode: ignore
+        metric_statements:
+          - context: resource
+            statements:
+              - set(attributes["k8s.pod.ip"], attributes["net.host.name"]) where attributes["service.name"] == "opentelemetry-collector"
     receivers:
       prometheus:
         config:
@@ -728,6 +757,8 @@ opentelemetry-gateway:
           exporters:
             - coralogix
           processors:
+            - transform/prometheus
+            - k8sattributes
             - memory_limiter
             - batch
           receivers:


### PR DESCRIPTION
# Description

Fixes: https://coralogix.atlassian.net/browse/ES-307

Example metric:
```
otelcol_process_memory_rss{cx_application_name="default", cx_subsystem_name="coralogix-opentelemetry-gateway", k8s_deployment_name="coralogix-opentelemetry-gateway", k8s_namespace_name="default", k8s_node_name="kind-control-plane", k8s_pod_name="coralogix-opentelemetry-gateway-574fb6cd8f-djpm4", http_scheme="http", job="opentelemetry-collector", k8s_pod_ip="10.244.0.12", net_host_name="10.244.0.12", net_host_port="8888", service_instance_id="10.244.0.12:8888", service_name="opentelemetry-collector", service_version="0.102.1"}
```

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
