### PR TITLE
Update integration-definition workflow to handle new versioning scheme

### DIFF
--- a/.github/workflows/Sync-integration-definition.yaml
+++ b/.github/workflows/Sync-integration-definition.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 jobs:
 
-  Get_vesrion:
+  Get_version:
     runs-on: ubuntu-latest
     name: Get the new version
     outputs:
@@ -25,7 +25,7 @@ jobs:
 
   commit_changes:
     runs-on: ubuntu-latest
-    needs: Get_vesrion
+    needs: Get_version
     steps:
       - name: Checkout destination repository
         uses: actions/checkout@v4
@@ -37,7 +37,7 @@ jobs:
         id: version_exist
         run: | 
           git fetch origin
-          template_version=${{ needs.Get_vesrion.outputs.Chart_version }}
+          template_version=${{ needs.Get_version.outputs.Chart_version }}
           if [ -d "./integrations/otel-agent-k8s/v$template_version" ]; then
             echo "version exist"
             echo "new_version_exist=true" >> $GITHUB_ENV
@@ -59,20 +59,21 @@ jobs:
           git push origin $branch_name
 
           current_time=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-          template_version=${{ needs.Get_vesrion.outputs.Chart_version }}
-          mkdir -p integrations/otel-agent-k8s/v${template_version}
+          template_version=${{ needs.Get_version.outputs.Chart_version }}
           last_version=$(grep  "revision: " ./integrations/otel-agent-k8s/manifest.yaml | tail -n 1 | grep -oE '[^ ]+$')
-          cp integrations/otel-agent-k8s/v$last_version/commands.yaml integrations/otel-agent-k8s/v${template_version}/
-          cp integrations/otel-agent-k8s/v$last_version/fields.yaml integrations/otel-agent-k8s/v${template_version}/
-          cp integrations/otel-agent-k8s/v$last_version/integration_guide.yaml integrations/otel-agent-k8s/v${template_version}/
-          sed -i "s/--version=[^[:space:]]*/--version=$template_version/" integrations/otel-agent-k8s/v${template_version}/commands.yaml
+          integration_version=$(echo $last_version | sed 's/+.*//')
+          mkdir -p integrations/otel-agent-k8s/v${integration_version}+${template_version}
+          cp integrations/otel-agent-k8s/v$last_version/commands.yaml integrations/otel-agent-k8s/v${integration_version}+${template_version}/
+          cp integrations/otel-agent-k8s/v$last_version/fields.yaml integrations/otel-agent-k8s/v${integration_version}+${template_version}/
+          cp integrations/otel-agent-k8s/v$last_version/integration_guide.yaml integrations/otel-agent-k8s/v${integration_version}+${template_version}/
+          sed -i "s/--version=[^[:space:]]*/--version=$template_version/" integrations/otel-agent-k8s/v${integration_version}+${template_version}/commands.yaml
           if [ -f ./integrations/otel-agent-k8s/manifest.yaml ]; then
-            echo "  - revision: ${template_version}
+            echo "  - revision: ${integration_version}+${template_version}
               template:
                 type: HelmChart
-                commands: v${template_version}/commands.yaml
-                integration_guide: v${template_version}/integration_guide.yaml
-              field_definitions: v${template_version}/fields.yaml
+                commands: v${integration_version}+${template_version}/commands.yaml
+                integration_guide: v${integration_version}+${template_version}/integration_guide.yaml
+              field_definitions: v${integration_version}+${template_version}/fields.yaml
               published_at: $current_time" >> integrations/otel-agent-k8s/manifest.yaml
           fi
           git add .


### PR DESCRIPTION
# Description
https://coralogix.atlassian.net/browse/NGSTN-1969

`otel-agent-k8s` is now versioned differently; it's no longer tightly coupled with chart version, but it keeps chart version in build metadata part of semver. That PR aligns automated logic to handle that new versioning scheme. 

# How Has This Been Tested?
I've tested the updated script logic on my local machine
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
~~- [ ] I have updated the relevant Helm chart(s) version(s)~~
~~- [ ] I have updated the relevant component changelog(s)~~
~~- [ ] This change does not affect any particular component (e.g. it's CI or docs change)~~
