### PR TITLE
update opentelemetry chart to latest (0.115.1)

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.176 / 2025-05-19
+- [Feat] Update Collector to v0.126.0
+- [Update] `kubeletstatsreceiver`: set `collect_all_network_interfaces` on `pods`
+
 ### v0.0.175 / 2025-05-19
 - [Fix] Fix utilization metric name and unit in `kubeletMetrics` preset to keep the metrics' backward compatibility for dashboards
 

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.175
+version: 0.0.176
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -11,27 +11,27 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.114.5"
+    version: "0.115.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-windows
-    version: "0.114.5"
+    version: "0.115.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-windows.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-cluster-collector
-    version: "0.114.5"
+    version: "0.115.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-cluster-collector.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-receiver
-    version: "0.114.5"
+    version: "0.115.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-receiver.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-gateway
-    version: "0.114.5"
+    version: "0.115.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-gateway.enabled
   - name: coralogix-ebpf-agent

--- a/otel-integration/k8s-helm/README.md
+++ b/otel-integration/k8s-helm/README.md
@@ -361,7 +361,7 @@ receivers:
     collection_interval: 20s
     endpoint: ${K8S_NODE_NAME}:10250
     collect_all_network_interfaces:
-      pod: false
+      pod: true
       node: true
 ```
 


### PR DESCRIPTION
# Description

This will update opentelemetry chart to latest (0.115.1) deploying those 2 changes:  https://github.com/coralogix/opentelemetry-helm-charts/pull/180 and https://github.com/coralogix/opentelemetry-helm-charts/pull/181

# Checklist:
- [ ] I have updated the relevant Helm chart(s) version(s)
- [ ] I have updated the relevant component changelog(s)

