### PR TITLE
[opentelemetry-integration] disable span metrics

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.105 / 2024-09-30
+- [Breaking] Change spanmetrics to disabled by default, which was enabled by mistake in v0.0.102
+
 ### v0.0.104 / 2024-09-26
 - [Feat] Bump collector version to `0.110.0`
 

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.104
+version: 0.0.105
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "warn"
   collectionInterval: "30s"
-  version: "0.0.104"
+  version: "0.0.105"
 
   extensions:
     kubernetesDashboard:
@@ -137,7 +137,7 @@ opentelemetry-agent:
       enabled: true
       collectionInterval: "{{.Values.global.collectionInterval}}"
     spanMetrics:
-      enabled: true
+      enabled: false
       collectionInterval: "{{.Values.global.collectionInterval}}"
       metricsExpiration: 5m
       histogramBuckets:


### PR DESCRIPTION
# Description

Fixes ES-359

[Breaking] Change spanmetrics to disabled by default, which was enabled by mistake in v0.0.102

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
