### PR TITLE
[opentelemetry-integration] Fix missing `source_identifier` in multiline configs

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## OpenTelemtry-Integration
 
-### v0.0.131 / 2025-01-14
+### v0.0.136 / 2025-01-14
 
 - [Fix] Add missing `source_identifier` to `presets.logsCollection.multilineConfigs`
 

--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.131 / 2025-01-14
+
+- [Fix] Add missing `source_identifier` to `presets.logsCollection.multilineConfigs`
+
 ### v0.0.135 / 2025-01-09
 
 - [Feat] Bump Windows 2019 image to the latest LTSC image for such version

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.135
+version: 0.0.136
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -11,27 +11,27 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.105.0"
+    version: "0.105.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-windows
-    version: "0.105.0"
+    version: "0.105.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-windows.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-cluster-collector
-    version: "0.105.0"
+    version: "0.105.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-cluster-collector.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-receiver
-    version: "0.105.0"
+    version: "0.105.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-receiver.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-gateway
-    version: "0.105.0"
+    version: "0.105.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-gateway.enabled
   - name: coralogix-ebpf-agent

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "warn"
   collectionInterval: "30s"
-  version: "0.0.135"
+  version: "0.0.136"
 
   extensions:
     kubernetesDashboard:


### PR DESCRIPTION
# Description

Fixes ES-304.

This adds the missing `source_identifier` configuration to recombines passed to the integration through `presets.logsCollection.multilineConfigs`.

# How Has This Been Tested?

Local kind cluster.

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
