### PR TITLE
[opentelemetry-integration] Change default value for metrics telemetry service address

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### v0.0.116 / 2024-11-29
 
-- [Fix] Change the default value of the metrics telemetry service to `0.0.0.0`.
+- [Fix] Change the default value of the metrics telemetry service address to `0.0.0.0:8888`.
 
 ### v0.0.115 / 2024-11-28
 

--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.116 / 2024-11-29
+
+- [Fix] Change the default value of the metrics telemetry service to `0.0.0.0`.
+
 ### v0.0.115 / 2024-11-28
 
 - [Fix] Make the metrics telemetry service listen on `0.0.0.0` instead of using shell var expansion to resolve the pod IP.

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.115
+version: 0.0.116
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "warn"
   collectionInterval: "30s"
-  version: "0.0.115"
+  version: "0.0.116"
 
   extensions:
     kubernetesDashboard:
@@ -313,7 +313,7 @@ opentelemetry-agent:
           level: "{{ .Values.global.logLevel }}"
           encoding: json
         metrics:
-          address: ${env:MY_POD_IP}:8888
+          address: 0.0.0.0:8888
       extensions:
         - zpages
         - pprof


### PR DESCRIPTION
# Description

<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> Fixes ES-386

# How Has This Been Tested?

Locally with kind.

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
