### PR TITLE
chore: bump otel-integration to v0.0.216

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## OpenTelemetry-Integration
 
+### v0.0.216 / 2025-08-19
+- [Feat] Add Kubernetes service resolver to load balancing preset and required RBAC.
+
 ### v0.0.215 / 2025-08-12
 - [Fix] Tail sampling values: correct Coralogix preset pipelines syntax.
 

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.215
+version: 0.0.216
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -11,27 +11,27 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.119.0"
+    version: "0.119.3"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-windows
-    version: "0.119.0"
+    version: "0.119.3"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-windows.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-cluster-collector
-    version: "0.119.0"
+    version: "0.119.3"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-cluster-collector.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-receiver
-    version: "0.119.0"
+    version: "0.119.3"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-receiver.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-gateway
-    version: "0.119.0"
+    version: "0.119.3"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-gateway.enabled
   - name: coralogix-ebpf-profiler

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "info"
   collectionInterval: "30s"
-  version: "0.0.215"
+  version: "0.0.216"
   deploymentEnvironmentName: ""
 
   extensions:


### PR DESCRIPTION
## Summary
- bump otel-integration chart and dependencies to latest opentelemetry-collector chart
- update global version and changelog
- remove outdated rate limiter notes from v0.0.216 changelog entry

## Testing
- `helm repo add coralogix https://cgx.jfrog.io/artifactory/coralogix-charts-virtual` *(fails: Forbidden)*
- `helm dependency update otel-integration/k8s-helm` *(fails: repository not reachable)*
- `helm lint otel-integration/k8s-helm`
- `scripts/changelog_check.sh otel-integration` *(fails: unknown revision origin/master)*
- `scripts/version_bump_check.sh otel-integration` *(fails: unknown revision origin/master)*

------
https://chatgpt.com/codex/tasks/task_b_68a456e52dcc8322a918914194737b3d