### PR TITLE
[otel-integration] Add more attributes to the pod association for the k8s attributes processor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .mdoxcache
 */ecs-ec2/ecsattributesprocessor/cmd*
 .DS_Store
+.idea
+.vscode

--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.129 / 2024-12-31
+
+- [Feat] Add k8s job name plus other pod association rules for the k8s metadata processor
+
 ### v0.0.128 / 2024-12-23
 
 - [Feat] add k8s ipv6 only support

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.128
+version: 0.0.129
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -11,27 +11,27 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.100.0"
+    version: "0.101.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-windows
-    version: "0.100.0"
+    version: "0.101.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-windows.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-cluster-collector
-    version: "0.100.0"
+    version: "0.101.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-cluster-collector.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-receiver
-    version: "0.100.0"
+    version: "0.101.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-receiver.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-gateway
-    version: "0.100.0"
+    version: "0.101.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-gateway.enabled
   - name: coralogix-ebpf-agent

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -275,6 +275,9 @@ opentelemetry-agent:
             - from: resource_attribute
               name: k8s.pod.uid
           - sources:
+            - from: resource_attribute
+              name: k8s.job.name
+          - sources:
             - from: connection
         filter:
           node_from_env_var: KUBE_NODE_NAME
@@ -516,6 +519,9 @@ opentelemetry-cluster-collector:
           - sources:
             - from: resource_attribute
               name: k8s.pod.uid
+          - sources:
+            - from: resource_attribute
+              name: k8s.job.name
           - sources:
               - from: connection
         extract:

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "warn"
   collectionInterval: "30s"
-  version: "0.0.128"
+  version: "0.0.129"
 
   extensions:
     kubernetesDashboard:

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -267,6 +267,15 @@ opentelemetry-agent:
               - delete_key(attributes, "service_instance_id") where resource.attributes["service.name"] == "opentelemetry-collector"
               - delete_key(attributes, "service_name") where resource.attributes["service.name"] == "opentelemetry-collector"
       k8sattributes:
+        pod_association:
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.ip
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.uid
+          - sources:
+            - from: connection
         filter:
           node_from_env_var: KUBE_NODE_NAME
         extract:
@@ -500,6 +509,15 @@ opentelemetry-cluster-collector:
         send_batch_max_size: 2048
         timeout: "1s"
       k8sattributes:
+        pod_association:
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.ip
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.uid
+          - sources:
+              - from: connection
         extract:
           metadata:
             - "k8s.namespace.name"

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -267,18 +267,6 @@ opentelemetry-agent:
               - delete_key(attributes, "service_instance_id") where resource.attributes["service.name"] == "opentelemetry-collector"
               - delete_key(attributes, "service_name") where resource.attributes["service.name"] == "opentelemetry-collector"
       k8sattributes:
-        pod_association:
-          - sources:
-            - from: resource_attribute
-              name: k8s.pod.ip
-          - sources:
-            - from: resource_attribute
-              name: k8s.pod.uid
-          - sources:
-            - from: resource_attribute
-              name: k8s.job.name
-          - sources:
-            - from: connection
         filter:
           node_from_env_var: KUBE_NODE_NAME
         extract:
@@ -512,18 +500,6 @@ opentelemetry-cluster-collector:
         send_batch_max_size: 2048
         timeout: "1s"
       k8sattributes:
-        pod_association:
-          - sources:
-            - from: resource_attribute
-              name: k8s.pod.ip
-          - sources:
-            - from: resource_attribute
-              name: k8s.pod.uid
-          - sources:
-            - from: resource_attribute
-              name: k8s.job.name
-          - sources:
-              - from: connection
         extract:
           metadata:
             - "k8s.namespace.name"


### PR DESCRIPTION
# Description

Fixes ES-401.

Bumps the Collector chart to bring in the extra attributes used for the pod association in the k8s attributes processor.

This should add things like CronJob attributes in Job metrics, among others.

# How Has This Been Tested?

Local kind cluster.

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
