### PR TITLE
otel-integration: add ebpf agent subchart

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## OpenTelemtry-Integration
 
-### v0.0.118 / 2024-11-25
+### v0.0.118 / 2024-12-04
 
 - [Feat] Add ebpf tracing agent subchart.
 
-- ### v0.0.117 / 2024-12-03
+### v0.0.117 / 2024-12-03
 
 - [Feat] Adding new configs to the Target Allocator.
 

--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## OpenTelemtry-Integration
 
-### v0.0.117 / 2024-12-03
+### v0.0.118 / 2024-11-25
+
+- [Feat] Add ebpf tracing agent subchart.
+
+- ### v0.0.117 / 2024-12-03
 
 - [Feat] Adding new configs to the Target Allocator.
 

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.117
+version: 0.0.118
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -34,6 +34,11 @@ dependencies:
     version: "0.98.6"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-gateway.enabled
+  - name: coralogix-ebpf-agent
+    alias: coralogix-ebpf-agent
+    version: "0.1.2"
+    repository: https://cgx.jfrog.io/artifactory/coralogix-charts
+    condition: coralogix-ebpf-agent.enabled
 sources:
   - https://github.com/coralogix/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector
 maintainers:

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -36,7 +36,7 @@ dependencies:
     condition: opentelemetry-gateway.enabled
   - name: coralogix-ebpf-agent
     alias: coralogix-ebpf-agent
-    version: "0.1.2"
+    version: "0.1.4"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts
     condition: coralogix-ebpf-agent.enabled
 sources:

--- a/otel-integration/k8s-helm/README.md
+++ b/otel-integration/k8s-helm/README.md
@@ -129,8 +129,6 @@ Provides information about Kubernetes version.
 
 coralogix-ebpf-agent is an agent developed by coralogix. using [EBPF](https://ebpf.io/what-is-ebpf/) to extract network traffic as spans (http requests, SQL traffic ect), allowing for [Coralogix APM](https://coralogix.com/docs/user-guides/apm/getting-started/introduction-to-apm/) capabilities without any service instrumentation.
 
-TODO: link to ebpf agent docs in coralogix site
-
 Componentes:
 - coralogix-ebpf-agent - The agent that extracts network traffic as spans, running as a daemonset.
 - k8s-watcher - The agent that watches for changes in k8s resources and publishes them to redis pubsub for coralogix-ebpf-agent to consume them, running as a deployment with 1 replica.

--- a/otel-integration/k8s-helm/README.md
+++ b/otel-integration/k8s-helm/README.md
@@ -1,4 +1,4 @@
- # OpenTelemetry Integration
+# OpenTelemetry Integration
 
 The OpenTelemetry Integration consists of two main compoenents, that provide our users with full fledged integration for their Kubernetes cluster - the [OpenTelemetry Agent](#opentelemetry-agent) and [OpenTelemetry Cluster Collector](#opentelemetry-cluster-collector). Depending on your needs, you can deploy both components (default behavior) or decide to disable eihter one under the `opentelemetry-agent` or `opentelemetry-cluster-collector` sections in the `values.yaml` file.
 
@@ -416,6 +416,7 @@ helm upgrade --install otel-coralogix-integration coralogix-charts-virtual/otel-
 ```
 
 ### Enabling Coralogix EBPF Agent
+
 To enable the coralogix EBPF agent, set `coralogix-ebpf-agent.enabled` to `true` in the `values.yaml` file.
 
 #### Filtering Specific Services For Coralogix EBPF Agent
@@ -435,7 +436,7 @@ coralogix-ebpf-agent:
       services_filter_type: "Allow"
 ```
 
-In another example, a case of where we want get all services beside `currencyservice` 
+In another example, a case of where we want get all services beside `currencyservice`
 
 ```yaml
 coralogix-ebpf-agent:
@@ -450,8 +451,6 @@ coralogix-ebpf-agent:
 
 A service is defined by the top owner of the specific container the performed the network request, in most cases a Deploymnet, StatefulSet, DaemonSet or CronJob.
 the name of the service is the name of that owner resource.
-
-
 
 # How to use it
 

--- a/otel-integration/k8s-helm/README.md
+++ b/otel-integration/k8s-helm/README.md
@@ -1,4 +1,4 @@
-# OpenTelemetry Integration
+ # OpenTelemetry Integration
 
 The OpenTelemetry Integration consists of two main compoenents, that provide our users with full fledged integration for their Kubernetes cluster - the [OpenTelemetry Agent](#opentelemetry-agent) and [OpenTelemetry Cluster Collector](#opentelemetry-cluster-collector). Depending on your needs, you can deploy both components (default behavior) or decide to disable eihter one under the `opentelemetry-agent` or `opentelemetry-cluster-collector` sections in the `values.yaml` file.
 
@@ -124,6 +124,19 @@ Provides information about Kubernetes version.
 
 - container_cpu_cfs_periods_total
 - container_cpu_cfs_throttled_periods_total
+
+## Coralogix EBPF Agent
+
+coralogix-ebpf-agent is an agent developed by coralogix. using [EBPF](https://ebpf.io/what-is-ebpf/) to extract network traffic as spans (http requests, SQL traffic ect), allowing for [Coralogix APM](https://coralogix.com/docs/user-guides/apm/getting-started/introduction-to-apm/) capabilities without any service instrumentation.
+
+TODO: link to ebpf agent docs in coralogix site
+
+Componentes:
+- coralogix-ebpf-agent - The agent that extracts network traffic as spans, running as a daemonset.
+- k8s-watcher - The agent that watches for changes in k8s resources and publishes them to redis pubsub for coralogix-ebpf-agent to consume them, running as a deployment with 1 replica.
+- redis - Redis Pubsub is used for communication between k8s-watcher and coralogix-ebpf-agent, running as a sts with 1 replica.
+
+to enable the coralogix-ebpf-agent deployment, set `coralogix-ebpf-agent.enabled` to `true` in the `values.yaml` file.
 
 # Prerequisites
 
@@ -403,6 +416,44 @@ Or you can provide the values directly in the command line by passing them with 
 helm upgrade --install otel-coralogix-integration coralogix-charts-virtual/otel-integration \
   --render-subchart-notes -f gke-autopilot-values.yaml --set global.clusterName=<cluster_name> --set global.domain=<domain>
 ```
+
+### Enabling Coralogix EBPF Agent
+To enable the coralogix EBPF agent, set `coralogix-ebpf-agent.enabled` to `true` in the `values.yaml` file.
+
+#### Filtering Specific Services For Coralogix EBPF Agent
+
+By default, the coralogix-ebpf-agent will collect traffic from all services in the cluster.
+but there are cases where you might want to filter specific services, or filter out specific services. you can use the
+`coralogix-ebpf-agent.ebpf_agent.sampler` parameter in `values.yaml` to change the service filtering behavior.
+
+For example, collect only traffic coming from `carts-service` and `orders-service`:
+
+```yaml
+coralogix-ebpf-agent:
+  enabled: true
+  ebpf_agent:
+    sampler:
+      services_filter: ["carts-service", "orders-service"]
+      services_filter_type: "Allow"
+```
+
+In another example, a case of where we want get all services beside `currencyservice` 
+
+```yaml
+coralogix-ebpf-agent:
+  enabled: true
+  ebpf_agent:
+    sampler:
+      services_filter: ["currency-service"]
+      services_filter_type: "Deny"
+```
+
+#### What Is Considered A Service By Coralogix EBPF Agent?
+
+A service is defined by the top owner of the specific container the performed the network request, in most cases a Deploymnet, StatefulSet, DaemonSet or CronJob.
+the name of the service is the name of that owner resource.
+
+
 
 # How to use it
 

--- a/otel-integration/k8s-helm/central-agent-values.yaml
+++ b/otel-integration/k8s-helm/central-agent-values.yaml
@@ -34,4 +34,5 @@ opentelemetry-agent-windows:
   enabled: false
 opentelemetry-gateway:
   enabled: false
-
+coralogix-ebpf-agent:
+  enabled: false

--- a/otel-integration/k8s-helm/central-tail-sampling-values.yaml
+++ b/otel-integration/k8s-helm/central-tail-sampling-values.yaml
@@ -98,3 +98,5 @@ opentelemetry-cluster-collector:
   enabled: false
 opentelemetry-agent-windows:
   enabled: false
+coralogix-ebpf-agent:
+  enabled: false

--- a/otel-integration/k8s-helm/ci/tail-sampling-values.yaml
+++ b/otel-integration/k8s-helm/ci/tail-sampling-values.yaml
@@ -53,3 +53,5 @@ opentelemetry-cluster-collector:
   enabled: true
 opentelemetry-agent-windows:
   enabled: false
+coralogix-ebpf-agent:
+  enabled: false

--- a/otel-integration/k8s-helm/gke-autopilot-values.yaml
+++ b/otel-integration/k8s-helm/gke-autopilot-values.yaml
@@ -47,7 +47,7 @@ opentelemetry-agent:
             - statsd
   resources:
     # slighly larger resource requests for gke/autopilot 
-    # since it was droping data
+    # since it was dropping data
     requests:
       cpu: 100m
       memory: 256Mi
@@ -70,4 +70,7 @@ opentelemetry-cluster-collector:
   enabled: true
 
 opentelemetry-agent-windows:
+  enabled: false
+
+coralogix-ebpf-agent:
   enabled: false

--- a/otel-integration/k8s-helm/tail-sampling-values.yaml
+++ b/otel-integration/k8s-helm/tail-sampling-values.yaml
@@ -58,5 +58,9 @@ opentelemetry-gateway:
 
 opentelemetry-cluster-collector:
   enabled: true
+
 opentelemetry-agent-windows:
+  enabled: false
+
+coralogix-ebpf-agent:
   enabled: false

--- a/otel-integration/k8s-helm/values-cluster-ksm.yaml
+++ b/otel-integration/k8s-helm/values-cluster-ksm.yaml
@@ -38,3 +38,6 @@ opentelemetry-cluster-collector:
             - prometheus
             - k8s_cluster
             - prometheus/ksm
+
+coralogix-ebpf-agent:
+  enabled: false

--- a/otel-integration/k8s-helm/values-crd-override.yaml
+++ b/otel-integration/k8s-helm/values-crd-override.yaml
@@ -19,4 +19,6 @@ opentelemetry-cluster-collector:
     generate: true
   configMap:
     create: false
-  
+
+coralogix-ebpf-agent:
+  enabled: false

--- a/otel-integration/k8s-helm/values-windows-tailsampling.yaml
+++ b/otel-integration/k8s-helm/values-windows-tailsampling.yaml
@@ -338,3 +338,6 @@ opentelemetry-agent:
 opentelemetry-cluster-collector:
   nodeSelector:
     kubernetes.io/os: linux
+
+coralogix-ebpf-agent:
+  enabled: false

--- a/otel-integration/k8s-helm/values-windows.yaml
+++ b/otel-integration/k8s-helm/values-windows.yaml
@@ -361,3 +361,6 @@ opentelemetry-agent:
 opentelemetry-cluster-collector:
   nodeSelector:
     kubernetes.io/os: linux
+
+coralogix-ebpf-agent:
+  enabled: false

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "warn"
   collectionInterval: "30s"
-  version: "0.0.117"
+  version: "0.0.118"
 
   extensions:
     kubernetesDashboard:
@@ -1113,3 +1113,38 @@ opentelemetry-receiver:
       enabled: false
     zipkin:
       enabled: false
+
+coralogix-ebpf-agent:
+  enabled: false
+  ebpf_agent:
+    debug: false
+    debug_modules:
+      - Otel
+    otel:
+      exporter:
+        max_queue_size: 10240
+        max_concurrent_exports: 3
+      sampler:
+        services_filter: []
+        services_filter_type: "Allow"  # Deny for blacklist
+    resources:
+      limits:
+        cpu: "1"
+        memory: 2Gi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+  k8s_watcher:
+    replicaCount: 1
+    debug: false
+    resources:
+      limits:
+        cpu: "1"
+        memory: 2Gi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+  priorityClass:
+    create: false
+    name: ""
+    value: 1000000000


### PR DESCRIPTION
# Description

This PR adds the ebpf tracing agent subchart

# How Has This Been Tested?

1. Package the new chart:
    - Set domain and clusterName in the values.yaml file
    - `helm lint ./otel-integration/k8s-helm`
    - `helm dependency build ./otel-integration/k8s-helm`
    - `helm package ./otel-integration/k8s-helm`
3. Create a new namespace on the cluster: `k create ns test-ebpf-agent-subchart`
4. Create a new coralogix-keys secret: `k create secret generic coralogix-keys -n test-ebpf-agent-subchart --from-literal=PRIVATE_KEY=bogus`
5. Install the chart while setting `enabled=true` for the subchart: `helm install cx-otel-shippers /Users/mattia.meleleo/cx/telemetry-shippers/otel-integration-0.0.114.tgz --namespace test-ebpf-agent-subchart --set coralogix-ebpf-agent.enabled=true`
6. Observe the created resources are running as expected

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
