### PR TITLE
FEAT - Switch to Contrib from ADOT

### DIFF
--- a/otel-ecs-fargate/README.md
+++ b/otel-ecs-fargate/README.md
@@ -1,4 +1,6 @@
-# ADOT (OTEL) ECS Fargate container
+# OTEL ECS Fargate container
+
+### Note: Previous versions of this integration used an ADOT (AWS Distribution for OpenTelemetry) collector image. If you are upgrading an existing deployment, make sure you upgrade both the configuration and the task definition.
 
 The OpenTelemetry collector offers a vendor-agnostic implementation of how to receive, process and export telemetry data.
 

--- a/otel-ecs-fargate/README.md
+++ b/otel-ecs-fargate/README.md
@@ -2,9 +2,9 @@
 
 The OpenTelemetry collector offers a vendor-agnostic implementation of how to receive, process and export telemetry data.
 
-In this document, we'll explain how to add the OTEL collector as a sidecar agent to your ECS Task Definitions. We use an AWS customized OpenTelemetry image called AWS Distro for OpenTelemetry (ADOT), as it has several features that allow for more convenient management of the configuration. We also have an example cloudformation template for review [here](https://github.com/coralogix/cloudformation-coralogix-aws/tree/master/aws-integrations/ecs-fargate)
+In this document, we'll explain how to add the OTEL collector as a sidecar agent to your ECS Task Definitions. We use the standard Opentelemetry Collector Contrib distribution but leverage the envprovider to generate the configuration from an AWS SSM Parameter Store. There is an example cloudformation template for review [here](https://github.com/coralogix/cloudformation-coralogix-aws/tree/master/aws-integrations/ecs-fargate)
 
-The ADOT image, [maintained here by AWS](https://github.com/aws-observability/aws-otel-collector), allows for loading of the OpenTelemetry configuration via Systems Manager Parameter Stores. This makes adjusting your configuration more convenient and more dynamic than baking a static configuration into your container image.
+The envprovider is used for loading of the OpenTelemetry configuration via Systems Manager Parameter Stores. This makes adjusting your configuration more convenient and more dynamic than baking a static configuration into your container image.
 
 Our config.yaml file includes a standard configuration that'll ensure proper ingestion by our backend. Make sure to create this parameter store in the same region as your ECS cluster. We've included a sample cloudformation template to deploy this parameter store to simplify this process.
 
@@ -19,7 +19,7 @@ Example container declaration within a Task Definition:
         },
         {
             "name": "otel-collector",
-            "image": "public.ecr.aws/aws-observability/aws-otel-collector",
+            "image": "otel/opentelemetry-collector-contrib",
             "cpu": 0,
             "portMappings": [
                 {
@@ -38,6 +38,10 @@ Example container declaration within a Task Definition:
                 }
             ],
             "essential": false,
+            "command": [
+                "--config",
+                "env:SSM_CONFIG"
+            ],
             "environment": [
                 {
                     "name": "PRIVATE_KEY",
@@ -52,8 +56,8 @@ Example container declaration within a Task Definition:
             "volumesFrom": [],
             "secrets": [
                 {
-                    "name": "AOT_CONFIG_CONTENT",
-                    "valueFrom": "config.yaml"
+                    "name": "SSM_CONFIG",
+                    "valueFrom": "/CX_OTEL/config.yaml"
                 }
             ],
             "logConfiguration": {
@@ -76,7 +80,7 @@ Example container declaration within a Task Definition:
 
 In the example above, you'll need to set two instances each of `<Coralogix PrivateKey>` and `<Coralogix Domain>`. The logConfiguration section included in the example will forward OTEL logs to the Coralogix platform, as documented in our fluentbit log processing configuration instructions [here](../logs/fluent-bit/ecs-fargate/README.md).
 
-**NOTE:** If you wish to store your Coralogix Privatekey in Secrets Manager, you can remove the `"Header"` from `"options"` and create one under `"secretOptions"` and reference the Secret's ARN. Store the secret as plaintext with the same format as above. You will also need to add the secretsmanager:GetSecretValue permission to your ecs Task Execution Role.
+**NOTE:** If you wish to store your Coralogix Privatekey in Secret Manager, you can remove the `"Header"` from `"options"` and create one under `"secretOptions"` and reference the Secret's ARN. Create the secret as plaintext with the same format as above. You will also need to add the secretsmanager:GetSecretValue permission to your ecs Task Execution Role.
 
 ```
 "secretOptions": [

--- a/otel-ecs-fargate/config.yaml
+++ b/otel-ecs-fargate/config.yaml
@@ -1,3 +1,42 @@
+exporters:
+  coralogix:
+    application_name: 'otel'
+    application_name_attributes:
+    - aws.ecs.task.family
+    - service.namespace
+    domain: ${CORALOGIX_DOMAIN}
+    logs:
+      headers:
+        X-Coralogix-Distribution: ecs-fargate-integration/0.0.1
+    metrics:
+      headers:
+        X-Coralogix-Distribution: ecs-fargate-integration/0.0.1
+    private_key: ${PRIVATE_KEY}
+    subsystem_name: 'integration'
+    subsystem_name_attributes:
+    - service.name
+    - aws.ecs.docker.name
+    timeout: 30s
+    traces:
+      headers:
+        X-Coralogix-Distribution: ecs-fargate-integration/0.0.1
+processors:
+  batch:
+    send_batch_max_size: 2048
+    send_batch_size: 1024
+    timeout: 1s
+  resource/metadata:
+    attributes:
+    - action: upsert
+      key: cx.otel_integration.name
+      value: coralogix-integration-ecs-fargate
+  resourcedetection:
+    detectors:
+    - env
+    - ec2
+    - ecs
+    override: true
+    timeout: 2s
 receivers:
   awsecscontainermetrics:
     collection_interval: 10s
@@ -7,49 +46,38 @@ receivers:
         endpoint: 0.0.0.0:4317
       http:
         endpoint: 0.0.0.0:4318
-processors:
-  resource/traces:
-    attributes:
-    - key: cx.application.name
-      from_attribute: aws.ecs.task.family
-      action: upsert
-    - key: cx.subsystem.name
-      from_attribute: service.name
-      action: upsert
-  resource/metrics:
-    attributes:
-    - key: cx.application.name
-      from_attribute: aws.ecs.task.family
-      action: upsert
-    - key: cx.subsystem.name
-      from_attribute: aws.ecs.docker.name
-      action: upsert
-  batch:
-      send_batch_size: 1024
-      send_batch_max_size: 2048
-      timeout: "1s"
-  resourcedetection:
-    detectors: [env, ec2, ecs]
-    timeout: 5s
-    override: true
-exporters:
-  logging:
-    verbosity: detailed
-  otlp:
-   endpoint: https://ingress.${CORALOGIX_DOMAIN}:443
-   headers:
-      Authorization: Bearer ${PRIVATE_KEY}
+  prometheus:
+    config:
+      scrape_configs:
+      - job_name: opentelemetry-collector
+        scrape_interval: 30s
+        static_configs:
+        - targets:
+          - 127.0.0.1:8888
 service:
   pipelines:
-    traces/otlp:
-      receivers: [otlp]
-      processors: [resourcedetection, resource/traces, batch]
-      exporters: [otlp]
-    metrics/otlp:
-      receivers: [otlp]
-      processors: [resourcedetection, resource/metrics, batch]
-      exporters: [otlp]
-    metrics/polled:
-      receivers: [awsecscontainermetrics]
-      processors: [resourcedetection, resource/metrics, batch]
-      exporters: [otlp]
+    metrics:
+      exporters:
+      - coralogix
+      processors:
+      - resource/metadata
+      - resourcedetection
+      - batch
+      receivers:
+      - otlp
+      - awsecscontainermetrics
+    traces:
+      exporters:
+      - coralogix
+      processors:
+      - resource/metadata
+      - resourcedetection
+      - batch
+      receivers:
+      - otlp
+  telemetry:
+    logs:
+      level: "warn"
+      encoding: json
+    metrics:
+      address: 0.0.0.0:8888

--- a/otel-ecs-fargate/parameter_store.cf
+++ b/otel-ecs-fargate/parameter_store.cf
@@ -5,10 +5,49 @@ Resources:
   OTELConfigParameter:
     Type: AWS::SSM::Parameter
     Properties:
-      Name: /OTEL/config.yaml
-      Description: Configuration parameter for Coralogix ADOT (OTEL) Collector
+      Name: /CX_OTEL/config.yaml
+      Description: Configuration parameter for Coralogix OTEL Collector
       Type: String
       Value: |
+        exporters:
+          coralogix:
+            application_name: 'otel'
+            application_name_attributes:
+            - aws.ecs.task.family
+            - service.namespace
+            domain: ${CORALOGIX_DOMAIN}
+            logs:
+              headers:
+                X-Coralogix-Distribution: ecs-fargate-integration/0.0.1
+            metrics:
+              headers:
+                X-Coralogix-Distribution: ecs-fargate-integration/0.0.1
+            private_key: ${PRIVATE_KEY}
+            subsystem_name: 'integration'
+            subsystem_name_attributes:
+            - service.name
+            - aws.ecs.docker.name
+            timeout: 30s
+            traces:
+              headers:
+                X-Coralogix-Distribution: ecs-fargate-integration/0.0.1
+        processors:
+          batch:
+            send_batch_max_size: 2048
+            send_batch_size: 1024
+            timeout: 1s
+          resource/metadata:
+            attributes:
+            - action: upsert
+              key: cx.otel_integration.name
+              value: coralogix-integration-ecs-fargate
+          resourcedetection:
+            detectors:
+            - env
+            - ec2
+            - ecs
+            override: true
+            timeout: 2s
         receivers:
           awsecscontainermetrics:
             collection_interval: 10s
@@ -18,50 +57,40 @@ Resources:
                 endpoint: 0.0.0.0:4317
               http:
                 endpoint: 0.0.0.0:4318
-        processors:
-          resource/traces:
-            attributes:
-            - key: cx.application.name
-              from_attribute: aws.ecs.task.family
-              action: upsert
-            - key: cx.subsystem.name
-              from_attribute: service.name
-              action: upsert
-          resource/metrics:
-            attributes:
-            - key: cx.application.name
-              from_attribute: aws.ecs.task.family
-              action: upsert
-            - key: cx.subsystem.name
-              from_attribute: aws.ecs.docker.name
-              action: upsert
-          batch:
-            timeout: 5s
-            send_batch_size: 256
-          resourcedetection:
-            detectors: [env, ec2, ecs]
-            timeout: 5s
-            override: true
-        exporters:
-          logging:
-            verbosity: detailed
-          otlp:
-           endpoint: https://ingress.${CORALOGIX_DOMAIN}:443
-           headers:
-              Authorization: Bearer ${PRIVATE_KEY}
+          prometheus:
+            config:
+              scrape_configs:
+              - job_name: opentelemetry-collector
+                scrape_interval: 30s
+                static_configs:
+                - targets:
+                  - 127.0.0.1:8888
         service:
           pipelines:
-            traces/otlp:
-              receivers: [otlp]
-              processors: [resourcedetection, resource/traces, batch]
-              exporters: [otlp]
-            metrics/otlp:
-              receivers: [otlp]
-              processors: [resourcedetection, resource/metrics, batch]
-              exporters: [otlp]
-            metrics/polled:
-              receivers: [awsecscontainermetrics]
-              processors: [resourcedetection, resource/metrics, batch]
-              exporters: [otlp]
+            metrics:
+              exporters:
+              - coralogix
+              processors:
+              - resource/metadata
+              - resourcedetection
+              - batch
+              receivers:
+              - otlp
+              - awsecscontainermetrics
+            traces:
+              exporters:
+              - coralogix
+              processors:
+              - resource/metadata
+              - resourcedetection
+              - batch
+              receivers:
+              - otlp
+          telemetry:
+            logs:
+              level: "warn"
+              encoding: json
+            metrics:
+              address: 0.0.0.0:8888
         
       Tier: Standard


### PR DESCRIPTION
# Description

Move away from ADOT in favor of OTEL Collector Contrib for ECS Fargate integration. Documentation has been done.

# How Has This Been Tested?

Deployed into ECS Fargate testing environment via documented installation steps.

# Checklist:
- [ ] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [] This change does not affect any particular component (e.g. it's CI or docs change)
