### PR TITLE
[otel-eks-fargate] Fix incorrect overwrite of k8s.node.name

### DIFF
--- a/otel-eks-fargate/CHANGELOG.md
+++ b/otel-eks-fargate/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## OpenTelemetry EKS-Fargate
 
+### v0.0.5 / 2025-05-14
+* [FIX] Remove overwrite of k8s.node.name attribute
+
 ### v0.0.4 / 2025-05-06
 * [FEAT] Add k8sattributes proccesor
 

--- a/otel-eks-fargate/cx-eks-fargate-otel.yaml
+++ b/otel-eks-fargate/cx-eks-fargate-otel.yaml
@@ -140,9 +140,6 @@ data:
           - key: "k8s.cluster.name"
             value: "${env:K8S_CLUSTER_NAME}"
             action: upsert
-          - key: "k8s.node.name"
-            value: "${env:K8S_NODE_NAME}"
-            action: upsert
     
       # add EKS metadata
       resourcedetection:


### PR DESCRIPTION
# Description

The value of `k8s_node_name` label set in telemetry from this integration is incorrect. It is incorrectly set to the **node** where the `fargate-otel-collector pod` is running

Fixes # CDS-2130

# How Has This Been Tested?
Verified in lab and with customer that the correct value is set after removing the k8s.node.name upsert in the resource/metadata processor.  

# Checklist:
- [ ] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
