### PR TITLE
[otel-eks-fargate] Document how to use the fleet management feature

### DIFF
--- a/otel-eks-fargate/cx-eks-fargate-otel-self-monitoring.yaml
+++ b/otel-eks-fargate/cx-eks-fargate-otel-self-monitoring.yaml
@@ -19,6 +19,21 @@ data:
         observe_pods: true
         observe_nodes: true
       health_check:
+      # The OpAMP extension below enables the Coralogix fleet management server connection. 
+      # Uncomment them to enable and add the "opamp" extension to the list under `service.extensions`.
+      # opamp:
+      #   server:
+      #     http:
+      #       endpoint: "https://ingress.${env:CORALOGIX_DOMAIN}/opamp/v1"
+      #       polling_interval: 2m
+      #       headers:
+      #         Authorization: "Bearer ${env:CORALOGIX_PRIVATE_KEY}"
+      #   agent_description:
+      #     non_identifying_attributes:
+      #       cx.agent.type: "gateway"
+      #       cx.cluster.name: "${env:K8S_CLUSTER_NAME}"
+      #       cx.integrationID: "eks-fargate"
+      #       k8s.node.name: ${env:K8S_NODE_NAME}
 
     receivers:
       # Monitor just the missing OTEL collector's kubelet
@@ -88,7 +103,8 @@ data:
           processors: [resource/metadata, resourcedetection, batch]
           exporters: [coralogix]
 
-      extensions: [k8s_observer, health_check]
+      # When enabling the fleet management feature, add the "opamp" extension to the list below. 
+      extensions: [health_check, k8s_observer]
 
 ---
 

--- a/otel-eks-fargate/cx-eks-fargate-otel-self-monitoring.yaml
+++ b/otel-eks-fargate/cx-eks-fargate-otel-self-monitoring.yaml
@@ -76,8 +76,8 @@ data:
     exporters:
       coralogix:
         timeout: "30s"
-        private_key: "${CORALOGIX_PRIVATE_KEY}"
-        domain: "${CORALOGIX_DOMAIN}"
+        private_key: "${env:CORALOGIX_PRIVATE_KEY}"
+        domain: "${env:CORALOGIX_DOMAIN}"
         application_name_attributes:
         - "k8s.namespace.name" 
         - "service.namespace"
@@ -90,8 +90,8 @@ data:
         - "k8s.container.name"
         - "k8s.node.name"
         - "service.name"
-        application_name: "${CX_APPLICATION}"
-        subsystem_name: "${CX_SUBSYSTEM}"
+        application_name: "${env:CX_APPLICATION}"
+        subsystem_name: "${env:CX_SUBSYSTEM}"
 
       debug:
         verbosity: detailed

--- a/otel-eks-fargate/cx-eks-fargate-otel-self-monitoring.yaml
+++ b/otel-eks-fargate/cx-eks-fargate-otel-self-monitoring.yaml
@@ -40,6 +40,15 @@ data:
             rule: type == "k8s.node" && labels["OTEL-collector-node"] == "true"
     
     processors:
+      resource/metadata:
+        attributes:
+          - key: "k8s.cluster.name"
+            value: "${env:K8S_CLUSTER_NAME}"
+            action: upsert
+          - key: "k8s.node.name"
+            value: "${env:K8S_NODE_NAME}"
+            action: upsert
+    
       # add cluster name from env variable and EKS metadata
       resourcedetection:
         detectors: [env, system, eks]
@@ -76,7 +85,7 @@ data:
       pipelines:
         metrics/colmon:
           receivers: [receiver_creator]
-          processors: [resourcedetection, batch]
+          processors: [resource/metadata, resourcedetection, batch]
           exporters: [coralogix]
 
       extensions: [k8s_observer, health_check]
@@ -118,8 +127,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "ClusterName=fargate-lab"
+            - name: K8S_CLUSTER_NAME
+              value: "fargate-lab"
             - name: CORALOGIX_DOMAIN
               value: "coralogix.com"
             - name: CX_APPLICATION

--- a/otel-eks-fargate/cx-eks-fargate-otel.yaml
+++ b/otel-eks-fargate/cx-eks-fargate-otel.yaml
@@ -76,13 +76,28 @@ metadata:
     component: cx-otel-collector-config
 data:
   cx-otel-collector-config: |
-    extensions:
-      k8s_observer:
-        auth_type: serviceAccount
-        observe_pods: true
-        observe_nodes: true
+    extensions: 
       health_check:
-
+      k8s_observer:
+          auth_type: serviceAccount
+          observe_pods: true
+          observe_nodes: true
+      # The OpAMP extension below enables the Coralogix fleet management server connection. 
+      # Uncomment them to enable and add the "opamp" extension to the list under `service.extensions`.
+      # opamp:
+      #   server:
+      #     http:
+      #       endpoint: "https://ingress.${env:CORALOGIX_DOMAIN}/opamp/v1"
+      #       polling_interval: 2m
+      #       headers:
+      #         Authorization: "Bearer ${env:CORALOGIX_PRIVATE_KEY}"
+      #   agent_description:
+      #     non_identifying_attributes:
+      #       cx.agent.type: "gateway"
+      #       cx.cluster.name: "${env:K8S_CLUSTER_NAME}"
+      #       cx.integrationID: "eks-fargate"
+      #       k8s.node.name: ${env:K8S_NODE_NAME}
+    
     receivers:
       # Monitoring of OTEL performance metrics
       prometheus/self:
@@ -184,7 +199,8 @@ data:
           receivers: [receiver_creator]
           processors: [resource/metadata, resourcedetection, batch]
           exporters: [coralogix]
-
+   
+      # When enabling the fleet management feature, add the "opamp" extension to the list below. 
       extensions: [health_check, k8s_observer]
 
 # configure the service and the collector as a StatefulSet

--- a/otel-eks-fargate/cx-eks-fargate-otel.yaml
+++ b/otel-eks-fargate/cx-eks-fargate-otel.yaml
@@ -83,7 +83,7 @@ data:
           observe_pods: true
           observe_nodes: true
       # The OpAMP extension below enables the Coralogix fleet management server connection. 
-      # Uncomment them to enable and add the "opamp" extension to the list under `service.extensions`.
+      # Uncomment them to enable the feature and add the "opamp" extension to the list under `service.extensions`.
       # opamp:
       #   server:
       #     http:
@@ -199,11 +199,9 @@ data:
           receivers: [receiver_creator]
           processors: [resource/metadata, resourcedetection, batch]
           exporters: [coralogix]
-   
+    
       # When enabling the fleet management feature, add the "opamp" extension to the list below. 
       extensions: [health_check, k8s_observer]
-
-# configure the service and the collector as a StatefulSet
 ---
 apiVersion: v1
 kind: Service
@@ -222,8 +220,8 @@ spec:
   selector:
     component: cx-otel-collector
   type: ClusterIP
-
 ---
+# configure the service and the collector as a StatefulSet
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/otel-eks-fargate/cx-eks-fargate-otel.yaml
+++ b/otel-eks-fargate/cx-eks-fargate-otel.yaml
@@ -120,7 +120,16 @@ data:
             endpoint: 0.0.0.0:4318
     
     processors:
-      # add cluster name from env variable and EKS metadata
+      resource/metadata:
+        attributes:
+          - key: "k8s.cluster.name"
+            value: "${env:K8S_CLUSTER_NAME}"
+            action: upsert
+          - key: "k8s.node.name"
+            value: "${env:K8S_NODE_NAME}"
+            action: upsert
+    
+      # add EKS metadata
       resourcedetection:
         detectors: [env, system, eks]
         system:
@@ -161,19 +170,19 @@ data:
       pipelines:
         traces:
           receivers: [otlp]
-          processors: [resourcedetection, batch]
+          processors: [resource/metadata, resourcedetection, batch]
           exporters: [coralogix]
         metrics/otlp:
           receivers: [otlp]
-          processors: [resourcedetection, batch]
+          processors: [resource/metadata, resourcedetection, batch]
           exporters: [coralogix]
         metrics/self:
           receivers: [prometheus/self]
-          processors: [resourcedetection, batch]
+          processors: [resource/metadata, resourcedetection, batch]
           exporters: [prometheusremotewrite]
         metrics/kubeletstats:
           receivers: [receiver_creator]
-          processors: [resourcedetection, batch]
+          processors: [resource/metadata, resourcedetection, batch]
           exporters: [coralogix]
 
       extensions: [health_check, k8s_observer]
@@ -246,8 +255,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "ClusterName=fargate-lab"
+            - name: K8S_CLUSTER_NAME
+              value: "fargate-lab"
             - name: CORALOGIX_DOMAIN
               value: "coralogix.com"
             - name: CX_APPLICATION

--- a/otel-eks-fargate/cx-eks-fargate-otel.yaml
+++ b/otel-eks-fargate/cx-eks-fargate-otel.yaml
@@ -155,14 +155,14 @@ data:
 
     exporters:
       prometheusremotewrite:
-        endpoint: https://ingress.${CORALOGIX_DOMAIN}/prometheus/v1
+        endpoint: https://ingress.${env:CORALOGIX_DOMAIN}/prometheus/v1
         headers:
-          Authorization: "Bearer ${CORALOGIX_PRIVATE_KEY}"
+          Authorization: "Bearer ${env:CORALOGIX_PRIVATE_KEY}"
 
       coralogix:
         timeout: "30s"
-        private_key: "${CORALOGIX_PRIVATE_KEY}"
-        domain: "${CORALOGIX_DOMAIN}"
+        private_key: "${env:CORALOGIX_PRIVATE_KEY}"
+        domain: "${env:CORALOGIX_DOMAIN}"
         application_name_attributes:
         - "k8s.namespace.name" 
         - "service.namespace"
@@ -175,8 +175,8 @@ data:
         - "k8s.container.name"
         - "k8s.node.name"
         - "service.name"
-        application_name: "${CX_APPLICATION}"
-        subsystem_name: "${CX_SUBSYSTEM}"
+        application_name: "${env:CX_APPLICATION}"
+        subsystem_name: "${env:CX_SUBSYSTEM}"
 
       debug:
         verbosity: detailed


### PR DESCRIPTION
# Description

Fixes ES-299.

Document how to enable the fleet management feature in EKS Fargate.

# How Has This Been Tested?

Tested in an EKS Fargate-only cluster.

# Checklist:
- [ ] I have updated the relevant Helm chart(s) version(s)
- [ ] I have updated the relevant component changelog(s)
- [x] This change does not affect any particular component (e.g. it's CI or docs change)
