### PR TITLE
[ci] Fix FM sync job when not running from workflow dispatch

### DIFF
--- a/.github/workflows/sync-fleet-manager-collector-chart-map.yml
+++ b/.github/workflows/sync-fleet-manager-collector-chart-map.yml
@@ -101,7 +101,7 @@ jobs:
           fi
         env:
           FORCE_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.force }}
-          CHART_VERSION_OVERRIDE: ${{ github.event_name == 'workflow_dispatch' && inputs.chart_version }}
+          CHART_VERSION_OVERRIDE: ${{ (github.event_name == 'workflow_dispatch' && inputs.chart_version) || '' }}
           GITHUB_EVENT_BEFORE: ${{ github.event.before }}
 
       - name: Set up Helm
@@ -122,8 +122,8 @@ jobs:
         if: steps.detect.outputs.bumped == 'true'
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          CHART_VERSION_OVERRIDE: ${{ github.event_name == 'workflow_dispatch' && inputs.chart_version }}
-          APP_VERSION_OVERRIDE: ${{ github.event_name == 'workflow_dispatch' && inputs.app_version }}
+          CHART_VERSION_OVERRIDE: ${{ (github.event_name == 'workflow_dispatch' && inputs.chart_version) || '' }}
+          APP_VERSION_OVERRIDE: ${{ (github.event_name == 'workflow_dispatch' && inputs.app_version) || '' }}
           CREATE_PR: ${{ github.event_name == 'workflow_dispatch' && inputs.create_pr }}
           GITHUB_EVENT_BEFORE: ${{ github.event.before }}
           GITHUB_EVENT_AFTER: ${{ github.event.after }}


### PR DESCRIPTION
# Description

Need some special handling for those env vars because of typing. As they are boolean, when a build that's not triggered from workflow dispatch runs, they will evaluate to `false`, breaking the logic of the script.

But setting them to `''` (empty string) unless we are on a workflow dispatch build, the logic that checks for their size will work correctly.