### PR TITLE
FIx [workflow]: Filter out NEUTRAL checks status for integration-definition sync jobs

### DIFF
--- a/.github/workflows/Sync-ec2-integration-definition.yaml
+++ b/.github/workflows/Sync-ec2-integration-definition.yaml
@@ -189,7 +189,8 @@ jobs:
           set -euo pipefail
 
           check_status() {
-            gh pr checks "$branch" --json state --jq 'all(.[]; .state == "SUCCESS")'
+            # Only check non-neutral checks - neutral checks are acceptable (e.g., cancelled or intentionally neutral)
+            gh pr checks "$branch" --json state --jq '[.[] | select(.state != "NEUTRAL")] | all(.[]; .state == "SUCCESS")'
           }
 
           max_wait_time=$((10 * 60))
@@ -198,6 +199,10 @@ jobs:
 
           echo "Waiting for all status checks to pass for $branch..."
           sleep 5
+
+          # Show current check statuses for debugging
+          echo "Current PR check statuses:"
+          gh pr checks "$branch" --json name,state,conclusion || true
 
           while true; do
             status=$(check_status || echo "false")
@@ -209,7 +214,8 @@ jobs:
 
             if [ "$elapsed_time" -ge "$max_wait_time" ]; then
               echo "Timeout reached: Status checks did not pass within 10 minutes."
-              gh pr checks "$branch" || true
+              echo "Final PR check statuses:"
+              gh pr checks "$branch" --json name,state,conclusion || true
               exit 1
             fi
 

--- a/.github/workflows/Sync-k8s-integration-definition.yaml
+++ b/.github/workflows/Sync-k8s-integration-definition.yaml
@@ -144,7 +144,8 @@ jobs:
         if: "${{env.new_version_exist == 'false' || github.event_name == 'workflow_dispatch'}}"
         run: |
           check_status() {
-            gh pr checks ${{ env.branch_name }} --json state --jq 'all(.[]; .state == "SUCCESS")'
+            # Only check non-neutral checks - neutral checks are acceptable (e.g., cancelled or intentionally neutral)
+            gh pr checks ${{ env.branch_name }} --json state --jq '[.[] | select(.state != "NEUTRAL")] | all(.[]; .state == "SUCCESS")'
           }
 
           # Initialize the timeout variables
@@ -156,6 +157,11 @@ jobs:
           echo "Waiting for all status checks to pass..."
           # Wait for 5 seconds before checking the status
           sleep 5
+          
+          # Show current check statuses for debugging
+          echo "Current PR check statuses:"
+          gh pr checks ${{ env.branch_name }} --json name,state,conclusion || true
+          
           while true; do
             status=$(check_status)
             
@@ -166,6 +172,8 @@ jobs:
             
             if [ "$elapsed_time" -ge "$max_wait_time" ]; then
               echo "Timeout reached: Status checks did not pass within 10 minutes."
+              echo "Final PR check statuses:"
+              gh pr checks ${{ env.branch_name }} --json name,state,conclusion || true
               exit 1
             fi
             


### PR DESCRIPTION
# Description

Update integration-definition sync jobs to filter out NEUTRAL check status.

ONLY WORKFLOW IS UPDATED
 does not affect any component

# Checklist:
- [ ] I have updated the relevant Helm chart(s) version(s)
- [ ] I have updated the relevant component changelog(s)
- [v ] This change does not affect any particular component (e.g. it's CI or docs change)
