### PR TITLE
[ci] Make the fleet-manager test less flaky

### DIFF
--- a/otel-integration/k8s-helm/e2e-test/fleet_manager_test.go
+++ b/otel-integration/k8s-helm/e2e-test/fleet_manager_test.go
@@ -7,7 +7,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/xk8stest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func TestE2E_FleetManager(t *testing.T) {
@@ -23,11 +27,36 @@ func TestE2E_FleetManager(t *testing.T) {
 
 	err = testServer.start(fmt.Sprintf("%s:4320", testServerAddr))
 	assert.NoError(t, err)
-	defer testServer.stop()
+	t.Cleanup(func() {
+		_ = testServer.stop()
+	})
+
+	// Get the kubeconfig path from env
+	kubeconfigPath := testKubeConfig
+	if kubeConfigFromEnv := os.Getenv(kubeConfigEnvVar); kubeConfigFromEnv != "" {
+		kubeconfigPath = kubeConfigFromEnv
+	}
+
+	k8sClient, err := xk8stest.NewK8sClient(kubeconfigPath)
+	require.NoError(t, err)
+
+	// We give a kick to all the Collector to trigger them to reconnect to the
+	// OpAMP server, decreasing the likelyhood of a false positive in the test.
+	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+	err = k8sClient.
+		DynamicClient.
+		Resource(gvr).
+		Namespace("").
+		DeleteCollection(
+			context.Background(),
+			metav1.DeleteOptions{},
+			metav1.ListOptions{LabelSelector: "app.kubernetes.io/instance=otel-integration-agent-e2e"},
+		)
+	require.NoError(t, err)
 
 	ctx := context.Background()
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
+	t.Cleanup(cancel)
 
 	// We wait for at least two messages:
 	// 1st: reporting the creation of the agent.

--- a/otel-integration/k8s-helm/e2e-test/fleet_manager_test.go
+++ b/otel-integration/k8s-helm/e2e-test/fleet_manager_test.go
@@ -40,13 +40,14 @@ func TestE2E_FleetManager(t *testing.T) {
 	k8sClient, err := xk8stest.NewK8sClient(kubeconfigPath)
 	require.NoError(t, err)
 
-	// We give a kick to all the Collector to trigger them to reconnect to the
-	// OpAMP server, decreasing the likelyhood of a false positive in the test.
+	// We give a kick to all the Collectors to trigger them to be recreated and
+	// reconnect to the OpAMP server, decreasing the likelyhood of a false
+	// positive in the test.
 	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
 	err = k8sClient.
 		DynamicClient.
 		Resource(gvr).
-		Namespace("").
+		Namespace("default").
 		DeleteCollection(
 			context.Background(),
 			metav1.DeleteOptions{},


### PR DESCRIPTION
# Description

Fixes ES-550.

We delete the pods created by the Helm chart to trigger them to be recreated and restart the opamp connection. This ensures we get the minimum amount of messages to pass the test much more reliably.

# Checklist:
- [ ] I have updated the relevant Helm chart(s) version(s)
- [ ] I have updated the relevant component changelog(s)
- [x] This change does not affect any particular component (e.g. it's CI or docs change)
