### PR TITLE
add presets.coralogixExporter.pipelines to allow enabling exporter on 2 pipelines at once

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## OpenTelemetry-Integration
 
+### v0.0.196 / 2025-07-02
+- [Breaking] Rewrite `presets.coralogixExporter.pipeline` from `string` to `array` to allow enabling exporter on 2 pipelines at once.
+
 ### v0.0.195 / 2025-07-02
 - [Fix] Support templating for `presets.resourceDetection.deploymentEnvironmentName`.
 

--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## OpenTelemetry-Integration
 
 ### v0.0.196 / 2025-07-02
-- [Breaking] Rewrite `presets.coralogixExporter.pipeline` from `string` to `array` to allow enabling exporter on 2 pipelines at once.
+- [Feat] Add new variable `presets.coralogixExporter.pipelines` as an `array[string]` to allow enabling exporter on 2 pipelines at once. The old variable `presets.coralogixExporter.pipeline` is still available, but deprecated
 
 ### v0.0.195 / 2025-07-02
 - [Fix] Support templating for `presets.resourceDetection.deploymentEnvironmentName`.

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.195
+version: 0.0.196
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -11,27 +11,27 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.116.2"
+    version: "0.116.3"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-windows
-    version: "0.116.2"
+    version: "0.116.3"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-windows.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-cluster-collector
-    version: "0.116.2"
+    version: "0.116.3"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-cluster-collector.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-receiver
-    version: "0.116.2"
+    version: "0.116.3"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-receiver.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-gateway
-    version: "0.116.2"
+    version: "0.116.3"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-gateway.enabled
   - name: coralogix-ebpf-agent

--- a/otel-integration/k8s-helm/central-agent-values.yaml
+++ b/otel-integration/k8s-helm/central-agent-values.yaml
@@ -18,7 +18,7 @@ opentelemetry-agent:
     coralogixExporter:
       enabled: true
       privateKey: ${env:CORALOGIX_PRIVATE_KEY}
-      pipeline: ["none"]
+      pipelines: ["none"]
   config:
     exporters:
       otlp:

--- a/otel-integration/k8s-helm/central-agent-values.yaml
+++ b/otel-integration/k8s-helm/central-agent-values.yaml
@@ -18,7 +18,7 @@ opentelemetry-agent:
     coralogixExporter:
       enabled: true
       privateKey: ${env:CORALOGIX_PRIVATE_KEY}
-      pipeline: none
+      pipeline: ["none"]
   config:
     exporters:
       otlp:

--- a/otel-integration/k8s-helm/tail-sampling-values.yaml
+++ b/otel-integration/k8s-helm/tail-sampling-values.yaml
@@ -13,7 +13,7 @@ opentelemetry-agent:
     coralogixExporter:
       enabled: true
       privateKey: ${env:CORALOGIX_PRIVATE_KEY}
-      pipeline: ["none"]
+      pipelines: ["none"]
 
     loadBalancing:
       enabled: true

--- a/otel-integration/k8s-helm/tail-sampling-values.yaml
+++ b/otel-integration/k8s-helm/tail-sampling-values.yaml
@@ -13,7 +13,7 @@ opentelemetry-agent:
     coralogixExporter:
       enabled: true
       privateKey: ${env:CORALOGIX_PRIVATE_KEY}
-      pipeline: none
+      pipeline: ["none"]
 
     loadBalancing:
       enabled: true

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -721,7 +721,7 @@ opentelemetry-receiver:
     coralogixExporter:
       enabled: true
       privateKey: ${env:CORALOGIX_PRIVATE_KEY}
-      pipeline: ["none"]
+      pipelines: ["none"]
   config:
     # exporters: {}
     # processors: {}

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "info"
   collectionInterval: "30s"
-  version: "0.0.195"
+  version: "0.0.196"
 
   extensions:
     kubernetesDashboard:
@@ -721,7 +721,7 @@ opentelemetry-receiver:
     coralogixExporter:
       enabled: true
       privateKey: ${env:CORALOGIX_PRIVATE_KEY}
-      pipeline: "none"
+      pipeline: ["none"]
   config:
     # exporters: {}
     # processors: {}


### PR DESCRIPTION
Fixes CDS-2254 by deploying https://github.com/coralogix/opentelemetry-helm-charts/pull/234

This change will add new variable `presets.coralogixExporter.pipelines` as an `array` of `string` to allow enabling exporter on 2 pipelines at once.

So that in cases where we want to disable, let's say, coralogix exporter only in one pipeline, we could do this:

```
opentelemetry-agent:
  presets:
    coralogixExporter:
      enabled: true
      pipelines: ["metrics", "traces"]
```

instead of this:

```
opentelemetry-agent:
  presets:
    coralogixExporter:
      enabled: true
      pipeline: "none"
  config:
    service:
      pipelines:
        metrics:
          exporters:
            - coralogix
        traces:
          exporters:
            - coralogix
```

We've added a new variable instead of changing the existing one (`presets.coralogixExporter.pipeline`) for backward compatibility. The existing one `pipeline` will be deprecated in the future. For now, `pipelineS` will take precedence, while `pipeline` will be converted into array when set.