### PR TITLE
[opentelemetry-integration] remove hostmetrics from the pipeline

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.124 / 2024-12-10
+
+- [Feat] remove hostmetrics from the pipeline in default values.yaml, as it is added automatically by the preset
+
 ### v0.0.123 / 2024-12-09
 
 - [Fix] remove component.UseLocalHostAsDefaultHost feature gate from windows installations

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -330,7 +330,6 @@ opentelemetry-agent:
           receivers:
             - otlp
             - prometheus
-            - hostmetrics
             - statsd
         traces:
           exporters:


### PR DESCRIPTION
# Description

 Fixes ES-329

# How Has This Been Tested?

kind cluster - both hosmetrics preset enabled and disabled

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
