### PR TITLE
chore: bump otel collector chart to 0.120.0

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## OpenTelemetry-Integration
 
+### v0.0.224 / 2025-09-24
+- [CHORE] Bump Collector to 0.136.0
+
 ### v0.0.223 / 2025-09-18
 - [Fix] filter k8s node on k8sattributes/profiles processor
 

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.223
+version: 0.0.224
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -11,37 +11,37 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.119.18"
+    version: "0.120.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-windows
-    version: "0.119.18"
+    version: "0.120.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-windows.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-cluster-collector
-    version: "0.119.18"
+    version: "0.120.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-cluster-collector.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-receiver
-    version: "0.119.18"
+    version: "0.120.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-receiver.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-gateway
-    version: "0.119.18"
+    version: "0.120.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-gateway.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-eks-fargate
-    version: "0.119.18"
+    version: "0.120.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-eks-fargate.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-eks-fargate-monitoring
-    version: "0.119.18"
+    version: "0.120.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-eks-fargate-monitoring.enabled
   - name: coralogix-ebpf-profiler

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "info"
   collectionInterval: "30s"
-  version: "0.0.223"
+  version: "0.0.224"
   deploymentEnvironmentName: ""
 
   extensions:


### PR DESCRIPTION
## Summary
- bump the otel-integration chart version to 0.0.224 and align the global version
- update all opentelemetry-collector dependency references to 0.120.0
- document the upgrade in the otel-integration changelog

## Testing
- make check-docs *(fails: external documentation links blocked by remote server)*

------
https://chatgpt.com/codex/tasks/task_b_68d3ba37c8f48322a712f5e84ab65e21