### PR TITLE
[otel-integration] Update opentelemetry collector v0.119.0

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.149 / 2025-02-27
+
+- [Feat] Upgrade OpenTelemetry Collector to `0.119.0`
+
 ### v0.0.148 / 2025-02-20
 
 - [Fix] Filter only Pods from standard kubernetes workloads in kubernetesResource presets.

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.148
+version: 0.0.149
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -11,27 +11,27 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.106.4"
+    version: "0.107.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-windows
-    version: "0.106.4"
+    version: "0.107.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-windows.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-cluster-collector
-    version: "0.106.4"
+    version: "0.107.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-cluster-collector.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-receiver
-    version: "0.106.4"
+    version: "0.107.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-receiver.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-gateway
-    version: "0.106.4"
+    version: "0.107.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-gateway.enabled
   - name: coralogix-ebpf-agent

--- a/otel-integration/k8s-helm/e2e-test/expected_test.go
+++ b/otel-integration/k8s-helm/e2e-test/expected_test.go
@@ -5,7 +5,7 @@ var expectedResourceMetricsSchemaURL = map[string]bool{
 	"https://opentelemetry.io/schemas/1.9.0": false,
 }
 
-const expectedScopeVersion = "0.118.0"
+const expectedScopeVersion = ""
 
 var expectedResourceScopeNames = map[string]bool{
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/cpuscraper":        false,
@@ -17,6 +17,16 @@ var expectedResourceScopeNames = map[string]bool{
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper":    false,
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver":                                   false,
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver":                                     false,
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer":                                         false,
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor":                                false,
+
+	"go.opentelemetry.io/collector/exporter/exporterhelper":          false,
+	"go.opentelemetry.io/collector/processor/batchprocessor":         false,
+	"go.opentelemetry.io/collector/receiver/receiverhelper":          false,
+	"go.opentelemetry.io/collector/processor/memorylimiterprocessor": false,
+	"go.opentelemetry.io/collector/processor/processorhelper":        false,
+	"go.opentelemetry.io/collector/scraper/scraperhelper":            false,
+	"go.opentelemetry.io/collector/service":                          false,
 }
 
 var unwantedScopeNames = map[string]struct{}{
@@ -72,6 +82,87 @@ var expectedResourceAttributesHostmetricsreceiver = map[string]string{
 	"process.pid":              "",
 }
 
+var expectedResourceAttributesK8sattributesprocessor = map[string]string{
+	"service.name":             "",
+	"net.host.name":            "",
+	"server.address":           "",
+	"k8s.pod.ip":               "",
+	"net.host.port":            "",
+	"http.scheme":              "",
+	"server.port":              "",
+	"url.scheme":               "",
+	"cx_agent_type":            "",
+	"k8s_node_name":            "",
+	"service_instance_id":      "",
+	"cx.otel_integration.name": "coralogix-integration-helm",
+	"service_version":          "",
+	"k8s.cluster.name":         "otel-integration-agent-e2e",
+	"k8s.pod.name":             "",
+	"k8s.namespace.name":       "",
+	"k8s.daemonset.name":       "",
+	"k8s.node.name":            "otel-integration-agent-e2e-control-plane",
+	"host.name":                "",
+	"os.type":                  "linux",
+	"host.id":                  "",
+	"cloud.provider":           "azure",
+	"cloud.platform":           "azure_vm",
+	"cloud.region":             "",
+	"cloud.account.id":         "",
+	"azure.vm.name":            "",
+	"azure.vm.size":            "",
+	"azure.vm.scaleset.name":   "",
+	"azure.resourcegroup.name": "",
+}
+
+var expectedResourceAttributesMemorylimiterprocessor = map[string]string{
+	"service.name":             "opentelemetry-collector",
+	"net.host.name":            "",
+	"server.address":           "",
+	"k8s.pod.ip":               "",
+	"net.host.port":            "",
+	"http.scheme":              "http",
+	"server.port":              "",
+	"url.scheme":               "",
+	"cx_agent_type":            "",
+	"k8s_node_name":            "",
+	"service_instance_id":      "",
+	"cx.otel_integration.name": "coralogix-integration-helm",
+	"service_version":          expectedScopeVersion,
+	"k8s.cluster.name":         "otel-integration-agent-e2e",
+	"k8s.pod.name":             "",
+	"k8s.namespace.name":       "",
+	"k8s.daemonset.name":       "",
+	"k8s.node.name":            "otel-integration-agent-e2e-control-plane",
+	"host.name":                "",
+	"os.type":                  "linux",
+	"host.id":                  "",
+	"cloud.provider":           "azure",
+	"cloud.platform":           "azure_vm",
+	"cloud.region":             "",
+	"cloud.account.id":         "",
+	"azure.vm.name":            "",
+	"azure.vm.size":            "",
+	"azure.vm.scaleset.name":   "",
+	"azure.resourcegroup.name": "",
+}
+
+var expectedResourceAttributesLoadscraper = map[string]string{
+	"k8s.cluster.name":         "otel-integration-agent-e2e",
+	"cx.otel_integration.name": "coralogix-integration-helm",
+	"host.name":                "",
+	"os.type":                  "linux",
+	"host.id":                  "",
+	"k8s.node.name":            "otel-integration-agent-e2e-control-plane",
+	"cloud.provider":           "azure",
+	"cloud.platform":           "azure_vm",
+	"cloud.region":             "",
+	"cloud.account.id":         "",
+	"azure.vm.name":            "",
+	"azure.vm.size":            "",
+	"azure.vm.scaleset.name":   "",
+	"azure.resourcegroup.name": "",
+}
+
 var expectedResourceAttributesPrometheusreceiver = map[string]string{
 	"azure.resourcegroup.name": "",
 	"azure.vm.name":            "",
@@ -104,6 +195,29 @@ var expectedResourceAttributesPrometheusreceiver = map[string]string{
 	"url.scheme":               "",
 	"cx_agent_type":            "",
 	"service_instance_id":      "",
+}
+
+var expectedResourceAttributesProcessscraper = map[string]string{
+	"process.pid":              "",
+	"process.parent_pid":       "",
+	"process.executable.name":  "",
+	"process.executable.path":  "",
+	"process.command":          "",
+	"process.command_line":     "",
+	"k8s.cluster.name":         "otel-integration-agent-e2e",
+	"cx.otel_integration.name": "coralogix-integration-helm",
+	"host.name":                "",
+	"os.type":                  "linux",
+	"host.id":                  "",
+	"k8s.node.name":            "otel-integration-agent-e2e-control-plane",
+	"cloud.provider":           "azure",
+	"cloud.platform":           "azure_vm",
+	"cloud.region":             "",
+	"cloud.account.id":         "",
+	"azure.vm.name":            "",
+	"azure.vm.size":            "",
+	"azure.vm.scaleset.name":   "",
+	"azure.resourcegroup.name": "",
 }
 
 var expectedMetrics map[string]bool = map[string]bool{
@@ -152,18 +266,12 @@ var expectedMetrics map[string]bool = map[string]bool{
 	"otelcol_exporter_sent_log_records":               false,
 	"otelcol_exporter_sent_metric_points":             false,
 	"otelcol_exporter_sent_spans":                     false,
-	"otelcol_fileconsumer_open_files":                 false,
-	"otelcol_fileconsumer_reading_files":              false,
-	"otelcol_otelsvc_k8s_ip_lookup_miss":              false,
-	"otelcol_otelsvc_k8s_pod_added":                   false,
-	"otelcol_otelsvc_k8s_pod_table_size":              false,
-	"otelcol_otelsvc_k8s_pod_updated":                 false,
 	"otelcol_process_cpu_seconds":                     false,
-	"otelcol_process_memory_rss":                      false,
+	"otelcol_process_memory_rss_bytes":                false,
 	"otelcol_process_runtime_heap_alloc_bytes":        false,
 	"otelcol_process_runtime_total_alloc_bytes":       false,
 	"otelcol_process_runtime_total_sys_memory_bytes":  false,
-	"otelcol_process_uptime":                          false,
+	"otelcol_process_uptime_seconds":                  false,
 	"otelcol_processor_accepted_metric_points":        false,
 	"otelcol_processor_accepted_log_records":          false,
 	"otelcol_processor_accepted_spans":                false,
@@ -214,6 +322,13 @@ var expectedMetrics map[string]bool = map[string]bool{
 	"system.network.io":                               false,
 	"system.network.packets":                          false,
 	"up":                                              false,
+	"promhttp_metric_handler_errors":                  false,
+	"otelcol_fileconsumer_open_files_ratio":           false,
+	"otelcol_fileconsumer_reading_files_ratio":        false,
+	"otelcol_otelsvc_k8s_ip_lookup_miss_ratio":        false,
+	"otelcol_otelsvc_k8s_pod_added_ratio":             false,
+	"otelcol_otelsvc_k8s_pod_table_size_ratio":        false,
+	"otelcol_otelsvc_k8s_pod_updated_ratio":           false,
 }
 
 var expectedTracesSchemaURL = map[string]bool{

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "warn"
   collectionInterval: "30s"
-  version: "0.0.148"
+  version: "0.0.149"
 
   extensions:
     kubernetesDashboard:
@@ -292,6 +292,9 @@ opentelemetry-agent:
       transform/prometheus:
         error_mode: ignore
         metric_statements:
+          - context: metric
+            statements:
+              - replace_pattern(name, "_total$", "")
           - context: resource
             statements:
               - set(attributes["k8s.pod.ip"], attributes["net.host.name"]) where attributes["service.name"] == "opentelemetry-collector"
@@ -300,6 +303,7 @@ opentelemetry-agent:
           - context: datapoint
             statements:
               - delete_key(attributes, "service_name") where resource.attributes["service.name"] == "opentelemetry-collector"
+              - delete_key(attributes, "otel_scope_name") where attributes["service.name"] == "opentelemetry-collector"
       k8sattributes:
         filter:
           node_from_env_var: KUBE_NODE_NAME
@@ -355,14 +359,6 @@ opentelemetry-agent:
           cx.agent.type: "agent"
         logs:
           level: "{{ .Values.global.logLevel }}"
-          encoding: json
-        metrics:
-          readers:
-            - pull:
-                exporter:
-                  prometheus:
-                    host: ${env:MY_POD_IP}
-                    port: 8888
       extensions:
         - zpages
         - pprof
@@ -595,6 +591,9 @@ opentelemetry-cluster-collector:
       transform/prometheus:
         error_mode: ignore
         metric_statements:
+          - context: metric
+            statements:
+              - replace_pattern(name, "_total$", "")
           - context: resource
             statements:
               - set(attributes["k8s.pod.ip"], attributes["net.host.name"]) where attributes["service.name"] == "opentelemetry-collector"
@@ -603,6 +602,7 @@ opentelemetry-cluster-collector:
           - context: datapoint
             statements:
               - delete_key(attributes, "service_name") where resource.attributes["service.name"] == "opentelemetry-collector"
+              - delete_key(attributes, "otel_scope_name") where attributes["service.name"] == "opentelemetry-collector"
       resource/kube-events:
         attributes:
           - key: service.name
@@ -718,14 +718,6 @@ opentelemetry-cluster-collector:
           cx.agent.type: "cluster-collector"
         logs:
           level: "{{ .Values.global.logLevel }}"
-          encoding: json
-        metrics:
-          readers:
-            - pull:
-                exporter:
-                  prometheus:
-                    host: ${env:MY_POD_IP}
-                    port: 8888
       extensions:
         - zpages
         - pprof
@@ -956,6 +948,9 @@ opentelemetry-gateway:
       transform/prometheus:
         error_mode: ignore
         metric_statements:
+          - context: metric
+            statements:
+              - replace_pattern(name, "_total$", "")
           - context: resource
             statements:
               - set(attributes["k8s.pod.ip"], attributes["net.host.name"]) where attributes["service.name"] == "opentelemetry-collector"
@@ -964,6 +959,7 @@ opentelemetry-gateway:
           - context: datapoint
             statements:
               - delete_key(attributes, "service_name") where resource.attributes["service.name"] == "opentelemetry-collector"
+              - delete_key(attributes, "otel_scope_name") where attributes["service.name"] == "opentelemetry-collector"
     receivers:
       prometheus:
         config:
@@ -986,14 +982,6 @@ opentelemetry-gateway:
           cx.agent.type: "gateway"
         logs:
           level: "{{ .Values.global.logLevel }}"
-          encoding: json
-        metrics:
-          readers:
-            - pull:
-                exporter:
-                  prometheus:
-                    host: ${env:MY_POD_IP}
-                    port: 8888
       pipelines:
         metrics:
           exporters:
@@ -1153,6 +1141,9 @@ opentelemetry-receiver:
       transform/prometheus:
         error_mode: ignore
         metric_statements:
+          - context: metric
+            statements:
+              - replace_pattern(name, "_total$", "")
           - context: resource
             statements:
               - set(attributes["k8s.pod.ip"], attributes["net.host.name"]) where attributes["service.name"] == "opentelemetry-collector"
@@ -1161,6 +1152,7 @@ opentelemetry-receiver:
           - context: datapoint
             statements:
               - delete_key(attributes, "service_name") where resource.attributes["service.name"] == "opentelemetry-collector"
+              - delete_key(attributes, "otel_scope_name") where attributes["service.name"] == "opentelemetry-collector"
     receivers:
       prometheus:
         config:
@@ -1183,14 +1175,6 @@ opentelemetry-receiver:
           cx.agent.type: "receiver"
         logs:
           level: "{{ .Values.global.logLevel }}"
-          encoding: json
-        metrics:
-          readers:
-            - pull:
-                exporter:
-                  prometheus:
-                    host: ${env:MY_POD_IP}
-                    port: 8888
       pipelines:
         metrics/self_monitoring:
           exporters:


### PR DESCRIPTION
# Description

Fixes ES-479

Removing telemetry settings for logs and metrics to make values.yaml smaller, since now they are baked in upstream chart.

Looks like there were a lot of changes in internal collector telemetry. So I'm  changing transform processor to remove double _total suffix, and get rid of otel_scope_name which was added to all metrics.


```
          - context: metric
            statements:
              - replace_pattern(name, "_total$", "") 
          - context: resource
            statements:
              - set(attributes["k8s.pod.ip"], attributes["net.host.name"]) where attributes["service.name"] == "opentelemetry-collector"
	@@ -964,6 +959,7 @@ opentelemetry-gateway:
          - context: datapoint
            statements:
              - delete_key(attributes, "service_name") where resource.attributes["service.name"] == "opentelemetry-collector"
              - delete_key(attributes, "otel_scope_name") where attributes["service.name"] == "opentelemetry-collector"
```

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the relevant Helm chart(s) version(s)
- [ ] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
