### PR TITLE
Bump Windows image to collector version 0.104.0

### DIFF
--- a/otel-collector-windows-image/Dockerfile
+++ b/otel-collector-windows-image/Dockerfile
@@ -3,7 +3,7 @@ ARG WIN_BASE_IMAGE
 
 FROM --platform=$BUILDPLATFORM curlimages/curl AS build
 WORKDIR /src
-RUN curl -Lo otelcol.tar.gz https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.97.0/otelcol-contrib_0.97.0_windows_amd64.tar.gz
+RUN curl -Lo otelcol.tar.gz https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.104.0/otelcol-contrib_0.104.0_windows_amd64.tar.gz
 RUN tar -xzvf otelcol.tar.gz
 
 ##


### PR DESCRIPTION
# Description

Bump Windows image to latest collector version.

# How Has This Been Tested?

# Checklist:
- [ ] I have updated the relevant Helm chart(s) version(s)
- [ ] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
