### PR TITLE
fix: remove confusing comments about clusterRole in priorityClass

### DIFF
--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -88,7 +88,6 @@ opentelemetry-agent:
   # priorityClass:
   #   # Specifies whether a priorityClass should be created.
   #   create: false
-  #   # The name of the clusterRole to use.
   #   # If not set a name is generated using the fullname template.
   #   name: ""
   #   # Sets the priority value of the priority class.
@@ -345,7 +344,6 @@ opentelemetry-cluster-collector:
   # priorityClass:
   #   # Specifies whether a priorityClass should be created.
   #   create: false
-  #   # The name of the clusterRole to use.
   #   # If not set a name is generated using the fullname template.
   #   name: ""
   #   # Sets the priority value of the priority class.


### PR DESCRIPTION
# Description

<!-- Please describe the changes you made in a few words or sentences. -->
- This PR removes a confusing comment about name of clusterRole to use right below name field for a priorityClass. Hence, removed it. clusterRole section is one step above it, not in middle of priorityClass and its already pre-defined.

# Checklist:
- [x] This change does not affect any particular component (e.g. it's CI or docs change)