### PR TITLE
chore: bump otel collector chart to 0.121.2

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemetry-Integration
 
+### v0.0.227 / 2025-10-08
+- [Feat] Enable the compact span metrics preset by default.
+- [FIX] Route the logs router default path through a continuation stage so extra filelog operators always run and drop the now-redundant export noop stage.
+
 ### v0.0.226 / 2025-10-08
 - [Feat] Enable the `k8sResourceAttributes` preset for the otel agent by default.
 

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.226
+version: 0.0.227
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -11,37 +11,37 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.121.0"
+    version: "0.121.2"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-windows
-    version: "0.121.0"
+    version: "0.121.2"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-windows.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-cluster-collector
-    version: "0.121.0"
+    version: "0.121.2"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-cluster-collector.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-receiver
-    version: "0.121.0"
+    version: "0.121.2"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-receiver.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-gateway
-    version: "0.121.0"
+    version: "0.121.2"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-gateway.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-eks-fargate
-    version: "0.121.0"
+    version: "0.121.2"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-eks-fargate.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-eks-fargate-monitoring
-    version: "0.121.0"
+    version: "0.121.2"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-eks-fargate-monitoring.enabled
   - name: coralogix-ebpf-profiler

--- a/otel-integration/k8s-helm/e2e-test/expected_test.go
+++ b/otel-integration/k8s-helm/e2e-test/expected_test.go
@@ -390,6 +390,7 @@ var expectedMetrics map[string]bool = map[string]bool{
 	"otelcol_processor_batch_batch_size_trigger_send": false,
 	"otelcol_processor_batch_metadata_cardinality":    false,
 	"otelcol_processor_batch_timeout_trigger_send":    false,
+	"otelcol_processor_filter_datapoints.filtered":    false,
 	"otelcol_processor_filter_spans.filtered_ratio":   false,
 	"otelcol_processor_incoming_items":                false,
 	"otelcol_processor_outgoing_items":                false,

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "info"
   collectionInterval: "30s"
-  version: "0.0.226"
+  version: "0.0.227"
   deploymentEnvironmentName: ""
 
   extensions:


### PR DESCRIPTION
## Summary
- bump the otel-integration chart version to 0.0.227 and update the global version value
- update all opentelemetry-collector subchart dependencies to 0.121.2
- add a changelog entry capturing the upstream 0.121.2 changes

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68e66a63cf3483229a16bb9f1e5a73da