### PR TITLE
[opentelemetry-integration] Narrow down metrics service host back to pod ip

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.130 / 2025-01-02
+
+- [Fix] Rollback the default host of the metrics telemetry service to the pod's IP. 
+  If you are using the OpenTelemetry Operator and the Collector CRD, please update 
+  the Operator to version `0.116.0` or later
+
 ### v0.0.129 / 2024-12-31
 
 - [Feat] Add k8s job name plus other pod association rules for the k8s metadata processor

--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### v0.0.130 / 2025-01-02
 
-- [Fix] Rollback the default host of the metrics telemetry service to the pod's IP. 
-  If you are using the OpenTelemetry Operator and the Collector CRD, please update 
+- [Fix] Rollback the default host of the metrics telemetry service to the pod's IP.
+  If you are using the OpenTelemetry Operator and the Collector CRD, please update
   the Operator to version `0.116.0` or later
 
 ### v0.0.129 / 2024-12-31

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.129
+version: 0.0.130
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -11,27 +11,27 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.101.0"
+    version: "0.102.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-windows
-    version: "0.101.0"
+    version: "0.102.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-windows.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-cluster-collector
-    version: "0.101.0"
+    version: "0.102.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-cluster-collector.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-receiver
-    version: "0.101.0"
+    version: "0.102.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-receiver.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-gateway
-    version: "0.101.0"
+    version: "0.102.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-gateway.enabled
   - name: coralogix-ebpf-agent

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "warn"
   collectionInterval: "30s"
-  version: "0.0.129"
+  version: "0.0.130"
 
   extensions:
     kubernetesDashboard:


### PR DESCRIPTION
# Description

Fixes ES-411.

Narrow down the metrics service host back to the pod ip after the original issue was solved upstream in the OpenTelemetry Operator since version v0.116.0.

# How Has This Been Tested?

Local kind cluster.

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
