### PR TITLE
chore: update otel-integration collector chart to 0.121.3

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## OpenTelemetry-Integration
 
+### v0.0.228 / 2025-10-14
+- [Feat] Enable compact metrics for span-derived database metrics by default.
+
 ### v0.0.227 / 2025-10-08
 - [Feat] Enable the compact span metrics preset by default.
 - [FIX] Route the logs router default path through a continuation stage so extra filelog operators always run and drop the now-redundant export noop stage.

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.227
+version: 0.0.228
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -11,37 +11,37 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.121.2"
+    version: "0.121.3"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-windows
-    version: "0.121.2"
+    version: "0.121.3"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-windows.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-cluster-collector
-    version: "0.121.2"
+    version: "0.121.3"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-cluster-collector.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-receiver
-    version: "0.121.2"
+    version: "0.121.3"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-receiver.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-gateway
-    version: "0.121.2"
+    version: "0.121.3"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-gateway.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-eks-fargate
-    version: "0.121.2"
+    version: "0.121.3"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-eks-fargate.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-eks-fargate-monitoring
-    version: "0.121.2"
+    version: "0.121.3"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-eks-fargate-monitoring.enabled
   - name: coralogix-ebpf-profiler

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "info"
   collectionInterval: "30s"
-  version: "0.0.227"
+  version: "0.0.228"
   deploymentEnvironmentName: ""
 
   extensions:


### PR DESCRIPTION
## Summary
- bump the otel-integration chart and global version to 0.0.228
- update all opentelemetry-collector dependencies to version 0.121.3
- document the collector upgrade in the changelog

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68ee32ef5ec88322b6a66517ad4c7568