### PR TITLE
chore(otel-integration): bump collector chart to 0.128.15

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## OpenTelemetry-Integration
 
+### v0.0.268 / 2026-01-22
+- [Fix] Use the configured `from` field for profiles k8sattributes service annotations.
+- [Fix] Fix `deltaToCumulative` preset producing `null` config when no options are set.
+- [Fix] Fix `reduceResourceAttributes` preset to only apply custom denylist when no provider is set (backward compatibility mode).
+
 ### v0.0.267 / 2026-01-20
 - [Fix] Use `instrumentation_scope.name` to detect spanmetrics connector metrics when mapping `otel.status_code` back to `status.code`.
 - [Feat] Add Azure-specific transform to set `host.name` from `azure.vm.name` when `host.name` is empty, applied to all pipelines including `logs/resource_catalog` when provider is Azure.

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.267
+version: 0.0.268
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -11,37 +11,37 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.128.13"
+    version: "0.128.15"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-windows
-    version: "0.128.13"
+    version: "0.128.15"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-windows.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-cluster-collector
-    version: "0.128.13"
+    version: "0.128.15"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-cluster-collector.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-receiver
-    version: "0.128.13"
+    version: "0.128.15"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-receiver.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-gateway
-    version: "0.128.13"
+    version: "0.128.15"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-gateway.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-eks-fargate
-    version: "0.128.13"
+    version: "0.128.15"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-eks-fargate.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-eks-fargate-monitoring
-    version: "0.128.13"
+    version: "0.128.15"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-eks-fargate-monitoring.enabled
   - name: coralogix-ebpf-profiler
@@ -51,7 +51,7 @@ dependencies:
     condition: coralogix-ebpf-profiler.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-ebpf-profiler
-    version: "0.128.13"
+    version: "0.128.15"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-ebpf-profiler.enabled
   - name: opentelemetry-ebpf-instrumentation

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "info"
   collectionInterval: "30s"
-  version: "0.0.267"
+  version: "0.0.268"
   deploymentEnvironmentName: ""
 
   extensions:


### PR DESCRIPTION
### Motivation
- Upgrade the Coralogix OpenTelemetry Integration to use the latest `opentelemetry-collector` releases to pick up recent fixes and improvements.
- Align the integration chart and values with the repository upgrade rules for `otel-integration` to keep dependencies current.

### Description
- Bumped the otel-integration chart version to `0.0.268` in `otel-integration/k8s-helm/Chart.yaml`.
- Updated all `opentelemetry-collector` subchart dependency versions to `0.128.15` in `otel-integration/k8s-helm/Chart.yaml`.
- Updated the global chart `version` to `0.0.268` in `otel-integration/k8s-helm/values.yaml`.
- Added a `v0.0.268` entry to `otel-integration/CHANGELOG.md` summarizing the upstream collector fixes included.

### Testing
- No automated tests were run for this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6972327daf1883228ea9835c3793d754)