### PR TITLE
fix: markdown ci rate-limiting

### DIFF
--- a/.mdox.validate.yaml
+++ b/.mdox.validate.yaml
@@ -4,6 +4,9 @@ cache:
   type: 'SQLite'
 
 validators: 
+  # Ignore all GitHub links since they are rate-limited.
+  - regex: '(^http[s]?:\/\/)(www\.)?(github\.com\/).*'
+    type: 'ignore'
   # Ignore links to pr Labels.
   - regex: '(^http[s]?:\/\/)(www\.)?(github\.com\/)coralogix\/telemetry-shippers(\/issues.*)'
     type: 'ignore'


### PR DESCRIPTION
# Description

Our CI fails with these errors:
https://github.com/coralogix/telemetry-shippers/actions/runs/14855028603/job/41706205222?pr=565

Fixing to ignore github links, since they started rate-limiting

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the relevant Helm chart(s) version(s)
- [ ] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
