### PR TITLE
[opentelemetry-integration] Add a startup probe to the cluster collector

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.139 / 2025-02-03
+
+- [Feat] Add a startup probe to the cluster collector.
+
 ### v0.0.138 / 2025-01-31
 
 - [Feat] Add extraConfig to allow adding extra processors, receivers, exporters, and connectors to the collector.

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.138
+version: 0.0.139
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -11,27 +11,27 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.105.2"
+    version: "0.105.3"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-windows
-    version: "0.105.2"
+    version: "0.105.3"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-windows.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-cluster-collector
-    version: "0.105.2"
+    version: "0.105.3"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-cluster-collector.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-receiver
-    version: "0.105.2"
+    version: "0.105.3"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-receiver.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-gateway
-    version: "0.105.2"
+    version: "0.105.3"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-gateway.enabled
   - name: coralogix-ebpf-agent

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "warn"
   collectionInterval: "30s"
-  version: "0.0.138"
+  version: "0.0.139"
 
   extensions:
     kubernetesDashboard:
@@ -743,6 +743,14 @@ opentelemetry-cluster-collector:
   tolerations:
     - operator: Exists
 
+  startupProbe:
+    failureThreshold: 3
+    initialDelaySeconds: 15
+    periodSeconds: 15
+    httpGet:
+      port: 13133
+      scheme: HTTP
+  
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
# Description

Fixes #430.

Adds a startup probe to the cluster collector. According to my tests, this should allow it to start without any issues even on a resource-constrained machine/system.

# How Has This Been Tested?

Successfully tested this on my k3s cluster running on a Raspberry Pi 4.

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
