### PR TITLE
Bump otel-integration to v0.0.260 and update collector subcharts to 0.128.1

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## OpenTelemetry-Integration
 
+### v0.0.260 / 2026-01-06
+- [Fix] Remove unused `k8s_observer` extension from `kubernetesExtraMetrics` preset to avoid unnecessary API server load.
+
 ### v0.0.259 / 2026-01-05
 - [CHORE] Update Target Allocator image to v0.141.0
 

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.259
+version: 0.0.260
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -11,37 +11,37 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.128.0"
+    version: "0.128.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-windows
-    version: "0.128.0"
+    version: "0.128.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-windows.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-cluster-collector
-    version: "0.128.0"
+    version: "0.128.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-cluster-collector.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-receiver
-    version: "0.128.0"
+    version: "0.128.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-receiver.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-gateway
-    version: "0.128.0"
+    version: "0.128.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-gateway.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-eks-fargate
-    version: "0.128.0"
+    version: "0.128.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-eks-fargate.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-eks-fargate-monitoring
-    version: "0.128.0"
+    version: "0.128.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-eks-fargate-monitoring.enabled
   - name: coralogix-ebpf-profiler

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "info"
   collectionInterval: "30s"
-  version: "0.0.259"
+  version: "0.0.260"
   deploymentEnvironmentName: ""
 
   extensions:


### PR DESCRIPTION
### Motivation
- Upgrade the embedded OpenTelemetry Collector to include the `v0.128.1` fix that removes an unused `k8s_observer` extension.
- Keep the `otel-integration` chart and its global metadata in sync by bumping the chart version.
- Ensure all `opentelemetry-collector` subchart dependencies use the same supported collector release to avoid mismatched behavior.
- Record the upgrade in the integration changelog for traceability.

### Description
- Bumped the chart version in `otel-integration/k8s-helm/Chart.yaml` to `0.0.260`.
- Updated all `opentelemetry-collector` dependency versions (aliases: `opentelemetry-agent`, `opentelemetry-agent-windows`, `opentelemetry-cluster-collector`, `opentelemetry-receiver`, `opentelemetry-gateway`, `opentelemetry-agent-eks-fargate`, `opentelemetry-agent-eks-fargate-monitoring`) to `0.128.1` in `Chart.yaml`.
- Aligned the global chart value by updating `global.version` in `otel-integration/k8s-helm/values.yaml` to `0.0.260`.
- Added a new `### v0.0.260 / 2026-01-06` entry to `otel-integration/CHANGELOG.md` that mentions the collector fix.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695cf30d29dc8322b8436bd6c1ab2bba)