### PR TITLE
Allow setting custom non-identifying attributes for both supervisor and OpAMP extensions via  preset

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## OpenTelemetry-Integration
 
+### v0.0.233 / 2025-11-07
+- [Fix] Derive Coralogix application and subsystem names from `service.namespace` and `service.name` when using the standalone distribution.
+- [Fix] Emit Coralogix OTLP headers with the `helm-otel-standalone` distribution tag when the standalone distribution is selected.
+- [Feat] Add `filelogMulti` preset for configuring multiple filelog receivers with Coralogix resource annotations.
+- [Feat] Allow `filelogMulti` receivers to derive Coralogix application and subsystem names from resource attributes after custom operators run.
+- [Feat] Allow `additionalEndpoints` option to `coralogixExporter` preset to add additional Coralogix endpoints.
+- [Feat] extend opamp extension and resource catalog exporter to support additional endpoints.
+- [Feat] Allow `filelogMulti` preset receivers to configure multiline log parsing.
+- [Feat] Allow setting custom non-identifying attributes for both supervisor and OpAMP extensions via `fleetManagement.customAttributes` preset.
+
 ### v0.0.232 / 2025-10-22
 - [Feat] `opentelemetry-ebpf-instrumentation` - Increase http, postgres default buffer sizes, add graphql payload extraction
 

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.232
+version: 0.0.233
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -11,37 +11,37 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.121.10"
+    version: "0.124.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-windows
-    version: "0.121.10"
+    version: "0.124.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-windows.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-cluster-collector
-    version: "0.121.10"
+    version: "0.124.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-cluster-collector.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-receiver
-    version: "0.121.10"
+    version: "0.124.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-receiver.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-gateway
-    version: "0.121.10"
+    version: "0.124.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-gateway.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-eks-fargate
-    version: "0.121.10"
+    version: "0.124.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-eks-fargate.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-eks-fargate-monitoring
-    version: "0.121.10"
+    version: "0.124.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-eks-fargate-monitoring.enabled
   - name: coralogix-ebpf-profiler

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "info"
   collectionInterval: "30s"
-  version: "0.0.232"
+  version: "0.0.233"
   deploymentEnvironmentName: ""
 
   extensions:
@@ -113,6 +113,14 @@ opentelemetry-agent:
       enabled: true
       agentType: "agent"
       clusterName: "{{.Values.global.clusterName}}"
+      # Custom non-identifying attributes to add to the agent description.
+      # These attributes will be included in the non_identifying_attributes section
+      # for both supervisor and OpAMP extensions.
+      # Example:
+      #   customAttributes:
+      #     environment: "production"
+      #     team: "platform"
+      customAttributes: {}
 
     logsCollection:
       enabled: true
@@ -364,6 +372,14 @@ opentelemetry-cluster-collector:
       enabled: true
       agentType: "cluster-collector"
       clusterName: "{{.Values.global.clusterName}}"
+      # Custom non-identifying attributes to add to the agent description.
+      # These attributes will be included in the non_identifying_attributes section
+      # for both supervisor and OpAMP extensions.
+      # Example:
+      #   customAttributes:
+      #     environment: "production"
+      #     team: "platform"
+      customAttributes: {}
     clusterMetrics:
       enabled: true
       collectionInterval: "{{.Values.global.collectionInterval}}"
@@ -595,6 +611,14 @@ opentelemetry-gateway:
       enabled: true
       agentType: "gateway"
       clusterName: "{{.Values.global.clusterName}}"
+      # Custom non-identifying attributes to add to the agent description.
+      # These attributes will be included in the non_identifying_attributes section
+      # for both supervisor and OpAMP extensions.
+      # Example:
+      #   customAttributes:
+      #     environment: "production"
+      #     team: "platform"
+      customAttributes: {}
     metadata:
       enabled: true
       clusterName: "{{.Values.global.clusterName}}"
@@ -689,6 +713,14 @@ opentelemetry-receiver:
       enabled: true
       agentType: "receiver"
       clusterName: "{{.Values.global.clusterName}}"
+      # Custom non-identifying attributes to add to the agent description.
+      # These attributes will be included in the non_identifying_attributes section
+      # for both supervisor and OpAMP extensions.
+      # Example:
+      #   customAttributes:
+      #     environment: "production"
+      #     team: "platform"
+      customAttributes: {}
     metadata:
       enabled: true
       clusterName: "{{.Values.global.clusterName}}"


### PR DESCRIPTION
Fixes [CX-6736](https://coralogix.atlassian.net/browse/CX-6736).

This PR allows setting custom non-identifying attributes for both supervisor and OpAMP extensions via  `fleetManagement.customAttributes` preset.

[CX-6736]: https://coralogix.atlassian.net/browse/CX-6736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ