### PR TITLE
[opentelemetry-integration] Fix typo in README

### DIFF
--- a/otel-integration/k8s-helm/README.md
+++ b/otel-integration/k8s-helm/README.md
@@ -637,7 +637,7 @@ To do that, you can add the configuration below for transform statements that wi
 
 ```yaml
     spanMetrics:
-      enabled: false
+      enabled: true
       transformStatements:
       - set(attributes["db.namespace"], attributes["db.name"]) where attributes["db.namespace"] == nil
       - set(attributes["db.namespace"], attributes["server.address"]) where attributes["db.namespace"] == nil


### PR DESCRIPTION
# Description

Fix a small typo in the README for semantic convention migration.

# How Has This Been Tested?

N/A.

# Checklist:
- [ ] I have updated the relevant Helm chart(s) version(s)
- [ ] I have updated the relevant component changelog(s)
- [x] This change does not affect any particular component (e.g. it's CI or docs change)
