### PR TITLE
Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ In order to get the updated helm charts from the added repository, please run:
 helm repo update
 ```
 
-For installation of each integration, please go inside each intergation's directory:
+For installation of each integration, please go inside each integration's directory:
 - [Fluentd-HTTP chart](https://github.com/coralogix/telemetry-shippers/blob/master/logs/fluentd/k8s-helm/http/README.md)
 - [Fluent-bit-HTTP chart](https://github.com/coralogix/telemetry-shippers/blob/master/logs/fluent-bit/k8s-helm/http/README.md)
 - [Prometheus operator chart](https://github.com/coralogix/telemetry-shippers/blob/master/metrics/prometheus/operator/README.md)
@@ -77,7 +77,7 @@ For installation of each integration, please go inside each intergation's direct
 
 Our k8s manifests integration allow you to install without the use of Helm, specifically for those times were using helm is impossible.
 
-For installation of each integration, please go inside each intergation's directory:
+For installation of each integration, please go inside each integration's directory:
 - [Fluentd-HTTP](https://github.com/coralogix/telemetry-shippers/blob/master/logs/fluentd/k8s-manifest/README.md)
 - [Fluent-bit-HTTP](https://github.com/coralogix/telemetry-shippers/blob/master/logs/fluent-bit/k8s-manifest/README.md)
 


### PR DESCRIPTION
Fixes #442

Corrects a typo in the main `README.md` file.

* Changes 'intergation's' to 'integration's' in the section for installation of each integration.
* Changes 'intergation's' to 'integration's' in the section for Kubernetes installation.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/coralogix/telemetry-shippers/issues/442?shareId=XXXX-XXXX-XXXX-XXXX).