### PR TITLE
add opentelemetry-ebpf-instrumentation

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## OpenTelemetry-Integration
 
+### v0.0.190 / 2025-06-15
+- [Feat] Add opentelemetry-ebpf-instrumentation subchart.
+
 ### v0.0.189 / 2025-06-13
 - [Fix] Fix `command` template helper when using the Supervisor preset.
 

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -44,6 +44,11 @@ dependencies:
     version: "0.0.5"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts
     condition: coralogix-ebpf-profiler.enabled
+  - name: opentelemetry-ebpf-instrumentation
+    alias: opentelemetry-ebpf-instrumentation
+    version: "0.1.0"
+    repository: https://cgx.jfrog.io/artifactory/coralogix-charts
+    condition: opentelemetry-ebpf-instrumentation.enabled
 sources:
   - https://github.com/coralogix/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector
 maintainers:

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.189
+version: 0.0.190
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/README.md
+++ b/otel-integration/k8s-helm/README.md
@@ -1218,6 +1218,9 @@ The generated `kubernetes_sd_configs` is a common configuration syntax for disco
 
 ## Coralogix EBPF Agent
 
+> [WARNING] - The Coralogix EBPF Agent is deprecated and will be removed in a future release. Please use [OpenTelemetry EBPF Instrumentation](#opentelemetry-ebpf-instrumentation) instead.
+
+
 The Coralogix EBPF Agent (`coralogix-ebpf-agent`) is an agent developed by Coralogix using EBPF to extract network traffic as spans (HTTP requests, SQL traffic, etc.), enabling APM capabilities without service instrumentation.
 To enable the coralogix-ebpf-agent deployment, set `coralogix-ebpf-agent.enabled` to `true` in the `values.yaml` file.
 
@@ -1286,6 +1289,18 @@ helm repo add coralogix-charts-virtual https://cgx.jfrog.io/artifactory/coralogi
 helm upgrade --install otel-coralogix-integration coralogix-charts-virtual/otel-integration  \
   --render-subchart-notes -f values-ebpf-profiler.yaml \  
 ```
+
+## Opentelemetry EBPF Instrumentation
+The [OpenTelemetry EBPF Instrumentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation) is an OpenTelemetry component that uses eBPF to collect telemetry data from the Linux kernel, such as network metrics and spans,  without requiring modifications to the application code.
+To enable the OpenTelemetry EBPF Instrumentation, set `opentelemetry-ebpf-instrumenat.enabled` to `true` in the `values.yaml` file.
+
+for a full list of values for this chart, please look at [values.yaml])(https://github.com/coralogix/opentelemetry-helm-charts/blob/main/charts/opentelemetry-ebpf-instrumentation/values.yaml)
+
+### K8s Cache
+The OpenTelemetry EBPF Instrumentation includes a K8s Cache component that collects Kubernetes metadata and enriches the telemetry data with Kubernetes labels. This allows you to correlate the telemetry data with Kubernetes resources, such as Pods, Nodes, and Namespaces.
+The K8s Cache Component is critical for large scale kubernetes clusters, as it allows takes load of the K8s API Server by isolating the calls to only the K8s Cache services.
+The K8s Cache is turned on by default, with 2 replicas for high availability. You can configure the number of replicas by setting `opentelemetry-ebpf-instrumentation.k8sCache.replicas` in the `values.yaml` file.
+to turn off the K8s Cache, set `opentelemetry-ebpf-instrumentation.k8sCache.replicas` to `0` in the `values.yaml` file.
 
 # How to use it
 

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -829,6 +829,11 @@ coralogix-ebpf-profiler:
       requests:
         cpu: 100m
         memory: 128Mi
+
+opentelemetry-ebpf-instrumentation:
+  enabled: false
+  k8sCache:
+    replicas: 2
 #  priorityClass:
 #    create: false
 #    name: ""

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "info"
   collectionInterval: "30s"
-  version: "0.0.189"
+  version: "0.0.190"
 
   extensions:
     kubernetesDashboard:


### PR DESCRIPTION
# Description

<!-- Please describe the changes you made in a few words or sentences. -->
adds new subchart for [opentelemetry-ebpf-instrumentation](https://github.com/coralogix/opentelemetry-helm-charts/tree/main/charts/opentelemetry-ebpf-instrumentation)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. package chart:
```bash
helm package -u ./otel-integration/k8s-helm
```

2. install on cluster, enabling opentelemetry-ebpf-instrumentation
```bash
helm upgrade --install otel-coralogix-integration ./otel-integration/otel-integration-0.0.189.tgz \
  --render-subchart-notes \
  --set global.domain=<<domain>> \
  --set global.clusterName=<<cluster>> \
  --set opentelemetry-ebpf-instrumentation.enabled=true
```

3. validating opentelemetry-ebpf-instruemntation and otel-ebpf-k8s-cache pods
```bash
kubectl get pods | grep ebpf
```
```
otel-coralogix-integration-opentelemetry-ebpf-instrumentatq8ht7   1/1     Running   0          18m
otel-coralogix-integration-opentelemetry-ebpf-instrumentatv9jdb   1/1     Running   0          18m
otel-ebpf-k8s-cache-7b795676c5-4jmg5                              1/1     Running   0          18m
otel-ebpf-k8s-cache-7b795676c5-tt7sq                              1/1     Running   0          18m
```

4. validate metric and trace data being sent to coralogix from ebpf agent

# Checklist:
- [ ] I have updated the relevant Helm chart(s) version(s)
- [ ] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
