### PR TITLE
[otel-integration] Fix image template helper with Supervisor preset

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## OpenTelemtry-Integration
+## OpenTelemetry-Integration
+
+### v0.0.188 / 2025-06-12
+- [Fix] Fix `image` template helper when using the Supervisor preset and when using the Collector CRDs.
 
 ### v0.0.187 / 2025-06-12
 - [Feat] Add an alpha `supervisor` preset under the `fleetManagement` preset

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.187
+version: 0.0.188
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -11,27 +11,27 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.115.27"
+    version: "0.115.28"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-windows
-    version: "0.115.27"
+    version: "0.115.28"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-windows.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-cluster-collector
-    version: "0.115.27"
+    version: "0.115.28"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-cluster-collector.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-receiver
-    version: "0.115.27"
+    version: "0.115.28"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-receiver.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-gateway
-    version: "0.115.27"
+    version: "0.115.28"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-gateway.enabled
   - name: coralogix-ebpf-agent

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "info"
   collectionInterval: "30s"
-  version: "0.0.187"
+  version: "0.0.188"
 
   extensions:
     kubernetesDashboard:


### PR DESCRIPTION
# Description

Fixes ES-629.

Brings the fixes from https://github.com/coralogix/opentelemetry-helm-charts/pull/218.

# How Has This Been Tested?

Local tests.

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
