### PR TITLE
chore(otel-linux-standalone): bump chart to v0.0.4 and opentelemetry dependency to v0.128.1

### DIFF
--- a/otel-linux-standalone/Chart.yaml
+++ b/otel-linux-standalone/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: linux-standalone
 description: Standalone Linux OpenTelemetry Collector configuration
-version: 0.0.3
+version: 0.0.4
 keywords:
   - OpenTelemetry Collector
   - Coralogix
@@ -9,7 +9,7 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.127.7"
+    version: "0.128.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
 sources:

--- a/otel-linux-standalone/build/otel-config.yaml
+++ b/otel-linux-standalone/build/otel-config.yaml
@@ -110,27 +110,27 @@ exporters:
     domain: coralogix.com
     logs:
       headers:
-        X-Coralogix-Distribution: helm-otel-standalone/0.0.3
+        X-Coralogix-Distribution: helm-otel-standalone/0.0.4
     metrics:
       headers:
-        X-Coralogix-Distribution: helm-otel-standalone/0.0.3
+        X-Coralogix-Distribution: helm-otel-standalone/0.0.4
     private_key: ${env:CORALOGIX_PRIVATE_KEY}
     profiles:
       headers:
-        X-Coralogix-Distribution: helm-otel-standalone/0.0.3
+        X-Coralogix-Distribution: helm-otel-standalone/0.0.4
     subsystem_name: linux
     subsystem_name_attributes:
     - service.name
     timeout: 30s
     traces:
       headers:
-        X-Coralogix-Distribution: helm-otel-standalone/0.0.3
+        X-Coralogix-Distribution: helm-otel-standalone/0.0.4
   coralogix/resource_catalog:
     application_name: resource
     domain: coralogix.com
     logs:
       headers:
-        X-Coralogix-Distribution: helm-otel-standalone/0.0.3
+        X-Coralogix-Distribution: helm-otel-standalone/0.0.4
         x-coralogix-ingress: metadata-as-otlp-logs/v1
     private_key: ${CORALOGIX_PRIVATE_KEY}
     subsystem_name: catalog
@@ -144,7 +144,7 @@ extensions:
       include_resource_attributes: true
       non_identifying_attributes:
         cx.agent.type: agent
-        helm.chart.opentelemetry-agent.version: 0.127.7
+        helm.chart.opentelemetry-agent.version: 0.128.1
     server:
       http:
         endpoint: https://ingress.coralogix.com/opamp/v1

--- a/otel-linux-standalone/values.yaml
+++ b/otel-linux-standalone/values.yaml
@@ -4,7 +4,7 @@ global:
   defaultSubsystemName: "linux"
   logLevel: "info"
   collectionInterval: "30s"
-  version: "0.0.3"
+  version: "0.0.4"
   # deploymentEnvironmentName: "development"
 
 opentelemetry-agent:


### PR DESCRIPTION
### Motivation
- Keep the standalone Linux collector chart and embedded metadata aligned with the latest upstream collector chart.
- Ensure deployments using this chart pull `opentelemetry-collector` v0.128.1 rather than the older v0.127.7.
- Update distributed metadata so generated configs advertise the new chart and dependency versions.

### Description
- Update `otel-linux-standalone/Chart.yaml` chart `version` to `0.0.4` and bump the `opentelemetry-collector` dependency to `0.128.1`.
- Bump the packaged chart `global.version` in `otel-linux-standalone/values.yaml` to `0.0.4`.
- Refresh `otel-linux-standalone/build/otel-config.yaml` to replace `helm-otel-standalone/0.0.3` with `helm-otel-standalone/0.0.4` and update the `helm.chart.opentelemetry-agent.version` metadata to `0.128.1`.
- Commit the updated files to the repository.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695cf705ab348322a5064f5c24270d80)