### PR TITLE
Fleet management updates

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.127 / 2024-12-20
+
+- [Fix] Make the receiver Collector report as agent type `receiver`
+- [Feat] Add fleet management preset configuration to the Windows values files
+
 ### v0.0.126 / 2024-12-19
 
 - [Feat] add service.version to spanMetrics and dbMetrics

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.126
+version: 0.0.127
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/values-windows-tailsampling.yaml
+++ b/otel-integration/k8s-helm/values-windows-tailsampling.yaml
@@ -85,6 +85,10 @@ opentelemetry-agent-windows:
       enabled: true
       clusterName: "{{.Values.global.clusterName}}"
       integrationName: "coralogix-integration-helm"
+    fleetManagement:
+      enabled: false
+      agentType: "agent"
+      clusterName: "{{.Values.global.clusterName}}"
     logsCollection:
       enabled: true
       storeCheckpoints: true

--- a/otel-integration/k8s-helm/values-windows.yaml
+++ b/otel-integration/k8s-helm/values-windows.yaml
@@ -86,6 +86,10 @@ opentelemetry-agent-windows:
       enabled: true
       clusterName: "{{.Values.global.clusterName}}"
       integrationName: "coralogix-integration-helm"
+    fleetManagement:
+      enabled: false
+      agentType: "agent"
+      clusterName: "{{.Values.global.clusterName}}"
     logsCollection:
       enabled: true
       storeCheckpoints: true

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -937,7 +937,7 @@ opentelemetry-receiver:
   presets:
     fleetManagement:
       enabled: false
-      agentType: "gateway"
+      agentType: "receiver"
       clusterName: "{{.Values.global.clusterName}}"
     kubernetesAttributes:
       enabled: false

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "warn"
   collectionInterval: "30s"
-  version: "0.0.126"
+  version: "0.0.127"
 
   extensions:
     kubernetesDashboard:


### PR DESCRIPTION
# Description

Fixes ES-383.

- Make the `opentelemetry-receiver` Collector report agent type `receiver` to discern it from the gateway one.
- Add fleet management preset configuration to the Windows values files.

All the other collectors are already well configured in the main `values.yaml` file.

# How Has This Been Tested?

Run it in `kind`.

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [ ] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
