### PR TITLE
[ci] Allow automated builds to open the version mapping PR

### DIFF
--- a/.github/workflows/sync-fleet-manager-collector-chart-map.yml
+++ b/.github/workflows/sync-fleet-manager-collector-chart-map.yml
@@ -124,7 +124,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           CHART_VERSION_OVERRIDE: ${{ (github.event_name == 'workflow_dispatch' && inputs.chart_version) || '' }}
           APP_VERSION_OVERRIDE: ${{ (github.event_name == 'workflow_dispatch' && inputs.app_version) || '' }}
-          CREATE_PR: ${{ github.event_name == 'workflow_dispatch' && inputs.create_pr }}
+          CREATE_PR: ${{ github.event_name != 'workflow_dispatch' || inputs.create_pr }}
           GITHUB_EVENT_BEFORE: ${{ github.event.before }}
           GITHUB_EVENT_AFTER: ${{ github.event.after }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}


### PR DESCRIPTION
# Description

Confirmed through the dry run on https://github.com/coralogix/telemetry-shippers/actions/runs/21283668717/job/61259488772 (see the `Update Fleet Manager mapping and open PR` step logs), which ran as #772 was merged that versions were correctly detected and everything would work ok.

This follows up with testing fixes that were set up at #771.