### PR TITLE
[otel-ecs-fargate] Document the fleet management feature in ECS Fargate

### DIFF
--- a/otel-ecs-fargate/README.md
+++ b/otel-ecs-fargate/README.md
@@ -6,7 +6,7 @@
 
 The OpenTelemetry collector offers a vendor-agnostic implementation of how to receive, process and export telemetry data.
 
-In this document, we'll explain how to add the OTEL collector as a sidecar agent to your ECS Task Definitions. We use the standard Opentelemetry Collector Contrib distribution but leverage the envprovider to generate the configuration from an AWS SSM Parameter Store. There is an example cloudformation template for review [here](https://github.com/coralogix/cloudformation-coralogix-aws/tree/master/aws-integrations/ecs-fargate)
+In this document, we'll explain how to add the OTEL collector as a sidecar agent to your ECS Task Definitions. We use the standard Opentelemetry Collector Contrib distribution but leverage the envprovider to generate the configuration from an AWS SSM Parameter Store. There is an example cloudformation template for review [here](https://github.com/coralogix/cloudformation-coralogix-aws/tree/master/aws-integrations/ecs-fargate)
 
 The envprovider is used for loading of the OpenTelemetry configuration via Systems Manager Parameter Stores. This makes adjusting your configuration more convenient and more dynamic than baking a static configuration into your container image.
 
@@ -91,6 +91,17 @@ In the example above, you'll need to set `<Coralogix PrivateKey>` and `<Coralogi
 ```
 
 After adding the above container to your existing Task Definition, your applications can submit their traces and metrics exports to http://localhost:4318/v1/traces and /v1/metrics. It will also collect container metrics from all containers in the Task Definition.
+
+## Connecting to Coralogix fleet management
+
+In the Parameter Store configuration you will find commented lines that explain and configure the OpAMP extension to connect to Coralogix fleet management server.
+Read them to learn which lines to uncomment to enable the feature. Do not forget that besides configuring the extension it has to be added to the list in the `service.extensions` key of the configuration file.
+
+> [!CAUTION]
+> Important security consideration when enabling this feature:
+> - Because this extension shares your Collector's configuration with the fleet management server, it's important to ensure that any secret contained in it is using the environment variable expansion syntax.
+> - The default capabilities of the OpAMP extension **do not** include remote configuration or packages.
+> - By default, the extension will pool the server every 2 minutes. Additional network requests might be made between the server and the Collector, depending on the configuration on both sides.
 
 ## Granting permissions for parameter store access
 

--- a/otel-ecs-fargate/README.md
+++ b/otel-ecs-fargate/README.md
@@ -92,17 +92,6 @@ In the example above, you'll need to set `<Coralogix PrivateKey>` and `<Coralogi
 
 After adding the above container to your existing Task Definition, your applications can submit their traces and metrics exports to http://localhost:4318/v1/traces and /v1/metrics. It will also collect container metrics from all containers in the Task Definition.
 
-## Connecting to Coralogix fleet management
-
-In the Parameter Store configuration you will find commented lines that explain and configure the OpAMP extension to connect to Coralogix fleet management server.
-Read them to learn which lines to uncomment to enable the feature. Do not forget that besides configuring the extension it has to be added to the list in the `service.extensions` key of the configuration file.
-
-> [!CAUTION]
-> Important security consideration when enabling this feature:
-> - Because this extension shares your Collector's configuration with the fleet management server, it's important to ensure that any secret contained in it is using the environment variable expansion syntax.
-> - The default capabilities of the OpAMP extension **do not** include remote configuration or packages.
-> - By default, the extension will pool the server every 2 minutes. Additional network requests might be made between the server and the Collector, depending on the configuration on both sides.
-
 ## Granting permissions for parameter store access
 
 In order to allow container access to the Systems Manager Parameter Store, you'll need to provide the ssm:GetParameters action permissions to the task execution role:

--- a/otel-ecs-fargate/parameter_store_cf.yaml
+++ b/otel-ecs-fargate/parameter_store_cf.yaml
@@ -47,14 +47,14 @@ Resources:
             application_name_attributes:
             - aws.ecs.task.family
             - service.namespace
-            domain: ${CORALOGIX_DOMAIN}
+            domain: ${env:CORALOGIX_DOMAIN}
             logs:
               headers:
                 X-Coralogix-Distribution: ecs-fargate-integration/0.0.1
             metrics:
               headers:
                 X-Coralogix-Distribution: ecs-fargate-integration/0.0.1
-            private_key: ${PRIVATE_KEY}
+            private_key: ${env:PRIVATE_KEY}
             subsystem_name: 'integration'
             subsystem_name_attributes:
             - service.name

--- a/otel-ecs-fargate/parameter_store_cf.yaml
+++ b/otel-ecs-fargate/parameter_store_cf.yaml
@@ -27,6 +27,20 @@ Resources:
       Description: Configuration parameter for Coralogix OTEL Collector
       Type: String
       Value: |
+        extensions:
+        # The OpAMP extension below enables the Coralogix fleet management server connection. 
+        # Uncomment them to enable the feature and add the "opamp" extension to the list under `service.extensions`.
+        # opamp:
+        #   server:
+        #     http:
+        #       endpoint: "https://ingress.${env:CORALOGIX_DOMAIN}/opamp/v1"
+        #       polling_interval: 2m
+        #       headers:
+        #         Authorization: "Bearer ${env:PRIVATE_KEY}"
+        #   agent_description:
+        #     non_identifying_attributes:
+        #       cx.agent.type: "agent"
+        #       cx.integrationID: "ecs-fargate"
         exporters:
           coralogix:
             application_name: 'otel'
@@ -118,6 +132,7 @@ Resources:
                 - targets:
                   - 127.0.0.1:8888
         service:
+          extensions: []
           pipelines:
             logs:
               exporters:


### PR DESCRIPTION
# Description

Fixes ES-299.

Document how to enable the fleet management feature in ECS Fargate.

# How Has This Been Tested?

Tested in an ECS Fargate cluster.

# Checklist:
- [ ] I have updated the relevant Helm chart(s) version(s)
- [ ] I have updated the relevant component changelog(s)
- [x] This change does not affect any particular component (e.g. it's CI or docs change)
