### PR TITLE
[ES-490] Add opentelemetry-ebpf-profiler subchart.

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.155 / 2025-03-12
+- [Feat] Add ebpf-profiler subchart.
+
 ### v0.0.154 / 2025-03-07
 - [Feat] Update windows image to v0.121.0
 

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -39,6 +39,11 @@ dependencies:
     version: "0.1.12"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts
     condition: coralogix-ebpf-agent.enabled
+  - name: opentelemetry-ebpf-profiler
+    alias: coralogix-ebpf-profiler
+    version: "0.109.0"
+    repository: https://cgx.jfrog.io/artifactory/coralogix-charts
+    condition: coralogix-ebpf-profiler.enabled
 sources:
   - https://github.com/coralogix/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector
 maintainers:

--- a/otel-integration/k8s-helm/README.md
+++ b/otel-integration/k8s-helm/README.md
@@ -129,12 +129,18 @@ Provides information about Kubernetes version.
 
 coralogix-ebpf-agent is an agent developed by coralogix. using [EBPF](https://ebpf.io/what-is-ebpf/) to extract network traffic as spans (http requests, SQL traffic ect), allowing for [Coralogix APM](https://coralogix.com/docs/user-guides/apm/getting-started/introduction-to-apm/) capabilities without any service instrumentation.
 
-Componentes:
+Components:
 - coralogix-ebpf-agent - The agent that extracts network traffic as spans, running as a daemonset.
 - k8s-watcher - The agent that watches for changes in k8s resources and publishes them to redis pubsub for coralogix-ebpf-agent to consume them, running as a deployment with 1 replica.
 - redis - Redis Pubsub is used for communication between k8s-watcher and coralogix-ebpf-agent, running as a sts with 1 replica.
 
 to enable the coralogix-ebpf-agent deployment, set `coralogix-ebpf-agent.enabled` to `true` in the `values.yaml` file.
+
+## Coralogix EBPF Profiler
+
+coralogix-ebpf-profiler is an agent developed by coralogix. It is a fork from [opentelemetry-ebpf-profiler](https://github.com/open-telemetry/opentelemetry-ebpf-profiler) with some extra features to set k8s attributes.
+
+To enable the coralogix-ebpf-profiler deployment, set `coralogix-ebpf-profiler.enabled` to `true` in the `values.yaml` file.
 
 # Prerequisites
 

--- a/otel-integration/k8s-helm/central-agent-values.yaml
+++ b/otel-integration/k8s-helm/central-agent-values.yaml
@@ -36,3 +36,5 @@ opentelemetry-gateway:
   enabled: false
 coralogix-ebpf-agent:
   enabled: false
+coralogix-ebpf-profiler:
+  enabled: false

--- a/otel-integration/k8s-helm/central-tail-sampling-values.yaml
+++ b/otel-integration/k8s-helm/central-tail-sampling-values.yaml
@@ -100,3 +100,5 @@ opentelemetry-agent-windows:
   enabled: false
 coralogix-ebpf-agent:
   enabled: false
+coralogix-ebpf-profiler:
+  enabled: false

--- a/otel-integration/k8s-helm/ci/tail-sampling-values.yaml
+++ b/otel-integration/k8s-helm/ci/tail-sampling-values.yaml
@@ -55,3 +55,5 @@ opentelemetry-agent-windows:
   enabled: false
 coralogix-ebpf-agent:
   enabled: false
+coralogix-ebpf-profiler:
+  enabled: false

--- a/otel-integration/k8s-helm/gke-autopilot-values.yaml
+++ b/otel-integration/k8s-helm/gke-autopilot-values.yaml
@@ -74,3 +74,6 @@ opentelemetry-agent-windows:
 
 coralogix-ebpf-agent:
   enabled: false
+
+coralogix-ebpf-profiler:
+  enabled: false

--- a/otel-integration/k8s-helm/tail-sampling-values.yaml
+++ b/otel-integration/k8s-helm/tail-sampling-values.yaml
@@ -64,3 +64,6 @@ opentelemetry-agent-windows:
 
 coralogix-ebpf-agent:
   enabled: false
+
+coralogix-ebpf-profiler:
+  enabled: false

--- a/otel-integration/k8s-helm/values-cluster-ksm.yaml
+++ b/otel-integration/k8s-helm/values-cluster-ksm.yaml
@@ -41,3 +41,6 @@ opentelemetry-cluster-collector:
 
 coralogix-ebpf-agent:
   enabled: false
+
+coralogix-ebpf-profiler:
+  enabled: false

--- a/otel-integration/k8s-helm/values-crd-override.yaml
+++ b/otel-integration/k8s-helm/values-crd-override.yaml
@@ -22,3 +22,6 @@ opentelemetry-cluster-collector:
 
 coralogix-ebpf-agent:
   enabled: false
+  
+coralogix-ebpf-profiler:
+  enabled: false

--- a/otel-integration/k8s-helm/values-ebpf-agent-existing-collector.yaml
+++ b/otel-integration/k8s-helm/values-ebpf-agent-existing-collector.yaml
@@ -16,3 +16,6 @@ coralogix-ebpf-agent:
         # configure the opentelemetry collector endpoint here
         endpoint: "coralogix-opentelemetry-receiver:4317"
   tolerations: []
+
+coralogix-ebpf-profiler:
+  enabled: false

--- a/otel-integration/k8s-helm/values-windows-tailsampling.yaml
+++ b/otel-integration/k8s-helm/values-windows-tailsampling.yaml
@@ -339,3 +339,6 @@ opentelemetry-cluster-collector:
 
 coralogix-ebpf-agent:
   enabled: false
+
+coralogix-ebpf-profiler:
+  enabled: false

--- a/otel-integration/k8s-helm/values-windows.yaml
+++ b/otel-integration/k8s-helm/values-windows.yaml
@@ -359,3 +359,6 @@ opentelemetry-cluster-collector:
 
 coralogix-ebpf-agent:
   enabled: false
+  
+coralogix-ebpf-profiler:
+  enabled: false

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -1272,3 +1272,6 @@ coralogix-ebpf-agent:
     name: ""
     value: 1000000000
   tolerations: []
+
+coralogix-ebpf-profiler:
+  enabled: false


### PR DESCRIPTION
# Description

Fixes ES-490.

Add `opentelemetry-ebpf-profiler` subchart.

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the relevant Helm chart(s) version(s)
- [ ] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
