### PR TITLE
Update collector chart dependency

### DIFF
--- a/otel-agent/k8s-helm/Chart.yaml
+++ b/otel-agent/k8s-helm/Chart.yaml
@@ -1,14 +1,14 @@
 apiVersion: v2
 name: opentelemetry-coralogix
 description: OpenTelemetry agent to which instrumentation libraries export their telemetry data
-version: 0.0.37
+version: 0.0.38
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry agent
   - Coralogix
 dependencies:
   - name: opentelemetry-collector
-    version: "0.73.0"
+    version: "0.140.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
 sources:
   - https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector

--- a/otel-infrastructure-collector/k8s-helm/Chart.yaml
+++ b/otel-infrastructure-collector/k8s-helm/Chart.yaml
@@ -1,14 +1,14 @@
 apiVersion: v2
 name: otel-infrastructure-collector
 description: OpenTelemetry Infrastructure collector
-version: 0.1.9
+version: 0.1.10
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Infrastructure Collector
   - Coralogix
 dependencies:
   - name: opentelemetry-collector
-    version: "0.73.0"
+    version: "0.140.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
 sources:
   - https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector


### PR DESCRIPTION
## Summary
- bump the opentelemetry-collector chart dependency to version 0.140.0
- increment the chart versions for the agent and infrastructure collector charts

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6926b512cde88322ac6ed53f86315897)