### PR TITLE
[BREAKING][MAJOR] Update ECS Fargate integration to submit logs using OTEL vs fluentbit

### DIFF
--- a/logs/fluent-bit/ecs-fargate/README.md
+++ b/logs/fluent-bit/ecs-fargate/README.md
@@ -1,5 +1,7 @@
 # fluentbit ECS Fargate container
 
+# Note: This integration is for logs only. You can now collect logs from ECS fargate tasks through OTEL using our otel-ecs-fargate integration. Only use this integration if you only intend to ingest logs.
+
 fluentbit is a lightweight data shipper that we are using as a logs shipper for AWS ECS Fargate workloads.
 
 Here we explain how to deploy the fluentbit log_router into an existing AWS ECS Fargate task definition. We use an AWS customized fluentbit image called aws-for-fluent-bit, init version, as it has several features that allow for more convenient management of the configuration. We also have an example cloudformation template for review [here](https://github.com/coralogix/cloudformation-coralogix-aws/tree/master/aws-integrations/ecs-fargate)
@@ -76,7 +78,7 @@ In order to allow container access to the S3 object, you'll need to provide the 
 }
 ```
 
-Note: Don't confuse Task Execution Role for Task Role, this permission needs to be added to the Task Role. (Contrary to the ADOT (OTEL) Metrics and Traces integration)
+Note: Don't confuse Task Execution Role for Task Role, this permission needs to be added to the Task Role.
 
 After you've added the above container to your existing Task Definition, you need to adjust the logConfiguration for the containers you wish to forward to Coralogix.
 

--- a/otel-ecs-fargate/CHANGELOG.md
+++ b/otel-ecs-fargate/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## otel-ecs-fargate
+<!-- To add a new entry write: -->
+<!-- ### version / full date -->
+<!-- * [Update/Bug fix] message that describes the changes that you apply -->
+
+### 0.0.1 / 2024-09-11
+### 🛑 Breaking changes 🛑
+* [UPDATE] Update ecs-fargate integration to OTEL only (remove fluentbit logrouter)

--- a/otel-ecs-fargate/CHANGELOG.md
+++ b/otel-ecs-fargate/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
 ## otel-ecs-fargate
+
 <!-- To add a new entry write: -->
+
 <!-- ### version / full date -->
+
 <!-- * [Update/Bug fix] message that describes the changes that you apply -->
 
 ### 0.0.1 / 2024-09-11
+
 ### 🛑 Breaking changes 🛑
 * [UPDATE] Update ecs-fargate integration to OTEL only (remove fluentbit logrouter)

--- a/otel-ecs-fargate/README.md
+++ b/otel-ecs-fargate/README.md
@@ -89,6 +89,7 @@ In the example above, you'll need to set `<Coralogix PrivateKey>` and `<Coralogi
     }
 },
 ```
+
 If you don't want to have logs submitted to the Coralogix platform, you can replace the logConfiguration with whichever logDriver configuration you would prefer. To submit to Cloudwatch, you can configure as so:
 
 ```

--- a/otel-ecs-fargate/config.yaml
+++ b/otel-ecs-fargate/config.yaml
@@ -16,11 +16,42 @@ exporters:
     subsystem_name_attributes:
     - service.name
     - aws.ecs.docker.name
+    - container_name
     timeout: 30s
     traces:
       headers:
         X-Coralogix-Distribution: ecs-fargate-integration/0.0.1
 processors:
+  transform/firelens:
+    log_statements:
+      - context: log
+        statements:
+          # parse json logs
+          - merge_maps(cache, ParseJSON(body), "insert") where IsMatch(body, "^\\{")
+          # set message
+          - set(body, cache["message"]) where cache["message"] != nil
+
+          # set trace/span id
+          - set(trace_id.string, cache["trace_id"]) where cache["trace_id"] != nil
+          - set(span_id.string, cache["span_id"]) where cache["span_id"] != nil
+
+          # set severity when available
+          - set(severity_number, SEVERITY_NUMBER_INFO) where IsMatch(cache["level"], "(?i)info")
+          - set(severity_number, SEVERITY_NUMBER_WARN) where IsMatch(cache["level"], "(?i)warn")
+          - set(severity_number, SEVERITY_NUMBER_ERROR) where IsMatch(cache["level"], "(?i)err")
+          - set(severity_number, SEVERITY_NUMBER_DEBUG) where IsMatch(cache["level"], "(?i)debug")
+          - set(severity_number, SEVERITY_NUMBER_TRACE) where IsMatch(cache["level"], "(?i)trace")
+          - set(severity_number, cache["severity_number"])  where cache["severity_number"] != nil
+
+          # move log_record attributes to resource
+          - set(resource.attributes["container_name"], attributes["container_name"])
+          - set(resource.attributes["container_id"], attributes["container_id"])
+          - delete_key(attributes, "container_id")
+          - delete_key(attributes, "container_name")
+
+          - delete_matching_keys(cache, "^(message|trace_id|span_id|severity_number)$")
+
+          - merge_maps(attributes,cache, "insert")
   batch:
     send_batch_max_size: 2048
     send_batch_size: 1024
@@ -38,6 +69,9 @@ processors:
     override: true
     timeout: 2s
 receivers:
+  fluentforward/socket:
+    # ECS will send logs to this socket
+    endpoint: unix:///var/run/fluent.sock
   awsecscontainermetrics:
     collection_interval: 10s
   otlp:
@@ -56,6 +90,16 @@ receivers:
           - 127.0.0.1:8888
 service:
   pipelines:
+    logs:
+      exporters:
+      - coralogix
+      processors:
+      - transform/firelens
+      - resource/metadata
+      - resourcedetection
+      - batch
+      receivers:
+      - fluentforward/socket
     metrics:
       exporters:
       - coralogix

--- a/otel-ecs-fargate/parameter_store.cf
+++ b/otel-ecs-fargate/parameter_store.cf
@@ -27,11 +27,42 @@ Resources:
             subsystem_name_attributes:
             - service.name
             - aws.ecs.docker.name
+            - container_name
             timeout: 30s
             traces:
               headers:
                 X-Coralogix-Distribution: ecs-fargate-integration/0.0.1
         processors:
+          transform/firelens:
+            log_statements:
+              - context: log
+                statements:
+                  # parse json logs
+                  - merge_maps(cache, ParseJSON(body), "insert") where IsMatch(body, "^\\{")
+                  # set message
+                  - set(body, cache["message"]) where cache["message"] != nil
+
+                  # set trace/span id
+                  - set(trace_id.string, cache["trace_id"]) where cache["trace_id"] != nil
+                  - set(span_id.string, cache["span_id"]) where cache["span_id"] != nil
+
+                  # set severity when available
+                  - set(severity_number, SEVERITY_NUMBER_INFO) where IsMatch(cache["level"], "(?i)info")
+                  - set(severity_number, SEVERITY_NUMBER_WARN) where IsMatch(cache["level"], "(?i)warn")
+                  - set(severity_number, SEVERITY_NUMBER_ERROR) where IsMatch(cache["level"], "(?i)err")
+                  - set(severity_number, SEVERITY_NUMBER_DEBUG) where IsMatch(cache["level"], "(?i)debug")
+                  - set(severity_number, SEVERITY_NUMBER_TRACE) where IsMatch(cache["level"], "(?i)trace")
+                  - set(severity_number, cache["severity_number"])  where cache["severity_number"] != nil
+
+                  # move log_record attributes to resource
+                  - set(resource.attributes["container_name"], attributes["container_name"])
+                  - set(resource.attributes["container_id"], attributes["container_id"])
+                  - delete_key(attributes, "container_id")
+                  - delete_key(attributes, "container_name")
+
+                  - delete_matching_keys(cache, "^(message|trace_id|span_id|severity_number)$")
+
+                  - merge_maps(attributes,cache, "insert")
           batch:
             send_batch_max_size: 2048
             send_batch_size: 1024
@@ -49,6 +80,9 @@ Resources:
             override: true
             timeout: 2s
         receivers:
+          fluentforward/socket:
+            # ECS will send logs to this socket
+            endpoint: unix:///var/run/fluent.sock
           awsecscontainermetrics:
             collection_interval: 10s
           otlp:
@@ -67,6 +101,16 @@ Resources:
                   - 127.0.0.1:8888
         service:
           pipelines:
+            logs:
+              exporters:
+              - coralogix
+              processors:
+              - transform/firelens
+              - resource/metadata
+              - resourcedetection
+              - batch
+              receivers:
+              - fluentforward/socket
             metrics:
               exporters:
               - coralogix


### PR DESCRIPTION
# Description

ECS Fargate integration now processes logs via OTEL instead of extra fluentbit container.

# How Has This Been Tested?

This integration was deployed, taskdefinition launched, and logs and metrics observed in CX.

# Checklist:
- [] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
