### PR TITLE
[opentelemetry-integration] remove component.UseLocalHostAsDefaultHost for windows

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.123 / 2024-12-09
+
+- [Fix] remove component.UseLocalHostAsDefaultHost feature gate from windows installations
+
 ### v0.0.122 / 2024-12-06
 
 - [Feat] E2E Testing: Added deploying via kubeconfig to spin up telemetrygen. Traces are now tested.

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.122
+version: 0.0.123
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/values-windows-tailsampling.yaml
+++ b/otel-integration/k8s-helm/values-windows-tailsampling.yaml
@@ -56,10 +56,6 @@ opentelemetry-agent-windows:
         fieldRef:
           apiVersion: v1
           fieldPath: spec.nodeName
-  # Temporary feature gates to prevent breaking changes. Please see changelog for version 0.0.85 for more information.
-  command:
-    name: otelcol-contrib
-    extraArgs: ["--feature-gates=component.UseLocalHostAsDefaultHost"]
 
   serviceAccount:
     # Specifies whether a service account should be created

--- a/otel-integration/k8s-helm/values-windows.yaml
+++ b/otel-integration/k8s-helm/values-windows.yaml
@@ -26,10 +26,6 @@ opentelemetry-agent-windows:
     tag: "0.104.0"
     # When digest is set to a non-empty value, images will be pulled by digest (regardless of tag value).
     digest: ""
-  # Temporary feature gates to prevent breaking changes. Please see changelog for version 0.0.85 for more information.
-  command:
-    name: otelcol-contrib
-    extraArgs: ["--feature-gates=component.UseLocalHostAsDefaultHost"]
   
   extraVolumes:
     - name: etcmachineid

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "warn"
   collectionInterval: "30s"
-  version: "0.0.122"
+  version: "0.0.123"
 
   extensions:
     kubernetesDashboard:


### PR DESCRIPTION
# Description

 Fixes ES-384

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the relevant Helm chart(s) version(s)
- [ ] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
