### PR TITLE
update/CDS-2086: rewrite fluent-bit k8s configuration to YAML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ Chart.lock
 # Fluent-bit
 logs/fluent-bit/test/
 logs/fluent-bit/k8s-manifest/fluentbit-env-cm.yaml
+**/charts/

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@
 .idea
 .vscode
 Chart.lock
+
+# Fluent-bit
+logs/fluent-bit/test/
+logs/fluent-bit/k8s-manifest/fluentbit-env-cm.yaml

--- a/logs/CHANGELOG.md
+++ b/logs/CHANGELOG.md
@@ -56,6 +56,10 @@
 
 ## Fluent-Bit
 
+### v3.2.10-1 / 2025-5-6
+* [UPGRADE] Upgrade Fluentbit configuration to YAML in `k8s-manifests` and `k8s-helm`
+* [UPGRADE] Disable `ServiceMonitor` by default
+
 ### v3.2.10 / 2025-4-15
 * [REMOVE] Remove Coralogix plugin from Fluentbit image
 * [UPGRADE] Upgrade Fluentbit version to v3.2.10

--- a/logs/fluent-bit/image/Dockerfile
+++ b/logs/fluent-bit/image/Dockerfile
@@ -3,3 +3,4 @@ ARG TARGETARCH
 LABEL Maintainer="Coralogix Inc. <info@coralogix.com>"
 LABEL Description="Special Fluent-Bit image for Coralogix integration" Vendor="Coralogix Inc." Version="3.2.10"
 COPY ./functions.lua /fluent-bit/etc/
+CMD ["/fluent-bit/bin/fluent-bit", "-c", "/fluent-bit/etc/fluent-bit.yaml"]

--- a/logs/fluent-bit/k8s-helm/http/Chart.yaml
+++ b/logs/fluent-bit/k8s-helm/http/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: fluent-bit-http
 description: Fluent-Bit Chart with HTTP output plugin
-version: 3.2.10
+version: 3.3.0
 appVersion: 3.2.10
 keywords:
   - Fluent-Bit

--- a/logs/fluent-bit/k8s-helm/http/Chart.yaml
+++ b/logs/fluent-bit/k8s-helm/http/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: fluent-bit-http
 description: Fluent-Bit Chart with HTTP output plugin
-version: 3.3.0
+version: 3.2.10-1
 appVersion: 3.2.10
 keywords:
   - Fluent-Bit

--- a/logs/fluent-bit/k8s-helm/http/README.md
+++ b/logs/fluent-bit/k8s-helm/http/README.md
@@ -107,13 +107,15 @@ Note: we can use both static and dynamic at the sametime, static values take pre
 
 ## Coralogix Endpoints
 
-| Region | Logs Endpoint               |
-|--------|-----------------------------|
-| EU     | `ingress.coralogix.com`     |
-| EU2    | `ingress.eu2.coralogix.com` |
-| US     | `ingress.coralogix.us`      |
-| SG     | `ingress.coralogixsg.com`   |
-| IN     | `ingress.coralogix.in`      |
+| Region | Logs Endpoint                 |
+|--------|-------------------------------|
+| EU1    | `ingress.coralogix.com`       |
+| EU2    | `ingress.eu2.coralogix.com`   |
+| US1    | `ingress.coralogix.us`        |
+| US2    | `ingress.cx498.coralogix.com` |
+| AP1    | `ingress.coralogix.in`        |
+| AP2    | `ingress.coralogixsg.com`     |
+| AP3    | `ingress.ap3.coralogix.com`   |
 
 **NOTE**
 We suggest using dynamic app_name and sub_system, since it's more agile than using static values.

--- a/logs/fluent-bit/k8s-helm/http/values.yaml
+++ b/logs/fluent-bit/k8s-helm/http/values.yaml
@@ -5,8 +5,16 @@ fluent-bit:
     repository: coralogixrepo/coralogix-fluent-bit-multiarch
     tag: v3.2.10
 
+  command:
+    - /fluent-bit/bin/fluent-bit
+
+  args:
+    - --workdir=/fluent-bit/etc
+    - --config=/fluent-bit/etc/conf/fluent-bit.yaml
+
+  # enable if prometheus-operator is installed
   serviceMonitor:
-    enabled: true
+    enabled: false
     additionalEndpoints:
       - port: storage-metrics
         path: /metrics
@@ -82,142 +90,103 @@ fluent-bit:
         apiVersion: v1
         fieldPath: metadata.name
 
+  endpoint: ingress.eu2.coralogix.com
+  logLevel: error
+
   # The same usage as env, but used for passing dynamic values to the chart using the helm argument "--set <variable>=<value>"
   envWithTpl:
   - name: ENDPOINT
     value: "{{ .Values.endpoint }}"
+  - name: LOG_LEVEL
+    value: "{{ .Values.logLevel }}"
 
-  endpoint: ingress.eu2.coralogix.com
-  logLevel: error
-
-  config: 
-    service: |-
-      [SERVICE]
-          Daemon Off
-          Flush 1
-          Log_Level {{.Values.logLevel}}
-          Parsers_File parsers.conf
-          Parsers_File custom_parsers.conf
-          HTTP_Server On
-          HTTP_Listen 0.0.0.0
-          HTTP_Port {{.Values.service.port}}
-          Health_Check On
-          storage.metrics on
-
-    inputs: |-
-      [INPUT]
-          Name tail
-          Path /var/log/containers/*.log
-          multiline.parser docker, cri
-          Tag kube.*
-          Refresh_Interval 5
-          Skip_Long_Lines On
-          Mem_Buf_Limit 25MB
-          DB /var/log/fluentbit-tail.db
-
-      @INCLUDE input-systemd.conf
-      @INCLUDE input-fluentbit-metrics.conf
-
-    filters: |-
-      [FILTER]
-          Name kubernetes
-          Match kube.*
-          K8S-Logging.Parser On
-          K8S-Logging.Exclude On
-          Use_Kubelet On
-          Annotations Off
-          Labels On
-          Buffer_Size 0
-          Keep_Log Off
-          Merge_Log_Key log_obj
-          Merge_Log On
-
-      [FILTER]
-          Name        nest
-          Match       kube.*
-          Operation   nest
-          Wildcard    *
-          Nest_under  json
-
-      [FILTER]
-          Name    lua
-          Match   kube.*
-          script  /fluent-bit/scripts/script.lua
-          call    addcrxmetadata
-          time_as_table true
-          
-      @INCLUDE filters-systemd.conf
-
-    outputs: |-
-      [OUTPUT]
-          Name                  http
-          Match                 kube.*
-          Host                  ${ENDPOINT}
-          Port                  443
-          URI                   /logs/v1/singles
-          Format                json_lines
-          TLS                   On
-          Header                Authorization Bearer ${PRIVATE_KEY}
-          compress              gzip
-          Retry_Limit           False
-          net.keepalive         off
-
-      @INCLUDE output-systemd.conf
-      @INCLUDE output-fluentbit-metrics.conf
-    
+  config:
     extraFiles:
-      input-systemd.conf: |-
-        [INPUT]
-          Name systemd
-          Tag host.*
-          Systemd_Filter _SYSTEMD_UNIT=kubelet.service
-          Read_From_Tail On
-          Mem_Buf_Limit 5MB
+      fluent-bit.yaml: |
+        service:
+          daemon: off
+          flush: 1
+          log_level: ${LOG_LEVEL}
+          http_server: on
+          http_listen: 0.0.0.0
+          http_port: {{.Values.service.port}}
+        pipeline:
+          inputs:
+            - name: fluentbit_metrics
+              tag: metrics
+              scrape_interval: 5
+              scrape_on_start: true
+            - name: tail
+              tag: kube.*
+              path: /var/log/containers/*.log
+              multiline.parser: docker, cri
+              refresh_interval: 5
+              skip_long_lines: on
+              mem_buf_limit: 25MB
+              db: /var/log/fluentbit-tail.db
+              processors:
+                logs:
+                  - name: kubernetes
+                    "k8s-logging.parser": on
+                    "k8s-logging.exclude": on
+                    use_kubelet: On
+                    annotations: Off
+                    labels: On
+                    buffer_size: 100MB
+                    keep_log: Off
+                    merge_log_key: log_obj
+                    merge_log: On
+                    tls.verify: off
 
-      input-fluentbit-metrics.conf: |-
-        [INPUT]
-          name            fluentbit_metrics
-          tag             internal_metrics
-          scrape_interval 5
-          scrape_on_start true
+                  - name: nest
+                    operation: nest
+                    wildcard:
+                      - "*"
+                    nest_under: json
 
-      filters-systemd.conf: |-
-        [FILTER]
-          Name    modify
-          Match   host.*
-          Add    applicationName ${APP_NAME_SYSTEMD}
-          Copy   ${SUB_SYSTEM_SYSTEMD} subsystemName
+                  - name: lua
+                    script: /fluent-bit/scripts/script.lua
+                    call: addcrxmetadata
+                    time_as_table: true
 
-        [FILTER]
-          Name        nest
-          Match       host.*
-          Operation   nest
-          Wildcard    _HOSTNAME
-          Wildcard    SYSLOG_IDENTIFIER
-          Wildcard    _CMDLINE 
-          Wildcard    MESSAGE
-          Nest_under  json
+            - name: systemd
+              tag: host.*
+              systemd_filter: _SYSTEMD_UNIT=kubelet.service
+              read_from_tail: on
+              mem_buf_limit: 5MB
+              processors:
+                logs:
+                  - name: modify
+                    add:
+                      - applicationName ${APP_NAME_SYSTEMD}
+                    copy:
+                      - ${SUB_SYSTEM_SYSTEMD} subsystemName
 
-      output-fluentbit-metrics.conf: |-
-        [OUTPUT]
-          name            prometheus_exporter
-          match           internal_metrics
-          host            0.0.0.0
-          port            2021
+                  - name: nest
+                    operation: nest
+                    wildcard:
+                      - _HOSTNAME
+                      - SYSLOG_IDENTIFIER
+                      - _CMDLINE
+                      - MESSAGE
+                    nest_under: json
 
-      output-systemd.conf: |-
-        [OUTPUT]
-          Name                  http
-          Match                 host.*
-          Host                  ${ENDPOINT}
-          Port                  443
-          URI                   /logs/v1/singles
-          Format                json_lines
-          TLS                   On
-          Header                Authorization Bearer ${PRIVATE_KEY}
-          compress              gzip
-          Retry_Limit           False
-          net.keepalive         off
+          outputs:
+            - name: prometheus_exporter
+              match: metrics
+              host: 0.0.0.0
+              port: 2021
+            - name: http
+              match_regex: ^(kube\..*|host\..*)$
+              host: ${ENDPOINT}
+              port: 443
+              uri: /logs/v1/singles
+              format: json_lines
+              tls: on
+              header: Authorization Bearer ${PRIVATE_KEY}
+              compress: gzip
+              retry_limit: false
+              net.keepalive: off
 
   extraVolumes:
   - name: crxluascript

--- a/logs/fluent-bit/k8s-manifest/README.md
+++ b/logs/fluent-bit/k8s-manifest/README.md
@@ -7,6 +7,14 @@ Here you can find instructions on how to install the Fluent-Bit shipper, togethe
 
 ## Installation
 
+First, make sure you have a k8s secret with the Coralogix API key in the same namespace as the daemonSet. Here is one of the examples on how to create it, assuming you have a key in `CORALOGIX_API_KEY` env.
+
+```bash
+kubectl create secret generic coralogix-keys --from-literal=PRIVATE_KEY=${CORALOGIX_API_KEY} -n monitoring
+```
+
+Note: the configmap name is important and is being used by the daemonSet.
+
 In order to specify important environment variables, please create a configmap:
 
 ```yaml
@@ -17,7 +25,7 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/name: fluent-bit
-    app.kubernetes.io/instance	: fluent-bit-http
+    app.kubernetes.io/instance: fluent-bit-http
   name: fluent-bit-env
 data:
   ENDPOINT: ingress.coralogix.com
@@ -140,13 +148,15 @@ service "fluent-bit" deleted
 
 ## Coralogix Endpoints
 
-| Region | Logs Endpoint               |
-|--------|-----------------------------|
-| EU     | `ingress.coralogix.com`     |
-| EU2    | `ingress.eu2.coralogix.com` |
-| US     | `ingress.coralogix.us`      |
-| SG     | `ingress.coralogixsg.com`   |
-| IN     | `ingress.coralogix.in`      |
+| Region | Logs Endpoint                 |
+|--------|-------------------------------|
+| EU1    | `ingress.coralogix.com`       |
+| EU2    | `ingress.eu2.coralogix.com`   |
+| US1    | `ingress.coralogix.us`        |
+| US2    | `ingress.cx498.coralogix.com` |
+| AP1    | `ingress.coralogix.in`        |
+| AP2    | `ingress.coralogixsg.com`     |
+| AP3    | `ingress.ap3.coralogix.com`   |
 
 ## Dashboard
 

--- a/logs/fluent-bit/k8s-manifest/fluentbit-cm.yaml
+++ b/logs/fluent-bit/k8s-manifest/fluentbit-cm.yaml
@@ -6,135 +6,91 @@ metadata:
     app.kubernetes.io/name: fluent-bit
     app.kubernetes.io/instance: fluent-bit-http
 data:
-  custom_parsers.conf: |
-    [PARSER]
-        Name docker_no_time
-        Format json
-        Time_Keep Off
-        Time_Key time
-        Time_Format %Y-%m-%dT%H:%M:%S.%L
+  fluent-bit.yaml: |
+    service:
+      daemon: off
+      flush: 1
+      log_level: ${LOG_LEVEL}
+      http_server: on
+      http_listen: 0.0.0.0
+      http_port: 2020
+    pipeline:
+      inputs:
+        - name: fluentbit_metrics
+          tag: metrics
+          scrape_interval: 5
+          scrape_on_start: true
+        - name: tail
+          tag: kube.*
+          path: /var/log/containers/*.log
+          multiline.parser: docker, cri
+          refresh_interval: 5
+          skip_long_lines: on
+          mem_buf_limit: 25MB
+          db: /var/log/fluentbit-tail.db
+          processors:
+            logs:
+              - name: kubernetes
+                "k8s-logging.parser": on
+                "k8s-logging.exclude": on
+                use_kubelet: On
+                annotations: Off
+                labels: On
+                buffer_size: 100MB
+                keep_log: Off
+                merge_log_key: log_obj
+                merge_log: On
+                tls.verify: off
 
-  fluent-bit.conf: |
-    [SERVICE]
-        Daemon Off
-        Flush 1
-        Log_Level ${LOG_LEVEL}
-        Parsers_File parsers.conf
-        Parsers_File custom_parsers.conf
-        HTTP_Server On
-        HTTP_Listen 0.0.0.0
-        HTTP_Port 2020
-        Health_Check On
-        storage.metrics on
-    [INPUT]
-        Name tail
-        Path /var/log/containers/*.log
-        multiline.parser docker, cri
-        Tag kube.*
-        Refresh_Interval 5
-        Skip_Long_Lines On
-        Mem_Buf_Limit 25MB
-        DB /var/log/fluentbit-tail.db
+              - name: nest
+                operation: nest
+                wildcard:
+                  - "*"
+                nest_under: json
 
-    @INCLUDE input-systemd.conf
-    @INCLUDE input-fluentbit-metrics.conf
-    
-    [FILTER]
-        Name kubernetes
-        Match kube.*
-        K8S-Logging.Parser On
-        K8S-Logging.Exclude On
-        Use_Kubelet On
-        Annotations Off
-        Labels On
-        Buffer_Size 0
-        Keep_Log Off
-        Merge_Log_Key log_obj
-        Merge_Log On
+              - name: lua
+                script: /fluent-bit/scripts/script.lua
+                call: addcrxmetadata
+                time_as_table: true
 
-    [FILTER]
-        Name        nest
-        Match       kube.*
-        Operation   nest
-        Wildcard    *
-        Nest_under  json
+        - name: systemd
+          tag: host.*
+          systemd_filter: _SYSTEMD_UNIT=kubelet.service
+          read_from_tail: on
+          mem_buf_limit: 5MB
+          processors:
+            logs:
+              - name: modify
+                add:
+                  - applicationName systemd
+                copy:
+                  - SYSLOG_IDENTIFIER subsystemName
 
-    [FILTER]
-        Name    lua
-        Match   kube.*
-        script  /fluent-bit/scripts/script.lua
-        call    addcrxmetadata
-        time_as_table true
+              - name: nest
+                operation: nest
+                wildcard:
+                  - _HOSTNAME
+                  - SYSLOG_IDENTIFIER
+                  - _CMDLINE
+                  - MESSAGE
+                nest_under: json
 
-    @INCLUDE filters-systemd.conf
-    [OUTPUT]
-        Name                  http
-        Match                 kube.*
-        Host                  ${ENDPOINT}
-        Port                  443
-        URI                   /logs/v1/singles
-        Format                json_lines
-        TLS                   On
-        Header                Authorization Bearer ${PRIVATE_KEY}
-        compress              gzip
-        Retry_Limit           False
-        net.keepalive         off
-
-    @INCLUDE output-systemd.conf
-    @INCLUDE output-fluentbit-metrics.conf
-
-  filters-systemd.conf: |
-    [FILTER]
-      Name    modify
-      Match   host.*
-      Add    applicationName systemd
-      Copy   SYSLOG_IDENTIFIER subsystemName
-
-    [FILTER]
-      Name        nest
-      Match       host.*
-      Operation   nest
-      Wildcard    _HOSTNAME
-      Wildcard    SYSLOG_IDENTIFIER
-      Wildcard    _CMDLINE
-      Wildcard    MESSAGE
-      Nest_under  json
-
-  input-fluentbit-metrics.conf: |-
-    [INPUT]
-      name            fluentbit_metrics
-      tag             internal_metrics
-      scrape_interval 5
-      scrape_on_start true
-
-  input-systemd.conf: |
-    [INPUT]
-      Name systemd
-      Tag host.*
-      Systemd_Filter _SYSTEMD_UNIT=kubelet.service
-      Read_From_Tail On
-      Mem_Buf_Limit 5MB
-
-  output-systemd.conf: |
-    [OUTPUT]
-      Name                  http
-      Match                 host.*
-      Host                  ${ENDPOINT}
-      Port                  443
-      URI                   /logs/v1/singles
-      Format                json_lines
-      TLS                   On
-      Header                Authorization Bearer ${PRIVATE_KEY}
-      compress              gzip
-      Retry_Limit           False
-      net.keepalive         off
-
-  output-fluentbit-metrics.conf: |-
-    [OUTPUT]
-      name            prometheus_exporter
-      match           internal_metrics
-      host            0.0.0.0
-      port            2021
+      outputs:
+        - name: prometheus_exporter
+          match: metrics
+          host: 0.0.0.0
+          port: 2021
+        - name: http
+          match_regex: ^(kube\..*|host\..*)$
+          host: ${ENDPOINT}
+          port: 443
+          uri: /logs/v1/singles
+          format: json_lines
+          tls: on
+          header: Authorization Bearer ${PRIVATE_KEY}
+          compress: gzip
+          retry_limit: false
+          net.keepalive: off
 
 ---
 apiVersion: v1

--- a/logs/fluent-bit/k8s-manifest/fluentbit-ds.yaml
+++ b/logs/fluent-bit/k8s-manifest/fluentbit-ds.yaml
@@ -22,7 +22,7 @@ spec:
       containers:
         - name: fluent-bit
           image: "coralogixrepo/coralogix-fluent-bit-multiarch:v3.2.10"
-          imagePullPolicy: Always
+          imagePullPolicy: Never
           env:
             - name: HOSTNAME
               valueFrom:
@@ -59,27 +59,9 @@ spec:
               cpu: 100m
               memory: 250Mi
           volumeMounts:
-            - mountPath: /fluent-bit/etc/fluent-bit.conf
+            - mountPath: /fluent-bit/etc/fluent-bit.yaml
               name: config
-              subPath: fluent-bit.conf
-            - mountPath: /fluent-bit/etc/custom_parsers.conf
-              name: config
-              subPath: custom_parsers.conf
-            - name: config
-              mountPath: /fluent-bit/etc/filters-systemd.conf
-              subPath: filters-systemd.conf
-            - name: config
-              mountPath: /fluent-bit/etc/input-systemd.conf
-              subPath: input-systemd.conf
-            - name: config
-              mountPath: /fluent-bit/etc/output-systemd.conf
-              subPath: output-systemd.conf
-            - name: config
-              mountPath: /fluent-bit/etc/input-fluentbit-metrics.conf
-              subPath: input-fluentbit-metrics.conf
-            - name: config
-              mountPath: /fluent-bit/etc/output-fluentbit-metrics.conf
-              subPath: output-fluentbit-metrics.conf
+              subPath: fluent-bit.yaml
             - mountPath: /var/log
               name: varlog
             - mountPath: /var/lib/docker/containers


### PR DESCRIPTION
# Description

Fixes CDS-2086.

> Fluent Bit traditionally offered a classic configuration mode, a custom configuration format that we are gradually phasing out. While classic mode has served well for many years, it has several limitations. Its basic design only supports grouping sections with key-value pairs and lacks the ability to handle sub-sections or complex data structures like lists.
> 
> YAML, now a mainstream configuration format, has become essential in a cloud ecosystem where everything is configured this way. To minimize friction and provide a more intuitive experience for creating data pipelines, we strongly encourage users to transition to YAML. The YAML format enables features, such as processors, that are not possible to configure in classic mode.
> 
> As of Fluent Bit v3.2, you can configure everything in YAML.

This will move fluent-bit configuration to YAML in order to avoid doing it too late, when classic mode will be deprecated.

# Checklist

* `k8s-manifests`: migrated
* `k8s-helm-http`: migrated
* `k8s-helm-coralogix`: depends on older version (0.0.3)
* `ecs-fargate`: depends on https://github.com/aws/aws-for-fluent-bit , which is dependent on older version (1.9.10)
* `eks-fargate`: depends on https://github.com/aws/aws-for-fluent-bit , which is dependent on older version (1.9.10)

# How Has This Been Tested?

Run both manifests and helm chart on local k8s cluster, compared output to Coralogix with previous version to make sure there is no difference.

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
