### PR TITLE
Bump otel-integration collector chart

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## OpenTelemetry-Integration
 
+### v0.1.0 / 2025-07-18
+- [Fix] Skip prometheus receiver from collectorMetrics preset when PodMonitor or ServiceMonitor is enabled
+- [Fix] Remove extra blank lines when rendering container ports
+- [Feat] Allow disabling the /var/lib/dbus/machine-id mount via `presets.resourceDetection.dbusMachineId.enabled`
+- [Feat] Enable `without_units` in collector metrics preset
+- [Feat] Add transactions preset to group spans into transactions and enable Coralogix transaction processor
+- [Feat] Add `networkMode` option to configure IPv4 or IPv6 endpoints
+- [Feat] Update Collector to v0.130.0
+- [Feat] Update Collector to v0.130.0
+- [Feat] Allow configuring `aggregation_cardinality_limit` for spanMetrics presets.
+
 ### v0.0.202 / 2025-07-14
 - [Feat] Add E2E test for hostEntityEvents preset.
 

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.202
+version: 0.1.0
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -11,27 +11,27 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.117.3"
+    version: "0.118.6"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-windows
-    version: "0.117.3"
+    version: "0.118.6"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-windows.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-cluster-collector
-    version: "0.117.3"
+    version: "0.118.6"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-cluster-collector.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-receiver
-    version: "0.117.3"
+    version: "0.118.6"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-receiver.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-gateway
-    version: "0.117.3"
+    version: "0.118.6"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-gateway.enabled
   - name: coralogix-ebpf-agent

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "info"
   collectionInterval: "30s"
-  version: "0.0.202"
+  version: "0.1.0"
   deploymentEnvironmentName: ""
 
   extensions:


### PR DESCRIPTION
## Summary
- update otel-integration chart to version 0.1.0
- bump all opentelemetry-collector subcharts to 0.118.6
- document collector chart upgrade in CHANGELOG

## Testing
- `git diff --staged --name-only`

------
https://chatgpt.com/codex/tasks/task_b_687a190bef9483229423f27f45832c1a