### PR TITLE
Ecs fargate docs secrets manager private key

### DIFF
--- a/otel-ecs-fargate/CHANGELOG.md
+++ b/otel-ecs-fargate/CHANGELOG.md
@@ -7,6 +7,7 @@
 <!-- ### version / full date -->
 
 <!-- * [Update/Bug fix] message that describes the changes that you apply -->
+
 ### 0.0.1 / 2024-10-15
 
 * [DOCS] Update Documentation with optional Secrets Manager for Private Key

--- a/otel-ecs-fargate/CHANGELOG.md
+++ b/otel-ecs-fargate/CHANGELOG.md
@@ -7,6 +7,9 @@
 <!-- ### version / full date -->
 
 <!-- * [Update/Bug fix] message that describes the changes that you apply -->
+### 0.0.1 / 2024-10-15
+
+* [DOCS] Update Documentation with optional Secrets Manager for Private Key
 
 ### 0.0.1 / 2024-09-11
 

--- a/otel-ecs-fargate/README.md
+++ b/otel-ecs-fargate/README.md
@@ -147,7 +147,7 @@ If you prefer to store your Coralogix private key in AWS Secrets Manager, remove
 
 ```
 
-You will also need to add the `secretsmanager:GetSecretValue` permission to your ECS Task Execution Role.
+Create the Secret as "Plaintext" with only the API key with no quotation marks. You will also need to add the `secretsmanager:GetSecretValue` permission to your ECS Task Execution Role.
 
 ## Granting permissions for Secrets Manager Secret access
 

--- a/otel-ecs-fargate/README.md
+++ b/otel-ecs-fargate/README.md
@@ -114,6 +114,7 @@ In order to allow container access to the Systems Manager Parameter Store, you'l
 ```
 
 ## Alternative log drivers (CloudWatch)
+
 If you don't want all containers to submit their logs to Coralogix, you can set their logConfiguration with whichever logDriver configuration you would prefer. To submit them to Cloudwatch, you can configure as so:
 
 ```


### PR DESCRIPTION
# Description

Updated ECS Fargate documentation with example of private key via Secrets Manager.

CDS-1609

# How Has This Been Tested?

Deployed to ECS Fargate. 

# Checklist:
- [ ] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
