### PR TITLE
Bump otel integration collector chart

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## OpenTelemetry-Integration
 
+### v0.0.203 / 2025-07-24
+- [Feat] Add additional Prometheus transform rules for collector metrics preset.
+- [Feat] Fail installation if kubernetesResources preset is enabled in daemonset mode.
+- [Feat] Set spanMetrics aggregationCardinalityLimit default to 100000.
+- [Feat] Update Collector to v0.130.1
+- [Feat] Add `reduceLogAttributes` preset to remove specified log record attributes from collected logs.
+- [Fix] Set `error_mode` to `silent` for the transformations of the `reduceResourceAttributes` and `reduceLogAttributes` presets.
+- [Feat] Add `host.image.id` to the `reduceResourceAttributes` preset.
+- [Fix] `command.name` override put back in place.
+- [Fix] `k8sResourceAttributes` preset works correctly when the `fleetManagement` preset is enabled.
+- [Feat] The `reduceResourceAttributes` preset now also removes attributes from traces and logs pipelines.
+- [Feat] The `reduceResourceAttributes` preset now removes a few more attributes.
+- [Fix] Remove `without_units` from collector metrics preset.
+- [Fix] Skip prometheus receiver from collectorMetrics preset when PodMonitor or ServiceMonitor is enabled.
+- [Fix] Remove extra blank lines when rendering container ports.
+- [Feat] Allow disabling the /var/lib/dbus/machine-id mount via `presets.resourceDetection.dbusMachineId.enabled`.
+- [Feat] Enable `without_units` in collector metrics preset.
+- [Feat] Add transactions preset to group spans into transactions and enable Coralogix transaction processor.
+- [Feat] Add `networkMode` option to configure IPv4 or IPv6 endpoints.
+- [Feat] Update Collector to v0.130.0.
+- [Feat] Update Collector to v0.130.0.
+- [Feat] Allow configuring `aggregation_cardinality_limit` for spanMetrics presets.
+
 ### v0.0.202 / 2025-07-14
 - [Feat] Add E2E test for hostEntityEvents preset.
 

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.202
+version: 0.0.203
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -11,27 +11,27 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.117.3"
+    version: "0.118.16"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-windows
-    version: "0.117.3"
+    version: "0.118.16"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-windows.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-cluster-collector
-    version: "0.117.3"
+    version: "0.118.16"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-cluster-collector.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-receiver
-    version: "0.117.3"
+    version: "0.118.16"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-receiver.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-gateway
-    version: "0.117.3"
+    version: "0.118.16"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-gateway.enabled
   - name: coralogix-ebpf-agent

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "info"
   collectionInterval: "30s"
-  version: "0.0.202"
+  version: "0.0.203"
   deploymentEnvironmentName: ""
 
   extensions:


### PR DESCRIPTION
## Summary
- bump otel-collector subchart versions to `0.118.16`
- bump otel-integration chart version to `0.0.203`
- update global chart version
- document latest collector changes

## Testing
- `make check-docs` *(fails: mdox could not be installed)*

------
https://chatgpt.com/codex/tasks/task_b_6881f465bc9c83228b851109ece26198