### PR TITLE
Bump otel-ecs-ec2 opentelemetry-agent dependency to 0.128.1 and chart version to 0.0.7

### DIFF
--- a/otel-ecs-ec2/CHANGELOG.md
+++ b/otel-ecs-ec2/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 0.0.7 / 2026-01-06
+
+* [CHANGE] Update Helm dependency `opentelemetry-agent` to chart version `0.128.1`.
+
 ### 0.0.6 / 2026-01-02
 
 * [CHANGE] Bump Coralogix OTEL collector image to `coralogixrepo/coralogix-otel-collector:v0.5.7` (aligned in Helm values, example manifest, and Terraform `image_version` default).

--- a/otel-ecs-ec2/Chart.yaml
+++ b/otel-ecs-ec2/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ecs-ec2-integration
 description: ECS-EC2 OpenTelemetry Integration
-version: 0.0.6
+version: 0.0.7
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -11,7 +11,7 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.119.8"
+    version: "0.128.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
 sources:

--- a/otel-ecs-ec2/examples/manifest.yaml
+++ b/otel-ecs-ec2/examples/manifest.yaml
@@ -6,7 +6,7 @@ metadata:
   name: ecs-ec2-example-opentelemetry-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-agent-0.119.8
+    helm.sh/chart: opentelemetry-agent-0.128.1
     app.kubernetes.io/name: opentelemetry-agent
     app.kubernetes.io/instance: ecs-ec2-example
     app.kubernetes.io/version: "0.131.1"
@@ -19,7 +19,7 @@ metadata:
   name: ecs-ec2-example-opentelemetry-agent-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-agent-0.119.8
+    helm.sh/chart: opentelemetry-agent-0.128.1
     app.kubernetes.io/name: opentelemetry-agent
     app.kubernetes.io/instance: ecs-ec2-example
     app.kubernetes.io/version: "0.131.1"
@@ -129,7 +129,7 @@ data:
           non_identifying_attributes:
             cx.agent.type: agent
             cx.cluster.name: ''
-            helm.chart.opentelemetry-agent.version: 0.119.8
+            helm.chart.opentelemetry-agent.version: 0.128.1
         server:
           http:
             endpoint: https://ingress.eu2.coralogix.com/opamp/v1
@@ -596,7 +596,7 @@ metadata:
   name: ecs-ec2-example-opentelemetry-agent-agent
   namespace: default
   labels:
-    helm.sh/chart: opentelemetry-agent-0.119.8
+    helm.sh/chart: opentelemetry-agent-0.128.1
     app.kubernetes.io/name: opentelemetry-agent
     app.kubernetes.io/instance: ecs-ec2-example
     app.kubernetes.io/version: "0.131.1"

--- a/otel-ecs-ec2/examples/otel-config.yaml
+++ b/otel-ecs-ec2/examples/otel-config.yaml
@@ -100,7 +100,7 @@ extensions:
       non_identifying_attributes:
         cx.agent.type: agent
         cx.cluster.name: ''
-        helm.chart.opentelemetry-agent.version: 0.119.8
+        helm.chart.opentelemetry-agent.version: 0.128.1
     server:
       http:
         endpoint: https://ingress.eu2.coralogix.com/opamp/v1


### PR DESCRIPTION
### Motivation
- Update the embedded Helm dependency to a newer `opentelemetry-agent` chart to pick up fixes and improvements. 
- Bump the integration chart version to reflect the dependency change. 
- Keep example manifests and configuration in sync with the dependency version to avoid mismatches.

### Description
- Updated `otel-ecs-ec2/Chart.yaml` to `version: 0.0.7` and changed the `opentelemetry-agent` dependency to `version: "0.128.1"`.
- Replaced occurrences of `0.119.8` with `0.128.1` in `otel-ecs-ec2/examples/manifest.yaml` and `otel-ecs-ec2/examples/otel-config.yaml` to refresh embedded examples.
- Added a `0.0.7` entry to `otel-ecs-ec2/CHANGELOG.md` documenting the dependency bump.
- Committed the changes to the repository.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695cf6e5ec388322aecd37a478c7adea)