### PR TITLE
fix: [otel-integration] disable cx exporter for spans in tail-sampling

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## OpenTelemtry-Integration
 
+### v0.0.181 / 2025-06-05
+- [Fix] Disable Coralogix exporter for tracing pipeline when tail-sampling is used.
+
 ### v0.0.180 / 2025-06-04
 - [Feat] Use newly added presets instead of hardcoding stuff in values.yaml
 

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.180
+version: 0.0.181
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/central-agent-values.yaml
+++ b/otel-integration/k8s-helm/central-agent-values.yaml
@@ -14,6 +14,11 @@ global:
 distribution: ""
 opentelemetry-agent:
   enabled: true
+  presets:
+    coralogixExporter:
+      enabled: true
+      privateKey: ${env:CORALOGIX_PRIVATE_KEY}
+      pipeline: none
   config:
     exporters:
       otlp:
@@ -27,6 +32,12 @@ opentelemetry-agent:
         traces:
           exporters:
             - otlp
+        logs:
+          exporters:
+            - coralogix
+        metrics:
+          exporters:
+            - coralogix
 
 opentelemetry-cluster-collector:
   enabled: true

--- a/otel-integration/k8s-helm/tail-sampling-values.yaml
+++ b/otel-integration/k8s-helm/tail-sampling-values.yaml
@@ -10,6 +10,11 @@ opentelemetry-agent:
   enabled: true
   mode: daemonset
   presets:
+    coralogixExporter:
+      enabled: true
+      privateKey: ${env:CORALOGIX_PRIVATE_KEY}
+      pipeline: none
+
     loadBalancing:
       enabled: true
       routingKey: "traceID"
@@ -23,6 +28,12 @@ opentelemetry-agent:
         traces:
           exporters:
             - loadbalancing
+        logs:
+          exporters:
+            - coralogix
+        metrics:
+          exporters:
+            - coralogix
 
 opentelemetry-gateway:
   enabled: true

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "warn"
   collectionInterval: "30s"
-  version: "0.0.180"
+  version: "0.0.181"
 
   extensions:
     kubernetesDashboard:

--- a/otel-supervised-collector/README.md
+++ b/otel-supervised-collector/README.md
@@ -58,7 +58,7 @@ testing purposes and are not part of the released image.
 ### Configuration variables
 
 | Variable            | Description                            | Default                     |
-| ------------------- | -------------------------------------- | --------------------------- |
+|---------------------|----------------------------------------|-----------------------------|
 | `IMAGE_NAME`        | Container image name                   | `otel-supervised-collector` |
 | `IMAGE_TAG`         | Container image tag                    | `latest`                    |
 | `COLLECTOR_VERSION` | OpenTelemetry Collector version        | `0.127.0`                   |
@@ -77,16 +77,19 @@ testing purposes and are not part of the released image.
 ### Usage examples
 
 #### Basic build
+
 ```bash
 make build
 ```
 
 #### Build with a custom OpenTelemetry Collector version
+
 ```bash
 make build COLLECTOR_VERSION=0.128.0
 ```
 
 #### Build with custom image tag
+
 ```bash
 # Build with custom image tag
 make build IMAGE_TAG=v1.0.0
@@ -96,6 +99,7 @@ make build IMAGE_TAG=v1.0.0 IMAGE_NAME=supervised-collector COLLECTOR_VERSION=0.
 ```
 
 #### Multi-Architecture Builds
+
 ```bash
 # Build for multiple architectures (validates build but doesn't export)
 make build-multiarch


### PR DESCRIPTION
# Description

<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> Fixes ES-522

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the relevant Helm chart(s) version(s)
- [ ] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
