### PR TITLE
bump ebpf-agent chart version

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.121 / 2024-12-05
+- [Feat] Bump coralogix-ebpf-agent version to `0.1.5`
+
 ### v0.0.120 / 2024-12-05
 - [Feat] Bump collector version to `0.115.0`
 - [Feat] Bump Target Allocator version to `0.114.0`

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.120
+version: 0.0.121
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -36,7 +36,7 @@ dependencies:
     condition: opentelemetry-gateway.enabled
   - name: coralogix-ebpf-agent
     alias: coralogix-ebpf-agent
-    version: "0.1.4"
+    version: "0.1.5"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts
     condition: coralogix-ebpf-agent.enabled
 sources:

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "warn"
   collectionInterval: "30s"
-  version: "0.0.120"
+  version: "0.0.121"
 
   extensions:
     kubernetesDashboard:


### PR DESCRIPTION
# Description

updated otel endpoint in ebpf agent to send data otel agent instead of collector

# How Has This Been Tested?

deployed ebpf agent using helm and watched spans reach coralogix

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [x] This change does not affect any particular component (e.g. it's CI or docs change)
