### PR TITLE
Bump otel-ecs-supervisor default collector image to v0.145.0

### DIFF
--- a/otel-ecs-supervisor/CHANGELOG.md
+++ b/otel-ecs-supervisor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## ecs-ec2-integration
 
+### 0.0.4 / 2026-02-05
+
+* [IMPROVEMENT] Updated the default supervised collector image tag to `0.145.0` to align with the latest collector and supervisor release. ([#XXXX](https://github.com/coralogix/telemetry-shippers/pull/XXXX))
+
 ### 0.0.3 / 2025-11-21
 
 * [IMPROVEMENT] Updated the default supervised collector image tag to `0.140.1` to align with the latest collector and supervisor release.

--- a/otel-ecs-supervisor/variables.tf
+++ b/otel-ecs-supervisor/variables.tf
@@ -44,7 +44,7 @@ variable "subsystem_name" {
 variable "container_image" {
   description = "Container image for the supervisor"
   type        = string
-  default     = "coralogixrepo/otel-supervised-collector:0.140.1"
+  default     = "coralogixrepo/otel-supervised-collector:0.145.0"
 }
 
 variable "use_entrypoint_script" {


### PR DESCRIPTION
### Motivation
- Update the default supervised collector image used by the ECS supervisor module to pick up collector/supervisor fixes and new features, and document the change per the module's `AGENTS.md` guidance.

### Description
- Change default `container_image` in `otel-ecs-supervisor/variables.tf` from `coralogixrepo/otel-supervised-collector:0.140.1` to `coralogixrepo/otel-supervised-collector:0.145.0` and add a `0.0.4 / 2026-02-05` entry to `otel-ecs-supervisor/CHANGELOG.md` documenting the image bump.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69845bbf8ce4832282aa4b5343f3931d)