### PR TITLE
[opentelemetry-integration] Bump OTEL Collector to version 0.117.0

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.134 / 2025-01-09
+
+- [Feat] Upgrade OpenTelemetry Collector to `0.117.0`
+
 ### v0.0.133 / 2025-01-09
 
 - [Feat] use v1 entity endpoint for resource catalog
@@ -240,7 +244,7 @@
 ### v0.0.78 / 2024-06-06
 
 - [FEAT] Bump Collector to 0.102.1
-- [FIX] Important: This version contains fix for cve-2024-36129. For more information see https://opentelemetry.io/blog/2024/cve-2024-36129/
+- [FIX] Important: This version contains fix for cve-2024-36129. For more information see <https://opentelemetry.io/blog/2024/cve-2024-36129/>
 
 ### v0.0.77 / 2024-06-05
 
@@ -397,7 +401,7 @@
 ### v0.0.44 / 2023-12-13
 
 - [CHORE] Update collector to `v0.91.0`.
-- [FEATURE] Remove memoryballast and enable GOMEMLIMIT instead. This should significantly reduce memory footprint. See https://github.com/open-telemetry/opentelemetry-helm-charts/issues/891.
+- [FEATURE] Remove memoryballast and enable GOMEMLIMIT instead. This should significantly reduce memory footprint. See <https://github.com/open-telemetry/opentelemetry-helm-charts/issues/891>.
 
 ### v0.0.43 / 2023-12-12
 
@@ -427,53 +431,69 @@
 - [FIX] Kubelet Stats use Node IP instead of Node name.
 
 ### v0.0.37 / 2023-11-27
+
 - [:warning: BREAKING CHANGE] [FEATURE] Add support for span metrics preset. This replaces the deprecated `spanmetricsprocessor` with `spanmetricsconnector`. The new connector is disabled by default, as opposed the replaces processor. To enable it, set `presets.spanMetrics.enabled` to `true`.
 
 ### v0.0.36 / 2023-11-15
+
 - [FIX] Change statsd receiver port to 8125 instead of 8127
 
 ### v0.0.35 / 2023-11-14
+
 - [FEATURE] Adds statsd receiver to listen for metrics on 8125 port.
 
 ### v0.0.34 / 2023-11-13
+
 - [FIX] Remove Kube-State-Metrics receive_creator, which generated unnecessary configuration.
 
 ### v0.0.33 / 2023-11-08
+
 - [FIX] Remove Kube-State-Metrics, as K8s Cluster Receiver provides all the needed metrics.
 
 ### v0.0.32 / 2023-11-03
+
 - [FIX] Ensure correct order of processors for k8s deployment attributes.
 
 ### v0.0.31 / 2023-11-03
+
 - [FIX] Fix scraping Kube State Metrics
 - [CHORE] Update Collector to 0.88.0 (v0.76.0)
 - [FIX] Fix consistent k8s.deployment.name attribute
 
 ### v0.0.30 / 2023-10-31
+
 - [FEATURE] Add support for defining priority class
 
 ### v0.0.29 / 2023-10-31
+
 - [FIX] Fix support for openshift
 
 ### v0.0.28 / 2023-10-30
+
 - [CHORE] Update Collector to 0.87.0 (v0.75.0)
 
 ### v0.0.27 / 2023-10-30
+
 - [CHORE] Update Collector to 0.86.0 (v0.74.0)
 
 ### v0.0.26 / 2023-10-30
+
 - [CHORE] Upgrading upstream chart. (v0.73.7)
 
 ### v0.0.25 / 2023-10-26
+
 - [CHORE] Remove unnecessary cloud resource detector configuration.
 
 ### v0.0.24 / 2023-10-26
+
 - [FIX] service::pipelines::logs: references exporter "k8sattributes" which is not configured
 
 ### v0.0.23 / 2023-10-26
+
 - [FEATURE] Add k8sattributes and resourcedetecion processor for logs and traces in agent.
 
 ### v0.0.22 / 2023-10-24
+
 - [FEATURE] Add support for Windows node agent
 
 ### v0.0.21 / 2023-10-11

--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -244,7 +244,7 @@
 ### v0.0.78 / 2024-06-06
 
 - [FEAT] Bump Collector to 0.102.1
-- [FIX] Important: This version contains fix for cve-2024-36129. For more information see <https://opentelemetry.io/blog/2024/cve-2024-36129/>
+- [FIX] Important: This version contains fix for cve-2024-36129. For more information see https://opentelemetry.io/blog/2024/cve-2024-36129/
 
 ### v0.0.77 / 2024-06-05
 
@@ -401,7 +401,7 @@
 ### v0.0.44 / 2023-12-13
 
 - [CHORE] Update collector to `v0.91.0`.
-- [FEATURE] Remove memoryballast and enable GOMEMLIMIT instead. This should significantly reduce memory footprint. See <https://github.com/open-telemetry/opentelemetry-helm-charts/issues/891>.
+- [FEATURE] Remove memoryballast and enable GOMEMLIMIT instead. This should significantly reduce memory footprint. See https://github.com/open-telemetry/opentelemetry-helm-charts/issues/891.
 
 ### v0.0.43 / 2023-12-12
 
@@ -431,69 +431,53 @@
 - [FIX] Kubelet Stats use Node IP instead of Node name.
 
 ### v0.0.37 / 2023-11-27
-
 - [:warning: BREAKING CHANGE] [FEATURE] Add support for span metrics preset. This replaces the deprecated `spanmetricsprocessor` with `spanmetricsconnector`. The new connector is disabled by default, as opposed the replaces processor. To enable it, set `presets.spanMetrics.enabled` to `true`.
 
 ### v0.0.36 / 2023-11-15
-
 - [FIX] Change statsd receiver port to 8125 instead of 8127
 
 ### v0.0.35 / 2023-11-14
-
 - [FEATURE] Adds statsd receiver to listen for metrics on 8125 port.
 
 ### v0.0.34 / 2023-11-13
-
 - [FIX] Remove Kube-State-Metrics receive_creator, which generated unnecessary configuration.
 
 ### v0.0.33 / 2023-11-08
-
 - [FIX] Remove Kube-State-Metrics, as K8s Cluster Receiver provides all the needed metrics.
 
 ### v0.0.32 / 2023-11-03
-
 - [FIX] Ensure correct order of processors for k8s deployment attributes.
 
 ### v0.0.31 / 2023-11-03
-
 - [FIX] Fix scraping Kube State Metrics
 - [CHORE] Update Collector to 0.88.0 (v0.76.0)
 - [FIX] Fix consistent k8s.deployment.name attribute
 
 ### v0.0.30 / 2023-10-31
-
 - [FEATURE] Add support for defining priority class
 
 ### v0.0.29 / 2023-10-31
-
 - [FIX] Fix support for openshift
 
 ### v0.0.28 / 2023-10-30
-
 - [CHORE] Update Collector to 0.87.0 (v0.75.0)
 
 ### v0.0.27 / 2023-10-30
-
 - [CHORE] Update Collector to 0.86.0 (v0.74.0)
 
 ### v0.0.26 / 2023-10-30
-
 - [CHORE] Upgrading upstream chart. (v0.73.7)
 
 ### v0.0.25 / 2023-10-26
-
 - [CHORE] Remove unnecessary cloud resource detector configuration.
 
 ### v0.0.24 / 2023-10-26
-
 - [FIX] service::pipelines::logs: references exporter "k8sattributes" which is not configured
 
 ### v0.0.23 / 2023-10-26
-
 - [FEATURE] Add k8sattributes and resourcedetecion processor for logs and traces in agent.
 
 ### v0.0.22 / 2023-10-24
-
 - [FEATURE] Add support for Windows node agent
 
 ### v0.0.21 / 2023-10-11

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -36,7 +36,7 @@ dependencies:
     condition: opentelemetry-gateway.enabled
   - name: coralogix-ebpf-agent
     alias: coralogix-ebpf-agent
-    version: "0.105.0"
+    version: "0.1.7"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts
     condition: coralogix-ebpf-agent.enabled
 sources:

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.133
+version: 0.0.134
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -11,32 +11,32 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.104.1"
+    version: "0.105.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-windows
-    version: "0.104.1"
+    version: "0.105.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-windows.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-cluster-collector
-    version: "0.104.1"
+    version: "0.105.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-cluster-collector.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-receiver
-    version: "0.104.1"
+    version: "0.105.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-receiver.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-gateway
-    version: "0.104.1"
+    version: "0.105.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-gateway.enabled
   - name: coralogix-ebpf-agent
     alias: coralogix-ebpf-agent
-    version: "0.1.7"
+    version: "0.105.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts
     condition: coralogix-ebpf-agent.enabled
 sources:

--- a/otel-integration/k8s-helm/e2e-test/expected_test.go
+++ b/otel-integration/k8s-helm/e2e-test/expected_test.go
@@ -5,7 +5,7 @@ var expectedResourceMetricsSchemaURL = map[string]bool{
 	"https://opentelemetry.io/schemas/1.9.0": false,
 }
 
-const expectedScopeVersion = "0.116.0"
+const expectedScopeVersion = "0.117.0"
 
 var expectedResourceScopeNames = map[string]bool{
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/cpuscraper":        false,

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "warn"
   collectionInterval: "30s"
-  version: "0.0.133"
+  version: "0.0.134"
 
   extensions:
     kubernetesDashboard:
@@ -197,7 +197,7 @@ opentelemetry-agent:
     # This reduces target_info cardinality.
     reduceResourceAttributes:
       enabled: false
-     # Configures Host Metrics receiver to collect Entity Events.
+      # Configures Host Metrics receiver to collect Entity Events.
     hostEntityEvents:
       enabled: false
   config:
@@ -721,15 +721,15 @@ opentelemetry-gateway:
     clusterRoleBinding:
       name: "coralogix-opentelemetry-gateway"
     rules:
-    - apiGroups: [""]
-      resources: ["pods", "namespaces"]
-      verbs: ["get", "watch", "list"]
-    - apiGroups: ["apps"]
-      resources: ["replicasets"]
-      verbs: ["get", "list", "watch"]
-    - apiGroups: ["extensions"]
-      resources: ["replicasets"]
-      verbs: ["get", "list", "watch"]
+      - apiGroups: [""]
+        resources: ["pods", "namespaces"]
+        verbs: ["get", "watch", "list"]
+      - apiGroups: ["apps"]
+        resources: ["replicasets"]
+        verbs: ["get", "list", "watch"]
+      - apiGroups: ["extensions"]
+        resources: ["replicasets"]
+        verbs: ["get", "list", "watch"]
   extraEnvs:
     - name: CORALOGIX_PRIVATE_KEY
       valueFrom:
@@ -790,11 +790,11 @@ opentelemetry-gateway:
       # needed for self-monitored otel colector metrics
       transform/k8s_attributes:
         metric_statements:
-        - context: resource
-          statements:
-          - set(attributes["k8s.deployment.name"], attributes["k8s.replicaset.name"])
-          - replace_pattern(attributes["k8s.deployment.name"], "^(.*)-[0-9a-zA-Z]+$", "$$1") where attributes["k8s.replicaset.name"] != nil
-          - delete_key(attributes, "k8s.replicaset.name")
+          - context: resource
+            statements:
+              - set(attributes["k8s.deployment.name"], attributes["k8s.replicaset.name"])
+              - replace_pattern(attributes["k8s.deployment.name"], "^(.*)-[0-9a-zA-Z]+$", "$$1") where attributes["k8s.replicaset.name"] != nil
+              - delete_key(attributes, "k8s.replicaset.name")
       k8sattributes:
         filter:
           node_from_env_var: KUBE_NODE_NAME
@@ -914,15 +914,15 @@ opentelemetry-receiver:
     clusterRoleBinding:
       name: "coralogix-opentelemetry-receiver"
     rules:
-    - apiGroups: [""]
-      resources: ["pods", "namespaces"]
-      verbs: ["get", "watch", "list"]
-    - apiGroups: ["apps"]
-      resources: ["replicasets"]
-      verbs: ["get", "list", "watch"]
-    - apiGroups: ["extensions"]
-      resources: ["replicasets"]
-      verbs: ["get", "list", "watch"]
+      - apiGroups: [""]
+        resources: ["pods", "namespaces"]
+        verbs: ["get", "watch", "list"]
+      - apiGroups: ["apps"]
+        resources: ["replicasets"]
+        verbs: ["get", "list", "watch"]
+      - apiGroups: ["extensions"]
+        resources: ["replicasets"]
+        verbs: ["get", "list", "watch"]
   extraEnvs:
     - name: CORALOGIX_PRIVATE_KEY
       valueFrom:
@@ -983,11 +983,11 @@ opentelemetry-receiver:
       # needed for self-monitored otel colector metrics
       transform/k8s_attributes:
         metric_statements:
-        - context: resource
-          statements:
-          - set(attributes["k8s.deployment.name"], attributes["k8s.replicaset.name"])
-          - replace_pattern(attributes["k8s.deployment.name"], "^(.*)-[0-9a-zA-Z]+$", "$$1") where attributes["k8s.replicaset.name"] != nil
-          - delete_key(attributes, "k8s.replicaset.name")
+          - context: resource
+            statements:
+              - set(attributes["k8s.deployment.name"], attributes["k8s.replicaset.name"])
+              - replace_pattern(attributes["k8s.deployment.name"], "^(.*)-[0-9a-zA-Z]+$", "$$1") where attributes["k8s.replicaset.name"] != nil
+              - delete_key(attributes, "k8s.replicaset.name")
       k8sattributes:
         filter:
           node_from_env_var: KUBE_NODE_NAME
@@ -1123,7 +1123,7 @@ coralogix-ebpf-agent:
         max_concurrent_exports: 3
       sampler:
         services_filter: []
-        services_filter_type: "Allow"  # Deny for blacklist
+        services_filter_type: "Allow" # Deny for blacklist
     resources:
       limits:
         cpu: "1"

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -1123,7 +1123,7 @@ coralogix-ebpf-agent:
         max_concurrent_exports: 3
       sampler:
         services_filter: []
-        services_filter_type: "Allow" # Deny for blacklist
+        services_filter_type: "Allow"  # Deny for blacklist
     resources:
       limits:
         cpu: "1"

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -197,7 +197,7 @@ opentelemetry-agent:
     # This reduces target_info cardinality.
     reduceResourceAttributes:
       enabled: false
-      # Configures Host Metrics receiver to collect Entity Events.
+     # Configures Host Metrics receiver to collect Entity Events.
     hostEntityEvents:
       enabled: false
   config:
@@ -721,15 +721,15 @@ opentelemetry-gateway:
     clusterRoleBinding:
       name: "coralogix-opentelemetry-gateway"
     rules:
-      - apiGroups: [""]
-        resources: ["pods", "namespaces"]
-        verbs: ["get", "watch", "list"]
-      - apiGroups: ["apps"]
-        resources: ["replicasets"]
-        verbs: ["get", "list", "watch"]
-      - apiGroups: ["extensions"]
-        resources: ["replicasets"]
-        verbs: ["get", "list", "watch"]
+    - apiGroups: [""]
+      resources: ["pods", "namespaces"]
+      verbs: ["get", "watch", "list"]
+    - apiGroups: ["apps"]
+      resources: ["replicasets"]
+      verbs: ["get", "list", "watch"]
+    - apiGroups: ["extensions"]
+      resources: ["replicasets"]
+      verbs: ["get", "list", "watch"]
   extraEnvs:
     - name: CORALOGIX_PRIVATE_KEY
       valueFrom:
@@ -790,11 +790,11 @@ opentelemetry-gateway:
       # needed for self-monitored otel colector metrics
       transform/k8s_attributes:
         metric_statements:
-          - context: resource
-            statements:
-              - set(attributes["k8s.deployment.name"], attributes["k8s.replicaset.name"])
-              - replace_pattern(attributes["k8s.deployment.name"], "^(.*)-[0-9a-zA-Z]+$", "$$1") where attributes["k8s.replicaset.name"] != nil
-              - delete_key(attributes, "k8s.replicaset.name")
+        - context: resource
+          statements:
+          - set(attributes["k8s.deployment.name"], attributes["k8s.replicaset.name"])
+          - replace_pattern(attributes["k8s.deployment.name"], "^(.*)-[0-9a-zA-Z]+$", "$$1") where attributes["k8s.replicaset.name"] != nil
+          - delete_key(attributes, "k8s.replicaset.name")
       k8sattributes:
         filter:
           node_from_env_var: KUBE_NODE_NAME
@@ -914,15 +914,15 @@ opentelemetry-receiver:
     clusterRoleBinding:
       name: "coralogix-opentelemetry-receiver"
     rules:
-      - apiGroups: [""]
-        resources: ["pods", "namespaces"]
-        verbs: ["get", "watch", "list"]
-      - apiGroups: ["apps"]
-        resources: ["replicasets"]
-        verbs: ["get", "list", "watch"]
-      - apiGroups: ["extensions"]
-        resources: ["replicasets"]
-        verbs: ["get", "list", "watch"]
+    - apiGroups: [""]
+      resources: ["pods", "namespaces"]
+      verbs: ["get", "watch", "list"]
+    - apiGroups: ["apps"]
+      resources: ["replicasets"]
+      verbs: ["get", "list", "watch"]
+    - apiGroups: ["extensions"]
+      resources: ["replicasets"]
+      verbs: ["get", "list", "watch"]
   extraEnvs:
     - name: CORALOGIX_PRIVATE_KEY
       valueFrom:
@@ -983,11 +983,11 @@ opentelemetry-receiver:
       # needed for self-monitored otel colector metrics
       transform/k8s_attributes:
         metric_statements:
-          - context: resource
-            statements:
-              - set(attributes["k8s.deployment.name"], attributes["k8s.replicaset.name"])
-              - replace_pattern(attributes["k8s.deployment.name"], "^(.*)-[0-9a-zA-Z]+$", "$$1") where attributes["k8s.replicaset.name"] != nil
-              - delete_key(attributes, "k8s.replicaset.name")
+        - context: resource
+          statements:
+          - set(attributes["k8s.deployment.name"], attributes["k8s.replicaset.name"])
+          - replace_pattern(attributes["k8s.deployment.name"], "^(.*)-[0-9a-zA-Z]+$", "$$1") where attributes["k8s.replicaset.name"] != nil
+          - delete_key(attributes, "k8s.replicaset.name")
       k8sattributes:
         filter:
           node_from_env_var: KUBE_NODE_NAME


### PR DESCRIPTION
# Description

Fixes ES-408.

# How Has This Been Tested?

EKS with Windows and Linux nodes.

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
