### PR TITLE
An 331 ipv6

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## OpenTelemetry-Integration
 
+### v0.0.199 / 2025-07-09
+- [Feat] add k8s ipv6 support for ebpf-profiler sub-chart, fix ipv6-values.yaml to support change in address fields.
+
 ### v0.0.198 / 2025-07-09
 - [Fix] Apply `transform/prometheus` rule only for metrics from the Collector itself.
 

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.198
+version: 0.0.199
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -41,7 +41,7 @@ dependencies:
     condition: coralogix-ebpf-agent.enabled
   - name: coralogix-ebpf-profiler
     alias: coralogix-ebpf-profiler
-    version: "0.0.10"
+    version: "0.0.11"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts
     condition: coralogix-ebpf-profiler.enabled
   - name: opentelemetry-ebpf-instrumentation

--- a/otel-integration/k8s-helm/ipv6-values.yaml
+++ b/otel-integration/k8s-helm/ipv6-values.yaml
@@ -41,7 +41,12 @@ opentelemetry-agent:
     service:
       telemetry:
         metrics:
-          address: "[${env:MY_POD_IP}]:8888"
+          readers:
+            - pull:
+                exporter:
+                  prometheus:
+                    host: "[${env:MY_POD_IP}]"
+                    port: 8888
 
 opentelemetry-cluster-collector:
   enabled: true
@@ -80,5 +85,20 @@ opentelemetry-cluster-collector:
     service:
       telemetry:
         metrics:
-          address: "[${env:MY_POD_IP}]:8888"
+          readers:
+            - pull:
+                exporter:
+                  prometheus:
+                    host: "[${env:MY_POD_IP}]"
+                    port: 8888
 
+coralogix-ebpf-profiler:
+  k8s_watcher:
+    http:
+      host: "[::]"
+  profiling:
+    profiling_otel_agent:
+      otel:
+        exporter:
+        # configure the opentelemetry collector endpoint here
+          endpoint: "[$(HOST_IP)]:4317"

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "info"
   collectionInterval: "30s"
-  version: "0.0.198"
+  version: "0.0.199"
   deploymentEnvironmentName: ""
 
   extensions:


### PR DESCRIPTION
# Description

Support ipv6 for ebpf-profiler

# How Has This Been Tested?
I checked the helm otel-integration release with both ipv6 and ipv4 clusters.

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
