### PR TITLE
[otel-integration] enable fleet-manager by default

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.157 / 2025-03-17
+- [Feat] Enable fleetmanagement preset by default
+
 ### v0.0.156 / 2025-03-12
 - [Fix] Add missing service_instance_id in metrics
 - [docs] Add headsampling docs

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.155
+version: 0.0.156
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/values-windows-tailsampling.yaml
+++ b/otel-integration/k8s-helm/values-windows-tailsampling.yaml
@@ -86,7 +86,7 @@ opentelemetry-agent-windows:
       clusterName: "{{.Values.global.clusterName}}"
       integrationName: "coralogix-integration-helm"
     fleetManagement:
-      enabled: false
+      enabled: true
       agentType: "agent"
       clusterName: "{{.Values.global.clusterName}}"
     logsCollection:

--- a/otel-integration/k8s-helm/values-windows.yaml
+++ b/otel-integration/k8s-helm/values-windows.yaml
@@ -87,7 +87,7 @@ opentelemetry-agent-windows:
       clusterName: "{{.Values.global.clusterName}}"
       integrationName: "coralogix-integration-helm"
     fleetManagement:
-      enabled: false
+      enabled: true
       agentType: "agent"
       clusterName: "{{.Values.global.clusterName}}"
     logsCollection:

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "warn"
   collectionInterval: "30s"
-  version: "0.0.155"
+  version: "0.0.156"
 
   extensions:
     kubernetesDashboard:
@@ -127,7 +127,7 @@ opentelemetry-agent:
       clusterName: "{{.Values.global.clusterName}}"
       integrationName: "coralogix-integration-helm"
     fleetManagement:
-      enabled: false
+      enabled: true
       agentType: "agent"
       clusterName: "{{.Values.global.clusterName}}"
 
@@ -467,7 +467,7 @@ opentelemetry-cluster-collector:
   replicaCount: 1
   presets:
     fleetManagement:
-      enabled: false
+      enabled: true
       agentType: "cluster-collector"
       clusterName: "{{.Values.global.clusterName}}"
     clusterMetrics:
@@ -871,7 +871,7 @@ opentelemetry-gateway:
 
   presets:
     fleetManagement:
-      enabled: false
+      enabled: true
       agentType: "gateway"
       clusterName: "{{.Values.global.clusterName}}"
     kubernetesAttributes:
@@ -1063,7 +1063,7 @@ opentelemetry-receiver:
           fieldPath: spec.nodeName
   presets:
     fleetManagement:
-      enabled: false
+      enabled: true
       agentType: "receiver"
       clusterName: "{{.Values.global.clusterName}}"
     kubernetesAttributes:


### PR DESCRIPTION
# Description

 Fixes ES-510

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the relevant Helm chart(s) version(s)
- [ ] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
