### PR TITLE
Fix profileCollection preset to properly add coralogix exporter to profiles pipeline

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## OpenTelemetry-Integration
 
+### v0.0.210 / 2025-08-07
+- [Fix] `profilesCollection` preset correctly adds `coralogix` exporter to `profiles` pipeline.
+
 ### v0.0.209 / 2025-08-07
 - [Feat] add option to drop compact duration histogram in spanMetrics preset.
 

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.209
+version: 0.0.210
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -11,27 +11,27 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.118.27"
+    version: "0.118.28"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-windows
-    version: "0.118.27"
+    version: "0.118.28"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-windows.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-cluster-collector
-    version: "0.118.27"
+    version: "0.118.28"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-cluster-collector.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-receiver
-    version: "0.118.27"
+    version: "0.118.28"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-receiver.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-gateway
-    version: "0.118.27"
+    version: "0.118.28"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-gateway.enabled
   - name: coralogix-ebpf-profiler

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "info"
   collectionInterval: "30s"
-  version: "0.0.209"
+  version: "0.0.210"
   deploymentEnvironmentName: ""
 
   extensions:


### PR DESCRIPTION
## Summary
- Bump `otel-integration` chart version to `0.0.210` and dependencies to `0.118.28`
- Update global chart version in values
- Document the change in changelog

## Testing
- `helm dependency update` *(fails: no cached repository)*
- `helm lint . --set global.domain=example.com,global.clusterName=test`
