### PR TITLE
[opentelemetry-integration] update collector to 110

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.104 / 2024-09-26
+- [Feat] Bump collector version to `0.110.0`
+
 ### v0.0.103 / 2024-09-23
 - [Fix] agent_description.non_identifying_attributes expected a map, got 'slice'
 - [Fix] Change opamp poll interval to 2 minutes

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.103
+version: 0.0.104
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -11,27 +11,27 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.93.3"
+    version: "0.94.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-windows
-    version: "0.93.3"
+    version: "0.94.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-windows.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-cluster-collector
-    version: "0.93.3"
+    version: "0.94.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-cluster-collector.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-receiver
-    version: "0.93.3"
+    version: "0.94.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-receiver.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-gateway
-    version: "0.93.3"
+    version: "0.94.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-gateway.enabled
 sources:

--- a/otel-integration/k8s-helm/e2e-test/expected_test.go
+++ b/otel-integration/k8s-helm/e2e-test/expected_test.go
@@ -5,7 +5,7 @@ var expectedSchemaURL = map[string]bool{
 	"https://opentelemetry.io/schemas/1.9.0": false,
 }
 
-const expectedScopeVersion = "0.109.0"
+const expectedScopeVersion = "0.110.0"
 
 var expectedScopeNames = map[string]bool{
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/networkscraper":    false,
@@ -87,6 +87,7 @@ var expectedResourceAttributesPrometheusreceiver = map[string]string{
 	"azure.vm.size":            "",
 	"azure.vm.scaleset.name":   "",
 	"azure.resourcegroup.name": "",
+	"k8s_node_name":            "",
 }
 
 var expectedMetrics map[string]bool = map[string]bool{
@@ -151,7 +152,6 @@ var expectedMetrics map[string]bool = map[string]bool{
 	"otelcol_process_memory_rss":                     false,
 	"otelcol_processor_refused_metric_points":        false,
 	"otelcol_receiver_accepted_metric_points":        false,
-	"otelcol_processor_inserted_metric_points":       false,
 	"scrape_duration_seconds":                        false,
 	"otelcol_exporter_queue_capacity":                false,
 	"otelcol_otelsvc_k8s_ip_lookup_miss":             false,
@@ -184,8 +184,6 @@ var expectedMetrics map[string]bool = map[string]bool{
 	"otelcol_processor_batch_batch_send_size":        false,
 	"otelcol_fileconsumer_open_files":                false,
 	"otelcol_fileconsumer_reading_files":             false,
-	"otelcol_processor_incoming_log_records":         false,
-	"otelcol_processor_outgoing_log_records":         false,
-	"otelcol_processor_incoming_metric_points":       false,
-	"otelcol_processor_outgoing_metric_points":       false,
+	"otelcol_processor_outgoing_items":               false,
+	"otelcol_processor_incoming_items":               false,
 }

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "warn"
   collectionInterval: "30s"
-  version: "0.0.103"
+  version: "0.0.104"
 
   extensions:
     kubernetesDashboard:


### PR DESCRIPTION
# Description

Fixes ES-359

Change logs:

https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.110.0
https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.110.0

Didn't see any breaking changes that would affect our chart / presets

# How Has This Been Tested?

-
# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
