### PR TITLE
Work around issue for Windows 2019 image

### DIFF
--- a/.github/workflows/otel-collector-windows-image.yml
+++ b/.github/workflows/otel-collector-windows-image.yml
@@ -40,8 +40,11 @@ jobs:
           context: ./otel-collector-windows-image/
           platforms: windows/amd64
           push: true
-          build-args: |
-            WIN_BASE_IMAGE=mcr.microsoft.com/windows/servercore:1809
+          # For Windows 2019, we need to pin to specific sha256, in order to work around
+          # issue https://github.com/microsoft/Windows-Containers/issues/493. Once it's fixed,
+          # it can be removed.
+          build-args: |    
+            WIN_BASE_IMAGE=mcr.microsoft.com/windows/servercore:1809@sha256:6fdf140282a2f809dae9b13fe441635867f0a27c33a438771673b8da8f3348a4
           tags: |
             ${{ env.DOCKERHUB_REGISTRY }}:${{ steps.set-image-version.outputs.version }}
             ${{ env.DOCKERHUB_REGISTRY }}:latest


### PR DESCRIPTION
# Description

We need to adjust the base image and pin to specific SHA in order to work around issue which prevents successful builds. More info on the issue and workaround is here https://github.com/microsoft/Windows-Containers/issues/493/. 

# How Has This Been Tested?

# Checklist:
- [ ] I have updated the relevant Helm chart(s) version(s)
- [ ] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
