### PR TITLE
chore: bump macos-standalone opentelemetry-collector dependency to 0.128.1

### DIFF
--- a/otel-macos-standalone/CHANGELOG.md
+++ b/otel-macos-standalone/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## otel-macos-standalone
 
+### v0.0.3 / 2026-01-06
+
+- [Chore] Bump chart dependency to opentelemetry-collector 0.128.1
+
 ### v0.0.2 / 2025-12-25
 
 - [Faet] Bump chart version to 0.127.7

--- a/otel-macos-standalone/Chart.yaml
+++ b/otel-macos-standalone/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: macos-standalone
 description: Standalone macOS OpenTelemetry Collector configuration
-version: 0.0.2
+version: 0.0.3
 keywords:
   - OpenTelemetry Collector
   - Coralogix
@@ -9,7 +9,7 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.127.7"
+    version: "0.128.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
 sources:


### PR DESCRIPTION
### Motivation
- Update the macOS standalone chart to depend on the newer `opentelemetry-collector` chart release to pick up fixes and improvements.
- Keep the `macos-standalone` chart consistent with other charts that have already moved to `0.128.1`.
- Bump the chart patch version to indicate the dependency change.

### Description
- Updated `otel-macos-standalone/Chart.yaml` to set `version` to `0.0.3` and the `opentelemetry-collector` dependency `version` to `0.128.1`.
- Added a `v0.0.3` entry to `otel-macos-standalone/CHANGELOG.md` documenting the dependency bump.
- Verified the file changes and created a commit reflecting the chart and changelog updates.

### Testing
- No automated tests or CI jobs were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695cf696e2948322aeb2de2bced26dac)