### PR TITLE
Bump otel-integration to opentelemetry-collector 0.128.13

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemetry-Integration
 
+### v0.0.267 / 2026-01-20
+- [Fix] Use `instrumentation_scope.name` to detect spanmetrics connector metrics when mapping `otel.status_code` back to `status.code`.
+- [Feat] Add Azure-specific transform to set `host.name` from `azure.vm.name` when `host.name` is empty, applied to all pipelines including `logs/resource_catalog` when provider is Azure.
+
 ### v0.0.266 / 2026-01-15
 - [Fix] Remove unneeded `status_code="STATUS_CODE_UNSET"` label from non-span metrics such as hostmetrics or kubeletmetrics.
 

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.266
+version: 0.0.267
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -11,37 +11,37 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.128.9"
+    version: "0.128.13"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-windows
-    version: "0.128.9"
+    version: "0.128.13"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-windows.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-cluster-collector
-    version: "0.128.9"
+    version: "0.128.13"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-cluster-collector.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-receiver
-    version: "0.128.9"
+    version: "0.128.13"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-receiver.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-gateway
-    version: "0.128.9"
+    version: "0.128.13"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-gateway.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-eks-fargate
-    version: "0.128.9"
+    version: "0.128.13"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-eks-fargate.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-eks-fargate-monitoring
-    version: "0.128.9"
+    version: "0.128.13"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-eks-fargate-monitoring.enabled
   - name: coralogix-ebpf-profiler
@@ -51,7 +51,7 @@ dependencies:
     condition: coralogix-ebpf-profiler.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-ebpf-profiler
-    version: "0.128.9"
+    version: "0.128.13"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-ebpf-profiler.enabled
   - name: opentelemetry-ebpf-instrumentation

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "info"
   collectionInterval: "30s"
-  version: "0.0.266"
+  version: "0.0.267"
   deploymentEnvironmentName: ""
 
   extensions:


### PR DESCRIPTION
### Motivation
- Upgrade the OpenTelemetry Integration to pick up fixes and features from the upstream collector and keep chart dependencies in sync by moving to `0.128.13` and incrementing the integration chart version. 
- Clean up the v0.0.267 changelog entry by removing ECS-related items that were not meant to be included.

### Description
- Bumped integration chart `version` to `0.0.267` in `otel-integration/k8s-helm/Chart.yaml` and updated `global.version` to `0.0.267` in `otel-integration/k8s-helm/values.yaml`.
- Updated all `opentelemetry-collector` dependencies (aliases: `opentelemetry-agent`, `opentelemetry-agent-windows`, `opentelemetry-cluster-collector`, `opentelemetry-receiver`, `opentelemetry-gateway`, `opentelemetry-agent-eks-fargate`, `opentelemetry-agent-eks-fargate-monitoring`, `opentelemetry-ebpf-profiler`) to version `0.128.13` in `otel-integration/k8s-helm/Chart.yaml`.
- Added the `v0.0.267` changelog entry summarizing the upstream collector changes and then removed the ECS-specific entries from that v0.0.267 section in `otel-integration/CHANGELOG.md` to trim unintended ECS mentions.

### Testing
- No automated tests were run (CI not executed or not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696f85e34cfc8322b458f772ed7976a4)