### PR TITLE
chore: update otel-integration chart

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## OpenTelemetry-Integration
 
+### v0.0.219 / 2025-09-05
+- [Feat] Coralogix exporter: add exporter helper settings (retry_on_failure, sending_queue); flatten values to `presets.coralogixExporter.retryOnFailure` and `sendingQueue`; add example and schema support.
+
 ### v0.0.218 / 2025-09-03
 - [Fix] Fix quoting issue with EKS Fargate `collectionInterval`.
 - [Fix] Fix `otel_annotations` field intendation for `k8sattributes/profiles`.

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.218
+version: 0.0.219
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -11,37 +11,37 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.119.13"
+    version: "0.119.14"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-windows
-    version: "0.119.13"
+    version: "0.119.14"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-windows.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-cluster-collector
-    version: "0.119.13"
+    version: "0.119.14"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-cluster-collector.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-receiver
-    version: "0.119.13"
+    version: "0.119.14"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-receiver.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-gateway
-    version: "0.119.13"
+    version: "0.119.14"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-gateway.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-eks-fargate
-    version: "0.119.13"
+    version: "0.119.14"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-eks-fargate.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-eks-fargate-monitoring
-    version: "0.119.13"
+    version: "0.119.14"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-eks-fargate-monitoring.enabled
   - name: coralogix-ebpf-profiler

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "info"
   collectionInterval: "30s"
-  version: "0.0.218"
+  version: "0.0.219"
   deploymentEnvironmentName: ""
 
   extensions:


### PR DESCRIPTION
## Summary
- bump otel-integration chart version and global version to 0.0.219
- upgrade opentelemetry-collector dependencies to 0.119.14
- document changes from collector 0.119.14 in changelog

## Testing
- `helm lint otel-integration/k8s-helm --set global.domain="example.com" --set global.clusterName="cluster"`

------
https://chatgpt.com/codex/tasks/task_b_68ba860054ac83229ac5e7b6d2db10a7