### PR TITLE
[otel-integration] Add `compactMetrics` option and fix `headSampling` preset

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemetry-Integration
 
+### v0.0.208 / 2025-08-05
+- [Fix] `headSampling` preset correctly removes `coralogix` exporter from the `traces` pipeline.
+- [Feat] Add compactMetrics option to spanMetrics preset.
+
 ### v0.0.207 / 2025-08-05
 - [Feat] remove `coralogix-ebpf-agent` subchart, as now we recommend using `opentelemetry-ebpf-instrumentation` chart.
 

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.207
+version: 0.0.208
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -11,27 +11,27 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.118.24"
+    version: "0.118.26"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-windows
-    version: "0.118.24"
+    version: "0.118.26"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-windows.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-cluster-collector
-    version: "0.118.24"
+    version: "0.118.26"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-cluster-collector.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-receiver
-    version: "0.118.24"
+    version: "0.118.26"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-receiver.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-gateway
-    version: "0.118.24"
+    version: "0.118.26"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-gateway.enabled
   - name: coralogix-ebpf-profiler

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "info"
   collectionInterval: "30s"
-  version: "0.0.207"
+  version: "0.0.208"
   deploymentEnvironmentName: ""
 
   extensions:


### PR DESCRIPTION
# Description

Fixes ES-718 and ES-715.

Should bring the changes from https://github.com/coralogix/opentelemetry-helm-charts/pull/271 and https://github.com/coralogix/opentelemetry-helm-charts/pull/272.

# How Has This Been Tested?

Linting, examples, and manual verification.

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
