### PR TITLE
chore: bump collector chart to 0.121.10

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## OpenTelemetry-Integration
 
+### v0.0.230 / 2025-10-20
+- [Feat] Add `prometheusMulti` preset for scraping multiple Prometheus targets with optional custom labels.
+- [Fix] Emit Prometheus multi-target jobs using the provided target name and only apply CX labels when explicitly configured.
+- [Chore] Standalone example enables the `prometheusMulti` preset with contrasting target configurations.
+- [Feat] Add `journaldReceiver` preset for systemd journal logs with optional directory, unit, and match filters.
+- [Feat] Allow conditional resource attribute removals in the `reduceResourceAttributes` preset via denylist entry conditions.
+- [Feat] Add `spanMetricsSanitization` preset to provide span name, URL, and database statement sanitization when span metrics presets are enabled.
+
 ### v0.0.229 / 2025-10-16
 - [FIX] compact metrics unit name change. compact_duration_count -> compact_duration_ms_count, compact_duration_sum -> compact_duration_ms_sum, db_compact_duration_count -> db_compact_duration_ms_count, compact_duration_sum -> compact_duration_ms_sum
 - [Feat] Allow configuring resource detection detectors for environment and cloud metadata.

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.229
+version: 0.0.230
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -11,37 +11,37 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.121.6"
+    version: "0.121.10"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-windows
-    version: "0.121.6"
+    version: "0.121.10"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-windows.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-cluster-collector
-    version: "0.121.6"
+    version: "0.121.10"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-cluster-collector.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-receiver
-    version: "0.121.6"
+    version: "0.121.10"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-receiver.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-gateway
-    version: "0.121.6"
+    version: "0.121.10"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-gateway.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-eks-fargate
-    version: "0.121.6"
+    version: "0.121.10"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-eks-fargate.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-eks-fargate-monitoring
-    version: "0.121.6"
+    version: "0.121.10"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-eks-fargate-monitoring.enabled
   - name: coralogix-ebpf-profiler

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "info"
   collectionInterval: "30s"
-  version: "0.0.229"
+  version: "0.0.230"
   deploymentEnvironmentName: ""
 
   extensions:


### PR DESCRIPTION
## Summary
- bump the otel-integration chart version to 0.0.230 and update the global default version
- update all opentelemetry-collector dependency charts to version 0.121.10
- record the collector 0.121.6-0.121.10 release notes in the otel-integration changelog

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68f62016fc1483228524b7f23f43745d