### PR TITLE
[otel-integration] add k8s ipv6 only support

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.128 / 2024-12-23
+
+- [Feat] add k8s ipv6 only support
+
 ### v0.0.127 / 2024-12-20
 
 - [Fix] Make the receiver Collector report as agent type `receiver`

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.127
+version: 0.0.128
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/README.md
+++ b/otel-integration/k8s-helm/README.md
@@ -415,6 +415,29 @@ helm upgrade --install otel-coralogix-integration coralogix-charts-virtual/otel-
   --render-subchart-notes -f gke-autopilot-values.yaml --set global.clusterName=<cluster_name> --set global.domain=<domain>
 ```
 
+### Installing the chart on IPV6 Only clusters.
+
+To run otel-integration inside IPV6 only cluster, you need to install using `ipv6-values.yaml` file.
+
+First make sure to add our Helm charts repository to the local repos list with the following command:
+
+```bash
+helm repo add coralogix-charts-virtual https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
+```
+
+In order to get the updated Helm charts from the added repository, please run:
+
+```bash
+helm repo update
+```
+
+Install the chart with the `ipv6-values.yaml` file. You can either provide the global values (secret key, cluster name) by adjusting the main `values.yaml` file and then passing the `values.yaml` file to the `helm upgrade` command as following:
+
+```bash
+helm upgrade --install otel-coralogix-integration coralogix-charts-virtual/otel-integration \
+  --render-subchart-notes -f values.yaml -f ipv6-values.yaml
+```
+
 ### Enabling Coralogix EBPF Agent
 
 To enable the coralogix EBPF agent, set `coralogix-ebpf-agent.enabled` to `true` in the `values.yaml` file.

--- a/otel-integration/k8s-helm/ipv6-values.yaml
+++ b/otel-integration/k8s-helm/ipv6-values.yaml
@@ -1,0 +1,84 @@
+opentelemetry-agent:
+  enabled: true
+
+  config:
+    extensions:
+      health_check:
+        endpoint: "[${env:MY_POD_IP}]:13133"
+
+    receivers:
+      kubeletstats:
+        endpoint: "[${env:K8S_NODE_IP}]:10250"
+      statsd:
+        endpoint: "[${env:MY_POD_IP}]:8125"
+      otlp:
+        protocols:
+          grpc:
+            endpoint: "[${env:MY_POD_IP}]:4317"
+          http:
+            endpoint: "[${env:MY_POD_IP}]:4318"
+      zipkin:
+        endpoint: "[${env:MY_POD_IP}]:9411"
+      jaeger:
+        protocols:
+          grpc:
+            endpoint: "[${env:MY_POD_IP}]:14250"
+          thrift_http:
+            endpoint: "[${env:MY_POD_IP}]:14268"
+          thrift_compact:
+            endpoint: "[${env:MY_POD_IP}]:6831"
+          thrift_binary:
+            endpoint: "[${env:MY_POD_IP}]:6832"
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: opentelemetry-collector
+              scrape_interval: 30s
+              static_configs:
+                - targets:
+                    - "[${env:MY_POD_IP}]:8888"
+
+    service:
+      telemetry:
+        metrics:
+          address: "[${env:MY_POD_IP}]:8888"
+
+opentelemetry-cluster-collector:
+  enabled: true
+  config:
+    extensions:
+      health_check:
+        endpoint: "[${env:MY_POD_IP}]:13133"
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: "[${env:MY_POD_IP}]:4317"
+          http:
+            endpoint: "[${env:MY_POD_IP}]:4318"
+      jaeger:
+        protocols:
+          grpc:
+            endpoint: "[${env:MY_POD_IP}]:14250"
+          thrift_http:
+            endpoint: "[${env:MY_POD_IP}]:14268"
+          thrift_compact:
+            endpoint: "[${env:MY_POD_IP}]:6831"
+          thrift_binary:
+            endpoint: "[${env:MY_POD_IP}]:6832"
+      zipkin:
+        endpoint: "[${env:MY_POD_IP}]:9411"
+
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: opentelemetry-infrastructure-collector
+              scrape_interval: 30s
+              static_configs:
+                - targets:
+                    - "[${env:MY_POD_IP}]:8888"
+    service:
+      telemetry:
+        metrics:
+          address: "[${env:MY_POD_IP}]:8888"
+

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "warn"
   collectionInterval: "30s"
-  version: "0.0.127"
+  version: "0.0.128"
 
   extensions:
     kubernetesDashboard:


### PR DESCRIPTION
# Description

Fixes ES-407

# How Has This Been Tested?

eks ipv6 cluster

# Checklist:
- [ ] I have updated the relevant Helm chart(s) version(s)
- [ ] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
