### PR TITLE
[opentelemetry-integration] Add the errorTracking spanmetrics preset

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.114 / 2024-11-27
+
+- [Feat] Add the `errorTracking` preset. It's enabled by default when `spanMetrics` is also enabled.
+
 ### v0.0.113 / 2024-11-21
 
 - [Fix] Setting max_batch_size for logsCollection preset now works on all recombine operators.

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.113
+version: 0.0.114
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -11,27 +11,27 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.98.2"
+    version: "0.98.3"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-windows
-    version: "0.98.2"
+    version: "0.98.3"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-windows.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-cluster-collector
-    version: "0.98.2"
+    version: "0.98.3"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-cluster-collector.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-receiver
-    version: "0.98.2"
+    version: "0.98.3"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-receiver.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-gateway
-    version: "0.98.2"
+    version: "0.98.3"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-gateway.enabled
 sources:

--- a/otel-integration/k8s-helm/README.md
+++ b/otel-integration/k8s-helm/README.md
@@ -507,7 +507,6 @@ presets:
        enabled: true
 ```
 
-
 #### SpanMetrics Database Monitoring
 
 Once you enable the Span Metrics preset, the dbMetrics configuration will automatically be enabled. The DbMetrics option generates RED (Request, Errors, Duration) metrics for database spans. For example, query `db_calls_total` to view generated request metrics.

--- a/otel-integration/k8s-helm/README.md
+++ b/otel-integration/k8s-helm/README.md
@@ -475,6 +475,39 @@ spanNameReplacePattern:
 
 This will result in your spans having generalized name `user-{id}`.
 
+#### SpanMetrics Error Tracking
+
+Once you enable the Span Metrics preset, the errorTracking configuration will automatically be enabled.
+
+This is how you can disable the errorTracking option:
+
+```
+presets:
+    spanMetrics:
+      enabled: true
+      errorTracking:
+        enabled: false
+```
+
+Note: errorTracking only works with OpenTelemetry SDKs that support OpenTelemetry Semantic conventions above v1.21.0. If you are using older versions, you might need to transform some attributes, such as:
+
+```
+http.status_code => http.response.status_code
+```
+
+To do that, you can add the following configuration:
+
+```
+presets:
+  spanMetrics:
+     enabled: true
+       transformStatements:
+       - set(attributes["http.response.status_code"], attributes["http.status_code"]) where attributes["http.response.status_code"] == nil
+     errorTracking:
+       enabled: true
+```
+
+
 #### SpanMetrics Database Monitoring
 
 Once you enable the Span Metrics preset, the dbMetrics configuration will automatically be enabled. The DbMetrics option generates RED (Request, Errors, Duration) metrics for database spans. For example, query `db_calls_total` to view generated request metrics.

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "warn"
   collectionInterval: "30s"
-  version: "0.0.113"
+  version: "0.0.114"
 
   extensions:
     kubernetesDashboard:
@@ -140,6 +140,10 @@ opentelemetry-agent:
       collectionInterval: "{{.Values.global.collectionInterval}}"
     spanMetrics:
       enabled: false
+      # transformStatements:
+      # - set(attributes["http.response.status_code"], attributes["http.status_code"]) where attributes["http.response.status_code"] == nil
+      errorTracking:
+        enabled: true
       dbMetrics:
         enabled: true
         # transformStatements:


### PR DESCRIPTION
# Description

This PR adds the error tracking spanmetrics preset. 

Fixes ES-385 by bringing the changes from https://github.com/coralogix/opentelemetry-helm-charts/pull/120.

# How Has This Been Tested?

Deployed to kind running locally.

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
