### PR TITLE
[opentelemetry-integration] Prioritize memory limiter processor in all pipelines

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.140 / 2025-02-04
+
+- [Fix] Prioritize memory limiter processor in all pipelines.
+
 ### v0.0.139 / 2025-02-03
 
 - [Feat] Add a startup probe to the cluster collector.

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -11,27 +11,27 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.106.0"
+    version: "0.106.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-windows
-    version: "0.106.0"
+    version: "0.106.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-windows.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-cluster-collector
-    version: "0.106.0"
+    version: "0.106.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-cluster-collector.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-receiver
-    version: "0.106.0"
+    version: "0.106.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-receiver.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-gateway
-    version: "0.106.0"
+    version: "0.106.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-gateway.enabled
   - name: coralogix-ebpf-agent

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.139
+version: 0.0.140
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "warn"
   collectionInterval: "30s"
-  version: "0.0.139"
+  version: "0.0.140"
 
   extensions:
     kubernetesDashboard:
@@ -362,11 +362,11 @@ opentelemetry-agent:
           exporters:
             - coralogix
           processors:
+            - memory_limiter
             - transform/prometheus
             - k8sattributes
             - resourcedetection/env
             - resourcedetection/region
-            - memory_limiter
             - batch
           receivers:
             - otlp
@@ -376,10 +376,10 @@ opentelemetry-agent:
           exporters:
             - coralogix
           processors:
+            - memory_limiter
             - k8sattributes
             - resourcedetection/env
             - resourcedetection/region
-            - memory_limiter
             - batch
           receivers:
             - otlp
@@ -720,21 +720,21 @@ opentelemetry-cluster-collector:
           exporters:
             - coralogix
           processors:
+            - memory_limiter
             - resource/kube-events
             - transform/kube-events
-            - memory_limiter
             - batch
         metrics:
           exporters:
             - coralogix
           processors:
+            - memory_limiter
             - transform/prometheus
             - k8sattributes
             - metricstransform/k8s-dashboard
             - transform/k8s-dashboard
             - resourcedetection/env
             - resourcedetection/region
-            - memory_limiter
             - batch
           receivers:
             - otlp
@@ -981,12 +981,12 @@ opentelemetry-gateway:
           exporters:
             - coralogix
           processors:
+            - memory_limiter
             - transform/prometheus
             - k8sattributes
             - transform/k8s_attributes
             - resourcedetection/env
             - resourcedetection/region
-            - memory_limiter
             - batch
           receivers:
             - prometheus
@@ -1174,12 +1174,12 @@ opentelemetry-receiver:
           exporters:
             - coralogix
           processors:
+            - memory_limiter
             - transform/prometheus
             - k8sattributes
             - transform/k8s_attributes
             - resourcedetection/env
             - resourcedetection/region
-            - memory_limiter
             - batch
           receivers:
             - prometheus


### PR DESCRIPTION
# Description

Fixes ES-319.

Moves the memory limiter processor to the top of all the pipelines in which it is present. This is the recommended best practice according to the [processor's documentation](https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiterprocessor/README.md#best-practices).

# How Has This Been Tested?

Tested locally in a `kind` cluster.

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
