### PR TITLE
deploy ebpf agent without collector

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.125 / 2024-12-12
+
+- [Feat] allow deploying of coralogix-ebpf-agent with existing collector
+
 ### v0.0.124 / 2024-12-10
 
 - [Feat] remove hostmetrics from the pipeline in default values.yaml, as it is added automatically by the preset

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.123
+version: 0.0.125
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -36,7 +36,7 @@ dependencies:
     condition: opentelemetry-gateway.enabled
   - name: coralogix-ebpf-agent
     alias: coralogix-ebpf-agent
-    version: "0.1.5"
+    version: "0.1.7"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts
     condition: coralogix-ebpf-agent.enabled
 sources:

--- a/otel-integration/k8s-helm/README.md
+++ b/otel-integration/k8s-helm/README.md
@@ -452,6 +452,18 @@ coralogix-ebpf-agent:
 A service is defined by the top owner of the specific container the performed the network request, in most cases a Deploymnet, StatefulSet, DaemonSet or CronJob.
 the name of the service is the name of that owner resource.
 
+#### Enabling Coralogix EBPF with existing OpenTelemetry Collector
+
+If you already have an existing OpenTelemetry Collector deployment and you want to enable the Coralogix EBPF agent.
+you can only deploy the ebpf agent and supply your existing OpenTelemetry Collector endpoint with this command:
+
+```bash
+helm repo add coralogix-charts-virtual https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
+
+helm upgrade --install otel-coralogix-central-collector coralogix-charts-virtual/otel-integration \
+  --render-subchart-notes -f values-ebpf-agent-existing-collector.yaml --set coralogix-ebpf-agent.ebpf_agent.otel.exporter.endpoint=<your-existing-collector-endpoint>
+```
+
 # How to use it
 
 ## Available Endpoints

--- a/otel-integration/k8s-helm/values-ebpf-agent-existing-collector.yaml
+++ b/otel-integration/k8s-helm/values-ebpf-agent-existing-collector.yaml
@@ -1,0 +1,17 @@
+global:
+  domain: "-"
+  clusterName: "-"
+
+opentelemetry-agent:
+  enabled: false
+
+opentelemetry-cluster-collector:
+  enabled: false
+
+coralogix-ebpf-agent:
+  enabled: true
+  ebpf_agent:
+    otel:
+      exporter:
+        # configure the opentelemetry collector endpoint here
+        endpoint: "coralogix-opentelemetry-receiver:4317"

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "warn"
   collectionInterval: "30s"
-  version: "0.0.123"
+  version: "0.0.125"
 
   extensions:
     kubernetesDashboard:


### PR DESCRIPTION
# Description

increased ebpf agent version to 0.1.7
added a way to deploy ebpf agent for an existing collector setup

# How Has This Been Tested?

created a new k8s cluster
setup a otel collector sending to coralogix not as part as the helm chart
and the ran
```
helm dependency build ./otel-integration/k8s-helm
helm package ./otel-integration/k8s-helm
helm install cx-otel ./otel-integration-0.0.125.tgz --namespace coralogix-ebpf  --create-namespace -f otel-integration/k8s-helm/values-ebpf-agent-existing-collector.yaml --set coralogix-ebpf-agent.ebpf_agent.otel.exporter.endpoint="http://otel-collector-sandbox.default.svc.cluster.local:4317"
```

then validate spans are reaching the collector / coralogix instance

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [x] This change does not affect any particular component (e.g. it's CI or docs change)
