### PR TITLE
chore: bump otel-integration collector charts to 0.127.3

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## OpenTelemetry-Integration
 
+### v0.0.255 / 2025-12-22
+- [Feat] Add support for custom pod labels on TargetAllocator pods via `targetAllocator.podLabels`.
+
 ### v0.0.254 / 2025-12-19
 - [Fix] Add missing `node` to `k8s_observer` for `kubernetesApiServerMetrics` preset.
 - [Fix] Add support for combining `profilesCollection` preset with `fleetManagement` preset.

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.254
+version: 0.0.255
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -11,37 +11,37 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.127.2"
+    version: "0.127.3"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-windows
-    version: "0.127.2"
+    version: "0.127.3"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-windows.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-cluster-collector
-    version: "0.127.2"
+    version: "0.127.3"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-cluster-collector.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-receiver
-    version: "0.127.2"
+    version: "0.127.3"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-receiver.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-gateway
-    version: "0.127.2"
+    version: "0.127.3"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-gateway.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-eks-fargate
-    version: "0.127.2"
+    version: "0.127.3"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-eks-fargate.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-eks-fargate-monitoring
-    version: "0.127.2"
+    version: "0.127.3"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-eks-fargate-monitoring.enabled
   - name: coralogix-ebpf-profiler

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "info"
   collectionInterval: "30s"
-  version: "0.0.254"
+  version: "0.0.255"
   deploymentEnvironmentName: ""
 
   extensions:
@@ -70,6 +70,10 @@ opentelemetry-agent:
     enabled: false
     replicas: 1
     allocationStrategy: "per-node"
+    # Custom labels to add to TargetAllocator pods
+    # podLabels:
+    #   team: platform-engineering
+    #   environment: production
     prometheusCR:
       enabled: true
       # The interval at which the target allocator will scrape the Prometheus server


### PR DESCRIPTION
## Summary
- bump otel-integration chart version to 0.0.255 and update opentelemetry-collector dependencies to 0.127.3
- document targetAllocator podLabels example in values.yaml
- note new release entry for pod label support in changelog

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69492cba71608326883856bbd05c4a0f)