### PR TITLE
Remove ebpf-profiler from subcharts

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.159 / 2025-03-25
+- [Revert] Remove `ebpf-profiler` as a subchart
+
 ### v0.0.158 / 2025-03-21
 - [Fix] OpentelemetryCollector crd generation
 

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.158
+version: 0.0.159
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -39,11 +39,6 @@ dependencies:
     version: "0.1.12"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts
     condition: coralogix-ebpf-agent.enabled
-  - name: opentelemetry-ebpf-profiler
-    alias: coralogix-ebpf-profiler
-    version: "0.109.0"
-    repository: https://cgx.jfrog.io/artifactory/coralogix-charts
-    condition: coralogix-ebpf-profiler.enabled
 sources:
   - https://github.com/coralogix/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector
 maintainers:

--- a/otel-integration/k8s-helm/README.md
+++ b/otel-integration/k8s-helm/README.md
@@ -129,18 +129,12 @@ Provides information about Kubernetes version.
 
 coralogix-ebpf-agent is an agent developed by coralogix. using [EBPF](https://ebpf.io/what-is-ebpf/) to extract network traffic as spans (http requests, SQL traffic ect), allowing for [Coralogix APM](https://coralogix.com/docs/user-guides/apm/getting-started/introduction-to-apm/) capabilities without any service instrumentation.
 
-Components:
+Componentes:
 - coralogix-ebpf-agent - The agent that extracts network traffic as spans, running as a daemonset.
 - k8s-watcher - The agent that watches for changes in k8s resources and publishes them to redis pubsub for coralogix-ebpf-agent to consume them, running as a deployment with 1 replica.
 - redis - Redis Pubsub is used for communication between k8s-watcher and coralogix-ebpf-agent, running as a sts with 1 replica.
 
 to enable the coralogix-ebpf-agent deployment, set `coralogix-ebpf-agent.enabled` to `true` in the `values.yaml` file.
-
-## Coralogix EBPF Profiler
-
-coralogix-ebpf-profiler is an agent developed by coralogix. It is a fork from [opentelemetry-ebpf-profiler](https://github.com/open-telemetry/opentelemetry-ebpf-profiler) with some extra features to set k8s attributes.
-
-To enable the coralogix-ebpf-profiler deployment, set `coralogix-ebpf-profiler.enabled` to `true` in the `values.yaml` file.
 
 # Prerequisites
 

--- a/otel-integration/k8s-helm/central-agent-values.yaml
+++ b/otel-integration/k8s-helm/central-agent-values.yaml
@@ -36,5 +36,3 @@ opentelemetry-gateway:
   enabled: false
 coralogix-ebpf-agent:
   enabled: false
-coralogix-ebpf-profiler:
-  enabled: false

--- a/otel-integration/k8s-helm/central-tail-sampling-values.yaml
+++ b/otel-integration/k8s-helm/central-tail-sampling-values.yaml
@@ -100,5 +100,3 @@ opentelemetry-agent-windows:
   enabled: false
 coralogix-ebpf-agent:
   enabled: false
-coralogix-ebpf-profiler:
-  enabled: false

--- a/otel-integration/k8s-helm/ci/tail-sampling-values.yaml
+++ b/otel-integration/k8s-helm/ci/tail-sampling-values.yaml
@@ -55,5 +55,3 @@ opentelemetry-agent-windows:
   enabled: false
 coralogix-ebpf-agent:
   enabled: false
-coralogix-ebpf-profiler:
-  enabled: false

--- a/otel-integration/k8s-helm/gke-autopilot-values.yaml
+++ b/otel-integration/k8s-helm/gke-autopilot-values.yaml
@@ -74,6 +74,3 @@ opentelemetry-agent-windows:
 
 coralogix-ebpf-agent:
   enabled: false
-
-coralogix-ebpf-profiler:
-  enabled: false

--- a/otel-integration/k8s-helm/tail-sampling-values.yaml
+++ b/otel-integration/k8s-helm/tail-sampling-values.yaml
@@ -64,6 +64,3 @@ opentelemetry-agent-windows:
 
 coralogix-ebpf-agent:
   enabled: false
-
-coralogix-ebpf-profiler:
-  enabled: false

--- a/otel-integration/k8s-helm/values-cluster-ksm.yaml
+++ b/otel-integration/k8s-helm/values-cluster-ksm.yaml
@@ -41,6 +41,3 @@ opentelemetry-cluster-collector:
 
 coralogix-ebpf-agent:
   enabled: false
-
-coralogix-ebpf-profiler:
-  enabled: false

--- a/otel-integration/k8s-helm/values-crd-override.yaml
+++ b/otel-integration/k8s-helm/values-crd-override.yaml
@@ -22,6 +22,3 @@ opentelemetry-cluster-collector:
 
 coralogix-ebpf-agent:
   enabled: false
-  
-coralogix-ebpf-profiler:
-  enabled: false

--- a/otel-integration/k8s-helm/values-ebpf-agent-existing-collector.yaml
+++ b/otel-integration/k8s-helm/values-ebpf-agent-existing-collector.yaml
@@ -16,6 +16,3 @@ coralogix-ebpf-agent:
         # configure the opentelemetry collector endpoint here
         endpoint: "coralogix-opentelemetry-receiver:4317"
   tolerations: []
-
-coralogix-ebpf-profiler:
-  enabled: false

--- a/otel-integration/k8s-helm/values-windows-tailsampling.yaml
+++ b/otel-integration/k8s-helm/values-windows-tailsampling.yaml
@@ -339,6 +339,3 @@ opentelemetry-cluster-collector:
 
 coralogix-ebpf-agent:
   enabled: false
-
-coralogix-ebpf-profiler:
-  enabled: false

--- a/otel-integration/k8s-helm/values-windows.yaml
+++ b/otel-integration/k8s-helm/values-windows.yaml
@@ -359,6 +359,3 @@ opentelemetry-cluster-collector:
 
 coralogix-ebpf-agent:
   enabled: false
-  
-coralogix-ebpf-profiler:
-  enabled: false

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "warn"
   collectionInterval: "30s"
-  version: "0.0.158"
+  version: "0.0.159"
 
   extensions:
     kubernetesDashboard:
@@ -1272,6 +1272,3 @@ coralogix-ebpf-agent:
     name: ""
     value: 1000000000
   tolerations: []
-
-coralogix-ebpf-profiler:
-  enabled: false


### PR DESCRIPTION
Reverting commit `36884f7418983d4092286ac2dfd19aa700c91ea8` because it seems it is producing some issues to customers even when disabled.

Some customers have some systems where they download all the images even when they are not using some subcharts. Since the `ebpf-profiler` image is not there yet, this is causing some issues.