### PR TITLE
[otel-integration] Update Windows image to `0.104.0`

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.86 / 2024-07-08
+- [FEAT] Update Windows collector image to `0.104.0`
+- [FEAT] Update values file to be in sync with Linux agents.
+
 ### v0.0.85 / 2024-07-03
 - [:warning: CHANGE] [FEAT] Bump collector version to `0.104.0`. If you are providing your own environemnt variables that are being expanded in the collector configuration, be sure to use the recommended syntax with the `env:` prefix (for example: `${env:ENV_VAR}` instead of just `${ENV_VAR}`). For more information see [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.104.0). The old way of setting environment variables will be removed in the near future.
 

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.85
+version: 0.0.86
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/values-windows.yaml
+++ b/otel-integration/k8s-helm/values-windows.yaml
@@ -5,6 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "warn"
   collectionInterval: "30s"
+  version: "0.0.85"
 
   extensions:
     kubernetesDashboard:
@@ -23,7 +24,7 @@ opentelemetry-agent-windows:
     repository: coralogixrepo/opentelemetry-collector-contrib-windows
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "0.97.0"
+    tag: "0.104.0"
     # When digest is set to a non-empty value, images will be pulled by digest (regardless of tag value).
     digest: ""
   # Temporary feature gates to prevent breaking changes. Please see changelog for version 0.0.85 for more information.
@@ -94,17 +95,35 @@ opentelemetry-agent-windows:
       enabled: true
       storeCheckpoints: true
       maxRecombineLogSize: 1048576
+      # The maximum number of consecutive entries that will be combined into a single entry before the match occurs
+      maxUnmatchedBatchSize: 1
       extraFilelogOperators: []
-#     - type: recombine
-#       combine_field: body
-#       source_identifier: attributes["log.file.path"]
-#       is_first_entry: body matches "^(YOUR-LOGS-REGEX)"
+      # - type: recombine
+      #   combine_field: body
+      #   source_identifier: attributes["log.file.path"]
+      #   is_first_entry: body matches "^(YOUR-LOGS-REGEX)"
+
+      # Configure specific multline options for namespaces
+      # / pods / container names.
+      multilineConfigs: []
+      # multilineConfigs:
+      #   - namespaceName:
+      #       value: kube-system
+      #     podName:
+      #       value: app-.*
+      #       useRegex: true
+      #     containerName:
+      #       value: http
+      #     firstEntryRegex: ^[^\s].*
+      #     combineWith: ""
     kubernetesAttributes:
       enabled: true
     hostMetrics:
       enabled: true
+      collectionInterval: "{{.Values.global.collectionInterval}}"
     kubeletMetrics:
       enabled: true
+      collectionInterval: "{{.Values.global.collectionInterval}}"
     spanMetrics:
       enabled: false
       collectionInterval: "{{.Values.global.collectionInterval}}"
@@ -114,6 +133,30 @@ opentelemetry-agent-windows:
         - name: http.method
         - name: cgx.transaction
         - name: cgx.transaction.root
+          # Configures the collector to export span metrics with different histogram bucket options
+      # for different applications. Applications are selected and routed to different pipelines
+      # using OTTL. For more information see https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/routingconnector
+      # Make sure to not use with spanMetrics preset, which applies single spanmetrics connector to tracing pipeline.
+    spanMetricsMulti:
+      enabled: false
+      collectionInterval: "{{.Values.global.collectionInterval}}"
+      metricsExpiration: 5m
+      extraDimensions:
+        - name: http.method
+        - name: cgx.transaction
+        - name: cgx.transaction.root
+        - name: status_code
+      defaultHistogramBuckets:
+        [1ms, 4ms, 10ms, 20ms, 50ms, 100ms, 200ms, 500ms, 1s, 2s, 5s]
+      configs: []
+      #  - selector: route() where attributes["service.name"] == "one"
+      #    histogramBuckets: [1s, 2s]
+      #  - selector: route() where attributes["service.name"] == "two"
+      #    histogramBuckets: [5s, 10s]
+    # Removes uids and other uneeded attributes from metric resources.
+    # This reduces target_info cardinality.
+    reduceResourceAttributes:
+      enabled: false
 
   config:
     extensions:
@@ -165,9 +208,15 @@ opentelemetry-agent-windows:
             host.id:
               enabled: true
       resourcedetection/region:
-        detectors: ["gcp", "ec2"]
+        detectors: ["gcp", "ec2", "azure"]
         timeout: 2s
         override: true
+      transform/prometheus:
+        error_mode: ignore
+        metric_statements:
+          - context: resource
+            statements:
+              - set(attributes["k8s.pod.ip"], attributes["net.host.name"]) where attributes["service.name"] == "opentelemetry-collector"
       k8sattributes:
         filter:
           node_from_env_var: KUBE_NODE_NAME
@@ -190,6 +239,15 @@ opentelemetry-agent-windows:
         timeout: "30s"
         private_key: "${env:CORALOGIX_PRIVATE_KEY}"
         domain: "{{ .Values.global.domain }}"
+        logs:
+          headers:
+            X-Coralogix-Distribution: "helm-otel-integration/{{ .Values.global.version }}"
+        metrics:
+          headers:
+            X-Coralogix-Distribution: "helm-otel-integration/{{ .Values.global.version }}"
+        traces:
+          headers:
+            X-Coralogix-Distribution: "helm-otel-integration/{{ .Values.global.version }}"
         application_name: "{{ .Values.global.defaultApplicationName }}"
         subsystem_name: "{{ .Values.global.defaultSubsystemName }}"
         application_name_attributes:
@@ -208,6 +266,7 @@ opentelemetry-agent-windows:
           # Supress this attribute, as we don't want the UUID of the collector to be sent,
           # instead we rely on instance label generated by Prometheus receiver.
           - service.instance.id:
+          - service.name:
         logs:
           level: "{{ .Values.global.logLevel }}"
           encoding: json

--- a/otel-integration/k8s-helm/values-windows.yaml
+++ b/otel-integration/k8s-helm/values-windows.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "warn"
   collectionInterval: "30s"
-  version: "0.0.85"
+  version: "0.0.86"
 
   extensions:
     kubernetesDashboard:

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "warn"
   collectionInterval: "30s"
-  version: "0.0.85"
+  version: "0.0.86"
 
   extensions:
     kubernetesDashboard:


### PR DESCRIPTION
# Description

Fixes https://coralogix.atlassian.net/browse/ES-281

Updates collector version for Windows to `0.104.0` and brings the Windows values file up to date.


# How Has This Been Tested?

On a test EKS cluster.

# Checklist:
- [X] I have updated the relevant Helm chart(s) version(s)
- [X] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
