### PR TITLE
Add Coralogix exporter and Service pipelines to Advanced config

### DIFF
--- a/otel-integration/k8s-helm/README.md
+++ b/otel-integration/k8s-helm/README.md
@@ -323,10 +323,9 @@ The [OpenTelemetry Collector Configuration](https://opentelemetry.io/docs/collec
 
 ```yaml
 opentelemetry-agent:
-...
-	config:
-		receivers:
-			prometheus:
+  config:
+    receivers:
+      prometheus:
         config:
           scrape_configs:
             - job_name: opentelemetry-infrastructure-collector
@@ -334,18 +333,13 @@ opentelemetry-agent:
               static_configs:
                 - targets:
                     - ${MY_POD_IP}:8888
-
-		...
-	  service:
-	    pipelines:
-				logs:
-					...
-				metrics:
-					receivers:
-					- prometheus
-	      traces:
-						...
-
+    service:
+      pipelines:
+        logs:
+        metrics:
+          receivers:
+            - prometheus
+        traces:
 ```
 
 ## Coralogix exporter
@@ -360,33 +354,27 @@ global:
   clusterName: "<cluster-name>"
   defaultApplicationName: "otel"
   defaultSubsystemName: "integration"
-...
 opentelemetry-agent:
-...
   config:
-	...
     exporters:
       coralogix:
         timeout: "30s"
         private_key: "${CORALOGIX_PRIVATE_KEY}"
-				## Values set in "global" section
+        ## Values set in "global" section
         domain: "{{ '{{' }} .Values.global.domain }}"
-				application_name: "{{ '{{' }} .Values.global.defaultApplicationName }}"
+        application_name: "{{ '{{' }} .Values.global.defaultApplicationName }}"
         subsystem_name: "{{ '{{' }} .Values.global.defaultSubsystemName }}"
     service:
       pipelines:
         metrics:
           exporters:
             - coralogix
-							...
         traces:
           exporters:
             - coralogix
-							...
         logs:
           exporters:
             - coralogix
-
 ```
 
 ## OpenTelemetry Agent


### PR DESCRIPTION
# Description

The OTel k8s README sync is now active and the Advanced config section of the README replaced the current Advanced config in the docs. They were very similar, except two sections: Coralogix exporter and Service pipelines.
I added them as they are (except yaml formatting) to the same location as in the original doc. 
Could you please verify the info in the sections and their placement?

# How Has This Been Tested?

mdox

# Checklist:
- [ ] I have updated the relevant Helm chart(s) version(s)
- [ ] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
