### PR TITLE
feat(e2e): add verify Go module, CLI, and patch scripts

### DIFF
--- a/e2e/cmd/e2e-verify/main.go
+++ b/e2e/cmd/e2e-verify/main.go
@@ -45,6 +45,7 @@ func main() {
 		logsFilter    = flag.String("logs-filter", "", "Override DataPrime filter clause for logs (use {{run_id}} placeholder)")
 		tracesFilter  = flag.String("traces-filter", "", "Override DataPrime filter clause for traces (use {{run_id}} placeholder)")
 		metricsFilter = flag.String("metrics-filter", "", "Override PromQL selector for metrics (use {{run_id}} placeholder)")
+		expectations  = flag.String("expectations", "", "Path to expectations YAML. When set, runs structured expectation checks instead of --check flags.")
 	)
 	var checks stringSlice
 	flag.Var(&checks, "check", "Signal to verify: logs, traces, or metrics. Repeat for multiple. [required]")
@@ -75,8 +76,8 @@ func main() {
 	if *runID == "" {
 		missing = append(missing, "--run-id")
 	}
-	if len(checks) == 0 {
-		missing = append(missing, "--check (one of: logs, traces, metrics)")
+	if len(checks) == 0 && *expectations == "" {
+		missing = append(missing, "--check (one of: logs, traces, metrics) OR --expectations <file>")
 	}
 	if len(missing) > 0 {
 		fmt.Fprintf(os.Stderr, "ERROR: missing required flags: %s\n\n", strings.Join(missing, ", "))
@@ -120,11 +121,36 @@ func main() {
 		MetricsFilter: *metricsFilter,
 	}
 
-	fmt.Fprintf(os.Stderr, "e2e-verify: domain=%s run_id=%s since=%s timeout=%s checks=%v\n",
-		*domain, *runID, sinceTime.Format(time.RFC3339), *timeout, checks)
-
 	ctx, cancel := context.WithTimeout(context.Background(), *timeout+30*time.Second)
 	defer cancel()
+
+	// --expectations mode: run structured checks from a YAML file.
+	if *expectations != "" {
+		exp, err := verify.LoadExpectations(*expectations)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
+			os.Exit(2)
+		}
+		fmt.Fprintf(os.Stderr, "e2e-verify: domain=%s run_id=%s since=%s timeout=%s expectations=%s\n",
+			*domain, *runID, sinceTime.Format(time.RFC3339), *timeout, *expectations)
+
+		result := verify.VerifyExpectations(ctx, cfg, exp)
+
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(result)
+
+		if !result.Pass {
+			fmt.Fprintf(os.Stderr, "FAIL: expectations not met:\n%s", result.FailureSummary())
+			os.Exit(1)
+		}
+		fmt.Fprintln(os.Stderr, "OK: all expectations met")
+		return
+	}
+
+	// --check mode: existence-only checks (legacy / debugging).
+	fmt.Fprintf(os.Stderr, "e2e-verify: domain=%s run_id=%s since=%s timeout=%s checks=%v\n",
+		*domain, *runID, sinceTime.Format(time.RFC3339), *timeout, checks)
 
 	results := verify.VerifyAll(ctx, cfg, signals)
 

--- a/e2e/cmd/e2e-verify/main.go
+++ b/e2e/cmd/e2e-verify/main.go
@@ -1,0 +1,151 @@
+// Command e2e-verify polls Coralogix to verify that telemetry data has arrived
+// from an E2E test run. It is invoked from CI workflows after the OTel collector
+// is deployed and telemetrygen has emitted data.
+//
+// Usage:
+//
+//	e2e-verify \
+//	  --domain coralogix.com \
+//	  --api-key $E2E_CX_API_KEY \
+//	  --run-id 12345-linux \
+//	  --since 2026-04-13T10:00:00Z \
+//	  --check logs --check traces --check metrics \
+//	  --timeout 10m
+//
+// On success, prints a JSON summary and exits 0. On any check failure, exits 1.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"coralogix.com/telemetry-shippers/e2e/verify"
+)
+
+// stringSlice is a flag.Value that accumulates repeated --check args.
+type stringSlice []string
+
+func (s *stringSlice) String() string     { return strings.Join(*s, ",") }
+func (s *stringSlice) Set(v string) error { *s = append(*s, v); return nil }
+
+func main() {
+	var (
+		domain        = flag.String("domain", "", "Coralogix domain (e.g. eu2.coralogix.com) [required]")
+		apiKey        = flag.String("api-key", "", "Coralogix API key with query permissions [required, or env E2E_CX_API_KEY]")
+		runID         = flag.String("run-id", "", "Unique E2E run identifier [required]")
+		since         = flag.String("since", "", "Earliest data timestamp (RFC3339, e.g. 2026-04-13T10:00:00Z). Overrides --window if set.")
+		window        = flag.Duration("window", 24*time.Hour, "Look back this far for data (relative to now). Ignored if --since is set.")
+		timeout       = flag.Duration("timeout", 10*time.Minute, "Total polling timeout")
+		initialDelay  = flag.Duration("initial-delay", 30*time.Second, "Wait this long before first poll (collector flush time)")
+		logsFilter    = flag.String("logs-filter", "", "Override DataPrime filter clause for logs (use {{run_id}} placeholder)")
+		tracesFilter  = flag.String("traces-filter", "", "Override DataPrime filter clause for traces (use {{run_id}} placeholder)")
+		metricsFilter = flag.String("metrics-filter", "", "Override PromQL selector for metrics (use {{run_id}} placeholder)")
+	)
+	var checks stringSlice
+	flag.Var(&checks, "check", "Signal to verify: logs, traces, or metrics. Repeat for multiple. [required]")
+
+	flag.Usage = func() {
+		fmt.Fprintln(os.Stderr, "e2e-verify polls Coralogix to verify telemetry data arrived from an E2E run.")
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "Flags:")
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+
+	// Resolve api-key from env if flag empty
+	if *apiKey == "" {
+		*apiKey = os.Getenv("E2E_CX_API_KEY")
+	}
+
+	// Validate required flags
+	missing := []string{}
+	if *domain == "" {
+		missing = append(missing, "--domain")
+	}
+	if *apiKey == "" {
+		missing = append(missing, "--api-key (or E2E_CX_API_KEY env var)")
+	}
+	if *runID == "" {
+		missing = append(missing, "--run-id")
+	}
+	if len(checks) == 0 {
+		missing = append(missing, "--check (one of: logs, traces, metrics)")
+	}
+	if len(missing) > 0 {
+		fmt.Fprintf(os.Stderr, "ERROR: missing required flags: %s\n\n", strings.Join(missing, ", "))
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	// Determine query start time: --since (explicit RFC3339) wins over --window (relative).
+	var sinceTime time.Time
+	if *since != "" {
+		t, err := time.Parse(time.RFC3339, *since)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: invalid --since timestamp (want RFC3339): %v\n", err)
+			os.Exit(2)
+		}
+		sinceTime = t
+	} else {
+		sinceTime = time.Now().Add(-*window)
+	}
+
+	// Validate signals
+	signals := make([]verify.Signal, 0, len(checks))
+	for _, c := range checks {
+		switch verify.Signal(c) {
+		case verify.SignalLogs, verify.SignalTraces, verify.SignalMetrics:
+			signals = append(signals, verify.Signal(c))
+		default:
+			fmt.Fprintf(os.Stderr, "ERROR: invalid --check %q (want logs|traces|metrics)\n", c)
+			os.Exit(2)
+		}
+	}
+
+	cfg := verify.Config{
+		Client:        verify.NewClient(*domain, *apiKey),
+		RunID:         *runID,
+		Since:         sinceTime,
+		Timeout:       *timeout,
+		InitialDelay:  *initialDelay,
+		LogsFilter:    *logsFilter,
+		TracesFilter:  *tracesFilter,
+		MetricsFilter: *metricsFilter,
+	}
+
+	fmt.Fprintf(os.Stderr, "e2e-verify: domain=%s run_id=%s since=%s timeout=%s checks=%v\n",
+		*domain, *runID, sinceTime.Format(time.RFC3339), *timeout, checks)
+
+	ctx, cancel := context.WithTimeout(context.Background(), *timeout+30*time.Second)
+	defer cancel()
+
+	results := verify.VerifyAll(ctx, cfg, signals)
+
+	// Print structured JSON summary to stdout
+	out := map[string]interface{}{
+		"run_id":  *runID,
+		"domain":  *domain,
+		"since":   sinceTime.Format(time.RFC3339),
+		"results": results,
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(out); err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR encoding result: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Exit non-zero if any check failed
+	for _, r := range results {
+		if !r.Found {
+			fmt.Fprintf(os.Stderr, "FAIL: signal=%s error=%q\n", r.Signal, r.Error)
+			os.Exit(1)
+		}
+	}
+	fmt.Fprintln(os.Stderr, "OK: all checks passed")
+}

--- a/e2e/cmd/e2e-verify/main.go
+++ b/e2e/cmd/e2e-verify/main.go
@@ -6,7 +6,7 @@
 //
 //	e2e-verify \
 //	  --domain coralogix.com \
-//	  --api-key $E2E_CX_API_KEY \
+//	  --api-key $E2E_CX_LOGS_QUERY_KEY \
 //	  --run-id 12345-linux \
 //	  --since 2026-04-13T10:00:00Z \
 //	  --check logs --check traces --check metrics \
@@ -35,8 +35,8 @@ func (s *stringSlice) Set(v string) error { *s = append(*s, v); return nil }
 
 func main() {
 	var (
-		domain        = flag.String("domain", "", "Coralogix domain (e.g. eu2.coralogix.com) [required]")
-		apiKey        = flag.String("api-key", "", "Coralogix API key with query permissions [required, or env E2E_CX_API_KEY]")
+		domain        = flag.String("domain", "", "Coralogix domain (e.g. coralogix.com) [required]")
+		apiKey        = flag.String("api-key", "", "Coralogix Logs Query Key (NOT the Send-Your-Data key) [required, or env E2E_CX_LOGS_QUERY_KEY]")
 		runID         = flag.String("run-id", "", "Unique E2E run identifier [required]")
 		since         = flag.String("since", "", "Earliest data timestamp (RFC3339, e.g. 2026-04-13T10:00:00Z). Overrides --window if set.")
 		window        = flag.Duration("window", 24*time.Hour, "Look back this far for data (relative to now). Ignored if --since is set.")
@@ -57,9 +57,11 @@ func main() {
 	}
 	flag.Parse()
 
-	// Resolve api-key from env if flag empty
+	// Resolve api-key from env if flag empty.
+	// Note: the Coralogix Send-Your-Data key (used by the collector to send data
+	// INTO CX) does NOT have query permissions. We need a separate Logs Query Key.
 	if *apiKey == "" {
-		*apiKey = os.Getenv("E2E_CX_API_KEY")
+		*apiKey = os.Getenv("E2E_CX_LOGS_QUERY_KEY")
 	}
 
 	// Validate required flags
@@ -68,7 +70,7 @@ func main() {
 		missing = append(missing, "--domain")
 	}
 	if *apiKey == "" {
-		missing = append(missing, "--api-key (or E2E_CX_API_KEY env var)")
+		missing = append(missing, "--api-key (or E2E_CX_LOGS_QUERY_KEY env var)")
 	}
 	if *runID == "" {
 		missing = append(missing, "--run-id")

--- a/e2e/expectations/ecs-ec2.yaml
+++ b/e2e/expectations/ecs-ec2.yaml
@@ -1,0 +1,27 @@
+# Expectations for the otel-ecs-ec2 chart E2E.
+# Adds aws.ecs.* attributes that the chart's coralogix exporter should attach
+# (regression target: v0.129.5 changed `aws.ecs.cluster` to `aws.ecs.cluster.name`).
+
+logs:
+  min_count: 1
+  required_attributes:
+    - aws.ecs.cluster.name
+    - service.name
+    - e2e.run_id
+
+traces:
+  min_count: 1
+  required_attributes:
+    - service.name
+    - e2e.run_id
+
+metrics:
+  min_count: 1
+  required_labels:
+    - cx_application_name
+    - cx_subsystem_name
+    - aws_ecs_cluster_name
+    - e2e_run_id
+
+collector_health:
+  max_send_failures: 0

--- a/e2e/expectations/k8s.yaml
+++ b/e2e/expectations/k8s.yaml
@@ -1,0 +1,29 @@
+# Expectations for the otel-integration K8S Helm chart E2E.
+# Adds k8s.* attributes that the chart's k8sattributes processor should attach.
+
+logs:
+  min_count: 1
+  required_attributes:
+    # k8sattributes processor adds these to every log.
+    - k8s.namespace.name
+    - k8s.node.name
+    - service.name
+    - e2e.run_id
+
+traces:
+  min_count: 1
+  required_attributes:
+    - service.name
+    - e2e.run_id
+
+metrics:
+  min_count: 1
+  required_labels:
+    - cx_application_name
+    - cx_subsystem_name
+    - k8s_namespace_name
+    - k8s_node_name
+    - e2e_run_id
+
+collector_health:
+  max_send_failures: 0

--- a/e2e/expectations/linux-standalone.yaml
+++ b/e2e/expectations/linux-standalone.yaml
@@ -1,0 +1,26 @@
+# Expectations for the otel-linux-standalone chart E2E.
+
+logs:
+  min_count: 1
+  required_attributes:
+    - host.name
+    - host.id
+    - service.name
+    - e2e.run_id
+
+traces:
+  min_count: 1
+  required_attributes:
+    - service.name
+    - e2e.run_id
+
+metrics:
+  min_count: 1
+  required_labels:
+    - cx_application_name
+    - cx_subsystem_name
+    - host_name
+    - e2e_run_id
+
+collector_health:
+  max_send_failures: 0

--- a/e2e/expectations/macos-standalone.yaml
+++ b/e2e/expectations/macos-standalone.yaml
@@ -1,0 +1,25 @@
+# Expectations for the otel-macos-standalone chart E2E.
+# Verified after the chart is deployed and telemetrygen has emitted data.
+#
+# Each section is optional. Adding/removing checks is the right way to evolve
+# this file as the chart's responsibilities change.
+
+logs:
+  min_count: 1
+  required_attributes:
+    - host.name
+    - host.id
+    - service.name
+    - e2e.run_id
+
+
+metrics:
+  min_count: 1
+  required_labels:
+    - cx_application_name
+    - cx_subsystem_name
+    - host_name
+    - e2e_run_id
+
+collector_health:
+  max_send_failures: 0

--- a/e2e/expectations/macos-standalone.yaml
+++ b/e2e/expectations/macos-standalone.yaml
@@ -12,6 +12,11 @@ logs:
     - service.name
     - e2e.run_id
 
+traces:
+  min_count: 1
+  required_attributes:
+    - service.name
+    - e2e.run_id
 
 metrics:
   min_count: 1

--- a/e2e/expectations/windows-standalone.yaml
+++ b/e2e/expectations/windows-standalone.yaml
@@ -1,0 +1,26 @@
+# Expectations for the otel-windows-standalone chart E2E.
+
+logs:
+  min_count: 1
+  required_attributes:
+    - host.name
+    - host.id
+    - service.name
+    - e2e.run_id
+
+traces:
+  min_count: 1
+  required_attributes:
+    - service.name
+    - e2e.run_id
+
+metrics:
+  min_count: 1
+  required_labels:
+    - cx_application_name
+    - cx_subsystem_name
+    - host_name
+    - e2e_run_id
+
+collector_health:
+  max_send_failures: 0

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -1,0 +1,11 @@
+module coralogix.com/telemetry-shippers/e2e
+
+go 1.23.0
+
+require github.com/stretchr/testify v1.10.0
+
+require (
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -2,10 +2,12 @@ module coralogix.com/telemetry-shippers/e2e
 
 go 1.23.0
 
-require github.com/stretchr/testify v1.10.0
+require (
+	github.com/stretchr/testify v1.10.0
+	gopkg.in/yaml.v3 v3.0.1
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/e2e/go.sum
+++ b/e2e/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
+github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
+github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/e2e/scripts/patch-config-runid.ps1
+++ b/e2e/scripts/patch-config-runid.ps1
@@ -1,0 +1,46 @@
+# patch-config-runid.ps1 -- inject e2e.run_id resource attribute into an OTel config.
+#
+# Usage: .\patch-config-runid.ps1 <config-yaml-path> <run-id>
+#
+# Windows equivalent of patch-config-runid.sh. Requires `yq` (mikefarah/yq) on PATH.
+# Install via `choco install yq` on GitHub Actions windows-latest runners.
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true, Position=0)]
+    [string]$Config,
+
+    [Parameter(Mandatory=$true, Position=1)]
+    [string]$RunId
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path $Config)) {
+    Write-Error "config file not found: $Config"
+    exit 1
+}
+
+if (-not (Get-Command yq -ErrorAction SilentlyContinue)) {
+    Write-Error "yq not found in PATH"
+    exit 1
+}
+
+# The standalone charts all use a processor named "resource/metadata" (with slash).
+# We append (not replace) an e2e.run_id entry to its existing attributes list.
+$expr = @"
+  .processors."resource/metadata".attributes = (.processors."resource/metadata".attributes // [])
+  | .processors."resource/metadata".attributes |= map(select(.key != "e2e.run_id"))
+  | .processors."resource/metadata".attributes += [{"action": "upsert", "key": "e2e.run_id", "value": "$RunId"}]
+"@
+
+yq -i $expr $Config
+
+# Sanity check: ensure the processor is referenced in at least one pipeline.
+$check = yq -e '.service.pipelines[].processors[] | select(. == "resource/metadata")' $Config 2>$null
+if (-not $check) {
+    Write-Error "'resource/metadata' processor is not referenced in any pipeline. Patch had no effect."
+    exit 1
+}
+
+Write-Host "Patched $Config with e2e.run_id=$RunId"

--- a/e2e/scripts/patch-config-runid.sh
+++ b/e2e/scripts/patch-config-runid.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# patch-config-runid.sh -- inject e2e.run_id resource attribute into an OTel config.
+#
+# Usage: patch-config-runid.sh <config-yaml-path> <run-id>
+#
+# This is the minimum patch standalone E2E tests need: every signal emitted by the
+# collector will carry a resource attribute "e2e.run_id" with the test run's unique
+# identifier. The verify CLI uses this attribute to isolate this run's data from
+# everything else in the Coralogix account.
+#
+# Looks for the resource processor's attributes list. If the processor or list does
+# not exist, creates them. Idempotent: re-running with the same run-id is a no-op.
+
+set -euo pipefail
+
+CONFIG=${1:?"usage: patch-config-runid.sh <config-yaml-path> <run-id>"}
+RUN_ID=${2:?"usage: patch-config-runid.sh <config-yaml-path> <run-id>"}
+
+if [ ! -f "$CONFIG" ]; then
+  echo "ERROR: config file not found: $CONFIG" >&2
+  exit 1
+fi
+
+if ! command -v yq >/dev/null 2>&1; then
+  echo "ERROR: yq not found in PATH" >&2
+  exit 1
+fi
+
+# The standalone charts all use a processor named "resource/metadata" (with slash).
+# We append (not replace) an e2e.run_id entry to its existing attributes list, so
+# pre-existing attributes like cx.otel_integration.name are preserved.
+#
+# Pipeline (yq syntax — mikefarah/yq Go version):
+#   1. Initialize processors."resource/metadata".attributes to [] if missing
+#   2. Drop any existing e2e.run_id entry (so re-runs replace, not duplicate)
+#   3. Append the new e2e.run_id entry with action: upsert (matches existing entries)
+PROCESSOR='"resource/metadata"'
+
+yq -i "
+  .processors.${PROCESSOR}.attributes = (.processors.${PROCESSOR}.attributes // [])
+  | .processors.${PROCESSOR}.attributes |= map(select(.key != \"e2e.run_id\"))
+  | .processors.${PROCESSOR}.attributes += [{\"action\": \"upsert\", \"key\": \"e2e.run_id\", \"value\": \"${RUN_ID}\"}]
+" "$CONFIG"
+
+# Sanity check: verify the processor is actually used in at least one pipeline.
+# If not, the patch had no effect on emitted telemetry — fail loudly.
+if ! yq -e '.service.pipelines[].processors[] | select(. == "resource/metadata")' "$CONFIG" >/dev/null 2>&1; then
+  echo "WARN: 'resource/metadata' processor is not referenced in any pipeline." >&2
+  echo "      e2e.run_id will NOT be added to emitted telemetry. Patch had no effect." >&2
+  exit 1
+fi
+
+echo "Patched $CONFIG with e2e.run_id=${RUN_ID}"

--- a/e2e/scripts/wait-healthy.sh
+++ b/e2e/scripts/wait-healthy.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# wait-healthy.sh -- poll an OTel collector health endpoint until it returns 200
+# or the timeout expires.
+#
+# Usage: wait-healthy.sh <url> [timeout-seconds]
+#
+# Examples:
+#   wait-healthy.sh http://127.0.0.1:13133 60
+#   wait-healthy.sh http://127.0.0.1:13133/healthcheck 300
+#
+# The collector's health_check extension serves on port 13133 by default and
+# returns 200 OK when the pipeline is ready to accept telemetry. Polling here
+# instead of "sleep 30" gives faster start when the collector boots quickly,
+# and clear failure when it never starts.
+
+set -euo pipefail
+
+URL=${1:?"usage: wait-healthy.sh <url> [timeout-seconds]"}
+TIMEOUT=${2:-60}
+INTERVAL=5
+
+START=$(date +%s)
+ATTEMPT=0
+
+echo "Waiting for collector health at ${URL} (timeout: ${TIMEOUT}s)..."
+
+while true; do
+  ATTEMPT=$((ATTEMPT + 1))
+  if curl -sf -o /dev/null -m 3 "$URL"; then
+    ELAPSED=$(( $(date +%s) - START ))
+    echo "Collector is healthy after ${ELAPSED}s (attempt ${ATTEMPT})"
+    exit 0
+  fi
+
+  ELAPSED=$(( $(date +%s) - START ))
+  if [ $ELAPSED -ge $TIMEOUT ]; then
+    echo "ERROR: collector not healthy after ${TIMEOUT}s (${ATTEMPT} attempts)" >&2
+    exit 1
+  fi
+
+  sleep $INTERVAL
+done

--- a/e2e/verify/coralogix.go
+++ b/e2e/verify/coralogix.go
@@ -1,0 +1,188 @@
+// Package verify provides functions to verify that telemetry data has arrived
+// in Coralogix after an E2E test deploys an OTel collector.
+package verify
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// Client wraps HTTP calls to the Coralogix DataPrime and PromQL APIs.
+type Client struct {
+	Domain     string // e.g. "coralogix.com"
+	APIKey     string // Coralogix Logs Query Key
+	HTTPClient *http.Client
+}
+
+// NewClient returns a Client with a sensible default HTTP timeout.
+func NewClient(domain, apiKey string) *Client {
+	return &Client{
+		Domain:     domain,
+		APIKey:     apiKey,
+		HTTPClient: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// dataprimeRequest is the body for POST /api/v1/dataprime/query.
+type dataprimeRequest struct {
+	Query    string             `json:"query"`
+	Metadata dataprimeMetadata  `json:"metadata"`
+}
+
+type dataprimeMetadata struct {
+	StartDate string `json:"startDate"`
+	EndDate   string `json:"endDate"`
+}
+
+// DataPrimeResult is a partial decode of the DataPrime response. The API
+// returns a stream of newline-delimited JSON objects; we count "result" entries
+// and capture the first row as a sample for debugging.
+type DataPrimeResult struct {
+	Count  int    // number of result rows returned
+	Sample string // first result row as a JSON string (for debugging)
+	Raw    string // full raw response (for debugging on error)
+}
+
+// QueryDataPrime executes a DataPrime query against logs or spans.
+// The query string uses DataPrime syntax, e.g.:
+//
+//	source logs | filter $d.resource.attributes.e2e_run_id == 'abc' | limit 5
+func (c *Client) QueryDataPrime(ctx context.Context, query string, since time.Time) (*DataPrimeResult, error) {
+	endpoint := fmt.Sprintf("https://ng-api-http.%s/api/v1/dataprime/query", c.Domain)
+
+	body, err := json.Marshal(dataprimeRequest{
+		Query: query,
+		Metadata: dataprimeMetadata{
+			StartDate: since.UTC().Format("2006-01-02T15:04:05.00Z"),
+			EndDate:   time.Now().UTC().Format("2006-01-02T15:04:05.00Z"),
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", c.APIKey) // DataPrime: no "Bearer" prefix
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("http: %w", err)
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("dataprime returned %d: %s", resp.StatusCode, string(raw))
+	}
+
+	return parseDataPrime(string(raw)), nil
+}
+
+// parseDataPrime parses the NDJSON response. DataPrime returns a stream of
+// JSON objects, one per line. Each object has a "result" key with rows, or
+// "queryId"/"warning"/"error" keys. We count rows across all "result" objects.
+func parseDataPrime(body string) *DataPrimeResult {
+	res := &DataPrimeResult{Raw: body}
+
+	dec := json.NewDecoder(bytes.NewReader([]byte(body)))
+	for dec.More() {
+		var obj struct {
+			Result *struct {
+				Results []json.RawMessage `json:"results"`
+			} `json:"result"`
+		}
+		if err := dec.Decode(&obj); err != nil {
+			break
+		}
+		if obj.Result == nil {
+			continue
+		}
+		for _, row := range obj.Result.Results {
+			if res.Sample == "" {
+				res.Sample = string(row)
+			}
+			res.Count++
+		}
+	}
+	return res
+}
+
+// PromQLResult is a partial decode of the PromQL query response.
+type PromQLResult struct {
+	Count  int    // number of series returned
+	Sample string // first series as a JSON string
+	Raw    string
+}
+
+// promQLResponse matches Coralogix's PromQL response shape:
+//
+//	{"status":"success","data":{"resultType":"vector","result":[...]}}
+type promQLResponse struct {
+	Status string `json:"status"`
+	Data   struct {
+		ResultType string            `json:"resultType"`
+		Result     []json.RawMessage `json:"result"`
+	} `json:"data"`
+	ErrorType string `json:"errorType,omitempty"`
+	Error     string `json:"error,omitempty"`
+}
+
+// QueryPromQL executes an instant PromQL query, e.g. `{e2e_run_id="abc"}`.
+// The endpoint is /metrics/api/v1/query (instant query at current time).
+func (c *Client) QueryPromQL(ctx context.Context, query string) (*PromQLResult, error) {
+	endpoint := fmt.Sprintf("https://ng-api-http.%s/metrics/api/v1/query", c.Domain)
+
+	q := url.Values{}
+	q.Set("query", query)
+	q.Set("time", fmt.Sprintf("%d", time.Now().Unix()))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint+"?"+q.Encode(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	// Metrics API uses Bearer prefix (different from DataPrime)
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("http: %w", err)
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("promql returned %d: %s", resp.StatusCode, string(raw))
+	}
+
+	var parsed promQLResponse
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return nil, fmt.Errorf("decode response: %w (body: %s)", err, string(raw))
+	}
+	if parsed.Status != "success" {
+		return nil, fmt.Errorf("promql error: %s: %s", parsed.ErrorType, parsed.Error)
+	}
+
+	res := &PromQLResult{Raw: string(raw), Count: len(parsed.Data.Result)}
+	if len(parsed.Data.Result) > 0 {
+		res.Sample = string(parsed.Data.Result[0])
+	}
+	return res, nil
+}

--- a/e2e/verify/coralogix.go
+++ b/e2e/verify/coralogix.go
@@ -42,11 +42,42 @@ type dataprimeMetadata struct {
 
 // DataPrimeResult is a partial decode of the DataPrime response. The API
 // returns a stream of newline-delimited JSON objects; we count "result" entries
-// and capture the first row as a sample for debugging.
+// and capture the rows for downstream attribute inspection.
 type DataPrimeResult struct {
-	Count  int    // number of result rows returned
-	Sample string // first result row as a JSON string (for debugging)
-	Raw    string // full raw response (for debugging on error)
+	Count  int            // number of result rows returned
+	Rows   []DataPrimeRow // parsed rows (resource attributes accessible via Rows[i].ResourceAttributes())
+	Sample string         // first result row as a JSON string (for debugging)
+	Raw    string         // full raw response (for debugging on error)
+}
+
+// DataPrimeRow is one row from a DataPrime query.
+type DataPrimeRow struct {
+	Metadata []KV   `json:"metadata"`
+	Labels   []KV   `json:"labels"`
+	UserData string `json:"userData"` // JSON-encoded string, parse separately
+}
+
+// KV is a single metadata/label entry.
+type KV struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// ResourceAttributes parses the userData JSON and returns the
+// resource.attributes map, or nil if the row has no parseable resource section.
+func (r DataPrimeRow) ResourceAttributes() map[string]interface{} {
+	if r.UserData == "" {
+		return nil
+	}
+	var doc struct {
+		Resource struct {
+			Attributes map[string]interface{} `json:"attributes"`
+		} `json:"resource"`
+	}
+	if err := json.Unmarshal([]byte(r.UserData), &doc); err != nil {
+		return nil
+	}
+	return doc.Resource.Attributes
 }
 
 // QueryDataPrime executes a DataPrime query against logs or spans.
@@ -94,7 +125,8 @@ func (c *Client) QueryDataPrime(ctx context.Context, query string, since time.Ti
 
 // parseDataPrime parses the NDJSON response. DataPrime returns a stream of
 // JSON objects, one per line. Each object has a "result" key with rows, or
-// "queryId"/"warning"/"error" keys. We count rows across all "result" objects.
+// "queryId"/"warning"/"error" keys. We count rows across all "result" objects
+// and parse each into DataPrimeRow.
 func parseDataPrime(body string) *DataPrimeResult {
 	res := &DataPrimeResult{Raw: body}
 
@@ -111,9 +143,13 @@ func parseDataPrime(body string) *DataPrimeResult {
 		if obj.Result == nil {
 			continue
 		}
-		for _, row := range obj.Result.Results {
+		for _, raw := range obj.Result.Results {
 			if res.Sample == "" {
-				res.Sample = string(row)
+				res.Sample = string(raw)
+			}
+			var row DataPrimeRow
+			if err := json.Unmarshal(raw, &row); err == nil {
+				res.Rows = append(res.Rows, row)
 			}
 			res.Count++
 		}
@@ -123,9 +159,32 @@ func parseDataPrime(body string) *DataPrimeResult {
 
 // PromQLResult is a partial decode of the PromQL query response.
 type PromQLResult struct {
-	Count  int    // number of series returned
-	Sample string // first series as a JSON string
+	Count  int           // number of series returned
+	Series []PromQLSeries // parsed series with labels accessible
+	Sample string         // first series as a JSON string
 	Raw    string
+}
+
+// PromQLSeries is one series from a PromQL response. We only care about the
+// metric labels for verification (not the value).
+type PromQLSeries struct {
+	Metric map[string]string `json:"metric"`
+	Value  []interface{}     `json:"value,omitempty"` // [timestamp, "value"]
+}
+
+// MetricValue returns the numeric value of an instant query result, or 0 if
+// the response shape is unexpected. Used by collector_health checks.
+func (s PromQLSeries) MetricValue() float64 {
+	if len(s.Value) < 2 {
+		return 0
+	}
+	str, ok := s.Value[1].(string)
+	if !ok {
+		return 0
+	}
+	var f float64
+	fmt.Sscanf(str, "%f", &f)
+	return f
 }
 
 // promQLResponse matches Coralogix's PromQL response shape:
@@ -183,6 +242,12 @@ func (c *Client) QueryPromQL(ctx context.Context, query string) (*PromQLResult, 
 	res := &PromQLResult{Raw: string(raw), Count: len(parsed.Data.Result)}
 	if len(parsed.Data.Result) > 0 {
 		res.Sample = string(parsed.Data.Result[0])
+	}
+	for _, raw := range parsed.Data.Result {
+		var s PromQLSeries
+		if err := json.Unmarshal(raw, &s); err == nil {
+			res.Series = append(res.Series, s)
+		}
 	}
 	return res, nil
 }

--- a/e2e/verify/coralogix_test.go
+++ b/e2e/verify/coralogix_test.go
@@ -1,0 +1,141 @@
+package verify
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueryDataPrime_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/dataprime/query", r.URL.Path)
+		assert.Equal(t, "test-key", r.Header.Get("Authorization")) // no Bearer prefix
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]interface{}
+		require.NoError(t, json.Unmarshal(body, &req))
+		assert.Contains(t, req["query"], "source logs")
+
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		// Two NDJSON objects: one with results, one without
+		_, _ = w.Write([]byte(`{"queryId":{"queryId":"abc"}}` + "\n"))
+		_, _ = w.Write([]byte(`{"result":{"results":[{"metadata":[]}, {"metadata":[]}]}}` + "\n"))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	res, err := c.QueryDataPrime(context.Background(), "source logs | limit 5", time.Now().Add(-1*time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, 2, res.Count)
+	assert.NotEmpty(t, res.Sample)
+}
+
+func TestQueryDataPrime_NoResults(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"result":{"results":[]}}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	res, err := c.QueryDataPrime(context.Background(), "source logs | limit 5", time.Now())
+	require.NoError(t, err)
+	assert.Equal(t, 0, res.Count)
+	assert.Empty(t, res.Sample)
+}
+
+func TestQueryDataPrime_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	_, err := c.QueryDataPrime(context.Background(), "x", time.Now())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "401")
+}
+
+func TestQueryPromQL_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/metrics/api/v1/query", r.URL.Path)
+		assert.Equal(t, "Bearer test-key", r.Header.Get("Authorization")) // Bearer prefix for metrics
+		assert.NotEmpty(t, r.URL.Query().Get("query"))
+
+		_, _ = w.Write([]byte(`{
+			"status":"success",
+			"data":{
+				"resultType":"vector",
+				"result":[
+					{"metric":{"__name__":"x","e2e_run_id":"abc"},"value":[1,"1"]},
+					{"metric":{"__name__":"y","e2e_run_id":"abc"},"value":[2,"2"]}
+				]
+			}
+		}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	res, err := c.QueryPromQL(context.Background(), `{e2e_run_id="abc"}`)
+	require.NoError(t, err)
+	assert.Equal(t, 2, res.Count)
+	assert.Contains(t, res.Sample, "__name__")
+}
+
+func TestQueryPromQL_PromError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"status":"error","errorType":"bad_data","error":"parse error"}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv)
+	_, err := c.QueryPromQL(context.Background(), "{")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse error")
+}
+
+// newTestClient builds a Client whose base URL points at the test server.
+// We do this by replacing "ng-api-http.<domain>" with the test server host.
+func newTestClient(srv *httptest.Server) *Client {
+	c := NewClient("coralogix.com", "test-key")
+	// Wrap the HTTP client to rewrite the URL host to the test server.
+	c.HTTPClient = &http.Client{
+		Transport: rewriteTransport{
+			to:    srv.URL,
+			inner: http.DefaultTransport,
+		},
+	}
+	return c
+}
+
+// rewriteTransport rewrites every outgoing request's URL to point at `to`,
+// preserving the path + query.
+type rewriteTransport struct {
+	to    string
+	inner http.RoundTripper
+}
+
+func (rt rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Replace scheme + host with the test server's
+	original := req.URL.String()
+	rewritten := strings.Replace(original, "https://ng-api-http.coralogix.com", rt.to, 1)
+	newReq := req.Clone(req.Context())
+	u, err := newReq.URL.Parse(rewritten)
+	if err != nil {
+		return nil, err
+	}
+	newReq.URL = u
+	newReq.Host = ""
+	return rt.inner.RoundTrip(newReq)
+}

--- a/e2e/verify/expectations.go
+++ b/e2e/verify/expectations.go
@@ -1,0 +1,74 @@
+package verify
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Expectations describes what a test run should find in Coralogix to count
+// as a pass. It is loaded from a per-target YAML file and used by
+// VerifyExpectations.
+//
+// Each section is optional. A nil section means "do not check this signal".
+// Within a section, an empty list of required attributes/labels means
+// "only check min_count, no per-record assertions".
+type Expectations struct {
+	Logs            *SignalExpectation    `yaml:"logs,omitempty"`
+	Traces          *SignalExpectation    `yaml:"traces,omitempty"`
+	Metrics         *SignalExpectation    `yaml:"metrics,omitempty"`
+	CollectorHealth *CollectorHealthCheck `yaml:"collector_health,omitempty"`
+}
+
+// SignalExpectation describes the assertions for a single signal
+// (logs, traces, or metrics).
+type SignalExpectation struct {
+	// MinCount is the minimum number of records that must arrive in CX.
+	// Zero is treated as 1 (we always require at least one record per signal
+	// when the section is defined).
+	MinCount int `yaml:"min_count"`
+
+	// RequiredAttributes are OTel resource attribute keys (with dots, as
+	// they appear in OTel) that every returned record must carry. Used for
+	// logs and traces (DataPrime path: $d.resource.attributes.<key>).
+	RequiredAttributes []string `yaml:"required_attributes,omitempty"`
+
+	// RequiredLabels are PromQL label names (already dot-converted to
+	// underscores by the Coralogix exporter) that every returned metric
+	// series must carry. Used for metrics only.
+	RequiredLabels []string `yaml:"required_labels,omitempty"`
+}
+
+// CollectorHealthCheck describes constraints on the collector's own
+// self-monitoring metrics (otelcol_*). These reveal pipeline issues that
+// don't show up as missing data — e.g., the Coralogix exporter rejecting
+// records due to label-length limits.
+type CollectorHealthCheck struct {
+	// MaxSendFailures is the maximum allowed value of
+	// sum(otelcol_exporter_send_failed_records_total) across all exporters
+	// for this run_id. Zero means no failures tolerated.
+	MaxSendFailures int `yaml:"max_send_failures"`
+}
+
+// LoadExpectations reads a YAML file and returns the parsed Expectations.
+func LoadExpectations(path string) (*Expectations, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read expectations file %s: %w", path, err)
+	}
+
+	var exp Expectations
+	if err := yaml.Unmarshal(data, &exp); err != nil {
+		return nil, fmt.Errorf("parse expectations file %s: %w", path, err)
+	}
+
+	// Normalize: a defined section with min_count=0 means "at least 1".
+	for _, s := range []*SignalExpectation{exp.Logs, exp.Traces, exp.Metrics} {
+		if s != nil && s.MinCount < 1 {
+			s.MinCount = 1
+		}
+	}
+
+	return &exp, nil
+}

--- a/e2e/verify/expectations_test.go
+++ b/e2e/verify/expectations_test.go
@@ -1,0 +1,269 @@
+package verify
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadExpectations(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "exp.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+logs:
+  min_count: 5
+  required_attributes:
+    - cx.application.name
+    - host.name
+metrics:
+  required_labels:
+    - cx_application_name
+collector_health:
+  max_send_failures: 0
+`), 0o644))
+
+	exp, err := LoadExpectations(path)
+	require.NoError(t, err)
+	require.NotNil(t, exp.Logs)
+	assert.Equal(t, 5, exp.Logs.MinCount)
+	assert.Equal(t, []string{"cx.application.name", "host.name"}, exp.Logs.RequiredAttributes)
+	require.NotNil(t, exp.Metrics)
+	assert.Equal(t, 1, exp.Metrics.MinCount, "default min_count should be 1 when omitted")
+	require.NotNil(t, exp.CollectorHealth)
+	assert.Equal(t, 0, exp.CollectorHealth.MaxSendFailures)
+	assert.Nil(t, exp.Traces, "missing section should be nil")
+}
+
+// dataPrimeRow is a helper to build a fake DataPrime NDJSON response with
+// configurable resource attributes.
+func dataPrimeRow(resourceAttrs map[string]string) string {
+	attrs := map[string]interface{}{}
+	for k, v := range resourceAttrs {
+		attrs[k] = v
+	}
+	userData, _ := json.Marshal(map[string]interface{}{
+		"resource": map[string]interface{}{
+			"attributes": attrs,
+		},
+	})
+	row, _ := json.Marshal(map[string]interface{}{
+		"metadata": []interface{}{},
+		"labels":   []interface{}{},
+		"userData": string(userData),
+	})
+	return string(row)
+}
+
+func TestVerifyExpectations_LogsAllPass(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Two rows, both with the required attributes
+		fmt.Fprintf(w, `{"result":{"results":[%s,%s]}}`,
+			dataPrimeRow(map[string]string{"cx.application.name": "app", "host.name": "h1"}),
+			dataPrimeRow(map[string]string{"cx.application.name": "app", "host.name": "h2"}),
+		)
+	}))
+	defer srv.Close()
+
+	cfg := Config{
+		Client: newTestClient(srv), RunID: "run1",
+		Since: time.Now().Add(-1 * time.Hour), Timeout: 30 * time.Second, InitialDelay: 0,
+	}
+	exp := &Expectations{
+		Logs: &SignalExpectation{
+			MinCount:           1,
+			RequiredAttributes: []string{"cx.application.name", "host.name"},
+		},
+	}
+
+	r := VerifyExpectations(context.Background(), cfg, exp)
+	assert.True(t, r.Pass, "result: %+v", r)
+	require.Len(t, r.Sections, 1)
+	assert.Equal(t, "logs", r.Sections[0].Name)
+	assert.True(t, r.Sections[0].Pass)
+}
+
+func TestVerifyExpectations_LogsMissingAttribute(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Row missing host.name
+		fmt.Fprintf(w, `{"result":{"results":[%s]}}`,
+			dataPrimeRow(map[string]string{"cx.application.name": "app"}),
+		)
+	}))
+	defer srv.Close()
+
+	cfg := Config{
+		Client: newTestClient(srv), RunID: "run1",
+		Since: time.Now().Add(-1 * time.Hour), Timeout: 5 * time.Second, InitialDelay: 0,
+	}
+	exp := &Expectations{
+		Logs: &SignalExpectation{
+			MinCount:           1,
+			RequiredAttributes: []string{"cx.application.name", "host.name"},
+		},
+	}
+
+	r := VerifyExpectations(context.Background(), cfg, exp)
+	assert.False(t, r.Pass)
+	summary := r.FailureSummary()
+	assert.Contains(t, summary, "required_attribute host.name")
+	assert.Contains(t, summary, "missing")
+}
+
+func TestVerifyExpectations_LogsBelowMinCount(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Always returns 1 row, but min_count is 5
+		fmt.Fprintf(w, `{"result":{"results":[%s]}}`,
+			dataPrimeRow(map[string]string{"cx.application.name": "app"}),
+		)
+	}))
+	defer srv.Close()
+
+	cfg := Config{
+		Client: newTestClient(srv), RunID: "run1",
+		Since: time.Now().Add(-1 * time.Hour), Timeout: 2 * time.Second, InitialDelay: 0,
+	}
+	exp := &Expectations{
+		Logs: &SignalExpectation{MinCount: 5},
+	}
+
+	r := VerifyExpectations(context.Background(), cfg, exp)
+	assert.False(t, r.Pass)
+	assert.Contains(t, r.FailureSummary(), "min_count >= 5")
+}
+
+func TestVerifyExpectations_MetricsAllPass(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"status":"success",
+			"data":{"resultType":"vector","result":[
+				{"metric":{"__name__":"system_cpu","cx_application_name":"otel","host_name":"h1"},"value":[1,"1"]},
+				{"metric":{"__name__":"system_mem","cx_application_name":"otel","host_name":"h1"},"value":[1,"2"]}
+			]}
+		}`))
+	}))
+	defer srv.Close()
+
+	cfg := Config{
+		Client: newTestClient(srv), RunID: "run1",
+		Since: time.Now().Add(-1 * time.Hour), Timeout: 5 * time.Second, InitialDelay: 0,
+	}
+	exp := &Expectations{
+		Metrics: &SignalExpectation{
+			MinCount:       1,
+			RequiredLabels: []string{"cx_application_name", "host_name"},
+		},
+	}
+
+	r := VerifyExpectations(context.Background(), cfg, exp)
+	assert.True(t, r.Pass, "summary: %s", r.FailureSummary())
+}
+
+func TestVerifyExpectations_MetricsMissingLabel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// host_name is missing on second series
+		_, _ = w.Write([]byte(`{
+			"status":"success",
+			"data":{"resultType":"vector","result":[
+				{"metric":{"__name__":"x","cx_application_name":"otel","host_name":"h1"},"value":[1,"1"]},
+				{"metric":{"__name__":"y","cx_application_name":"otel"},"value":[1,"2"]}
+			]}
+		}`))
+	}))
+	defer srv.Close()
+
+	cfg := Config{
+		Client: newTestClient(srv), RunID: "run1",
+		Since: time.Now().Add(-1 * time.Hour), Timeout: 5 * time.Second, InitialDelay: 0,
+	}
+	exp := &Expectations{
+		Metrics: &SignalExpectation{
+			MinCount:       1,
+			RequiredLabels: []string{"cx_application_name", "host_name"},
+		},
+	}
+
+	r := VerifyExpectations(context.Background(), cfg, exp)
+	assert.False(t, r.Pass)
+	summary := r.FailureSummary()
+	assert.Contains(t, summary, "required_label host_name")
+}
+
+func TestVerifyExpectations_CollectorHealthClean(t *testing.T) {
+	// PromQL returns empty result = no failures recorded
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[]}}`))
+	}))
+	defer srv.Close()
+
+	cfg := Config{
+		Client: newTestClient(srv), RunID: "run1",
+		Since: time.Now(), Timeout: 5 * time.Second, InitialDelay: 0,
+	}
+	exp := &Expectations{
+		CollectorHealth: &CollectorHealthCheck{MaxSendFailures: 0},
+	}
+
+	r := VerifyExpectations(context.Background(), cfg, exp)
+	assert.True(t, r.Pass)
+}
+
+func TestVerifyExpectations_CollectorHealthFails(t *testing.T) {
+	// PromQL returns a series with value=42 → exceeds max=0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"status":"success",
+			"data":{"resultType":"vector","result":[{"metric":{},"value":[1,"42"]}]}
+		}`))
+	}))
+	defer srv.Close()
+
+	cfg := Config{
+		Client: newTestClient(srv), RunID: "run1",
+		Since: time.Now(), Timeout: 5 * time.Second, InitialDelay: 0,
+	}
+	exp := &Expectations{
+		CollectorHealth: &CollectorHealthCheck{MaxSendFailures: 0},
+	}
+
+	r := VerifyExpectations(context.Background(), cfg, exp)
+	assert.False(t, r.Pass)
+	assert.Contains(t, r.FailureSummary(), "42 failures")
+}
+
+func TestVerifyExpectations_CombinedFailureSummary(t *testing.T) {
+	// Logs missing attr + metrics below count → both should appear in summary
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost { // DataPrime
+			fmt.Fprintf(w, `{"result":{"results":[%s]}}`,
+				dataPrimeRow(map[string]string{"only.this": "x"}))
+		} else { // PromQL
+			_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[]}}`))
+		}
+	}))
+	defer srv.Close()
+
+	cfg := Config{
+		Client: newTestClient(srv), RunID: "run1",
+		Since: time.Now().Add(-1 * time.Hour), Timeout: 2 * time.Second, InitialDelay: 0,
+	}
+	exp := &Expectations{
+		Logs:    &SignalExpectation{MinCount: 1, RequiredAttributes: []string{"cx.application.name"}},
+		Metrics: &SignalExpectation{MinCount: 5},
+	}
+
+	r := VerifyExpectations(context.Background(), cfg, exp)
+	assert.False(t, r.Pass)
+	summary := r.FailureSummary()
+	assert.True(t, strings.Contains(summary, "required_attribute"), "should mention required_attribute, got: %s", summary)
+	assert.True(t, strings.Contains(summary, "min_count"), "should mention min_count, got: %s", summary)
+}

--- a/e2e/verify/expectations_verify.go
+++ b/e2e/verify/expectations_verify.go
@@ -1,0 +1,336 @@
+package verify
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// ExpectationResult is the outcome of running one Expectations against CX.
+// It is the structured equivalent of "did this E2E run pass?".
+type ExpectationResult struct {
+	RunID    string         `json:"run_id"`
+	Domain   string         `json:"domain"`
+	Sections []SectionResult `json:"sections"`
+	Pass     bool           `json:"pass"`
+}
+
+// SectionResult is the outcome of one section of the expectations file
+// (one of: logs, traces, metrics, collector_health).
+type SectionResult struct {
+	Name     string        `json:"name"`               // "logs" | "traces" | "metrics" | "collector_health"
+	Pass     bool          `json:"pass"`
+	Checks   []CheckResult `json:"checks"`
+	Elapsed  time.Duration `json:"elapsed"`
+}
+
+// CheckResult is one assertion within a section (e.g., "min_count >= 5",
+// "required_attribute cx.application.name").
+type CheckResult struct {
+	Name    string `json:"name"`
+	Pass    bool   `json:"pass"`
+	Detail  string `json:"detail,omitempty"`
+}
+
+// VerifyExpectations runs all checks defined in the Expectations against CX.
+// Polls each signal section with the same backoff/timeout strategy as the
+// existing VerifyLogs/VerifyTraces/VerifyMetrics; once enough data arrives
+// to satisfy MinCount, runs the per-record assertions on the returned rows.
+func VerifyExpectations(ctx context.Context, cfg Config, exp *Expectations) ExpectationResult {
+	cfg.Defaults()
+
+	res := ExpectationResult{
+		RunID:  cfg.RunID,
+		Domain: cfg.Client.Domain,
+		Pass:   true,
+	}
+
+	if exp.Logs != nil {
+		section := verifyDataPrimeSection(ctx, cfg, "logs",
+			fmt.Sprintf("source logs | filter %s | limit 100",
+				substituteRunID(cfg.LogsFilter, cfg.RunID)),
+			exp.Logs)
+		res.Sections = append(res.Sections, section)
+		if !section.Pass {
+			res.Pass = false
+		}
+	}
+
+	if exp.Traces != nil {
+		section := verifyDataPrimeSection(ctx, cfg, "traces",
+			fmt.Sprintf("source spans | filter %s | limit 100",
+				substituteRunID(cfg.TracesFilter, cfg.RunID)),
+			exp.Traces)
+		res.Sections = append(res.Sections, section)
+		if !section.Pass {
+			res.Pass = false
+		}
+	}
+
+	if exp.Metrics != nil {
+		section := verifyMetricsSection(ctx, cfg,
+			substituteRunID(cfg.MetricsFilter, cfg.RunID),
+			exp.Metrics)
+		res.Sections = append(res.Sections, section)
+		if !section.Pass {
+			res.Pass = false
+		}
+	}
+
+	if exp.CollectorHealth != nil {
+		section := verifyCollectorHealth(ctx, cfg, exp.CollectorHealth)
+		res.Sections = append(res.Sections, section)
+		if !section.Pass {
+			res.Pass = false
+		}
+	}
+
+	return res
+}
+
+// verifyDataPrimeSection polls a DataPrime query until min_count rows arrive
+// (or timeout), then runs required_attributes assertions on the rows.
+func verifyDataPrimeSection(ctx context.Context, cfg Config, name, query string, exp *SignalExpectation) SectionResult {
+	start := time.Now()
+	sec := SectionResult{Name: name}
+
+	pollCtx, cancel := context.WithTimeout(ctx, cfg.Timeout)
+	defer cancel()
+
+	if !sleep(pollCtx, cfg.InitialDelay) {
+		sec.Checks = append(sec.Checks, CheckResult{
+			Name: "min_count", Pass: false, Detail: "context canceled during initial delay",
+		})
+		sec.Elapsed = time.Since(start)
+		return sec
+	}
+
+	var lastResult *DataPrimeResult
+	var lastErr error
+	deadline := time.Now().Add(cfg.Timeout)
+
+	for backoff := 10 * time.Second; ; {
+		dpResult, err := cfg.Client.QueryDataPrime(pollCtx, query, cfg.Since)
+		if err != nil {
+			lastErr = err
+		} else {
+			lastResult = dpResult
+			if dpResult.Count >= exp.MinCount {
+				break // enough data, run assertions
+			}
+		}
+
+		if time.Now().Add(backoff).After(deadline) {
+			break // timed out
+		}
+		if !sleep(pollCtx, backoff) {
+			break // context canceled
+		}
+		backoff *= 2
+		if backoff > 60*time.Second {
+			backoff = 60 * time.Second
+		}
+	}
+
+	sec.Elapsed = time.Since(start)
+
+	// min_count check
+	if lastResult == nil {
+		sec.Checks = append(sec.Checks, CheckResult{
+			Name: "min_count", Pass: false,
+			Detail: fmt.Sprintf("no successful query: %v", lastErr),
+		})
+		return sec
+	}
+
+	mc := CheckResult{Name: fmt.Sprintf("min_count >= %d", exp.MinCount)}
+	if lastResult.Count >= exp.MinCount {
+		mc.Pass = true
+		mc.Detail = fmt.Sprintf("got %d rows", lastResult.Count)
+	} else {
+		mc.Detail = fmt.Sprintf("got %d rows after %s", lastResult.Count, sec.Elapsed.Round(time.Second))
+	}
+	sec.Checks = append(sec.Checks, mc)
+
+	// required_attributes — every row must have all required attributes
+	if len(exp.RequiredAttributes) > 0 && lastResult.Count > 0 {
+		for _, attr := range exp.RequiredAttributes {
+			missing := 0
+			for _, row := range lastResult.Rows {
+				ra := row.ResourceAttributes()
+				if _, ok := ra[attr]; !ok {
+					missing++
+				}
+			}
+			cr := CheckResult{Name: fmt.Sprintf("required_attribute %s", attr)}
+			if missing == 0 {
+				cr.Pass = true
+				cr.Detail = fmt.Sprintf("present on all %d rows", len(lastResult.Rows))
+			} else {
+				cr.Detail = fmt.Sprintf("missing on %d/%d rows", missing, len(lastResult.Rows))
+			}
+			sec.Checks = append(sec.Checks, cr)
+		}
+	}
+
+	// Section passes only if every check passes
+	sec.Pass = true
+	for _, c := range sec.Checks {
+		if !c.Pass {
+			sec.Pass = false
+			break
+		}
+	}
+	return sec
+}
+
+// verifyMetricsSection polls PromQL for matching series until min_count is
+// reached, then checks required_labels are present on every series.
+func verifyMetricsSection(ctx context.Context, cfg Config, query string, exp *SignalExpectation) SectionResult {
+	start := time.Now()
+	sec := SectionResult{Name: "metrics"}
+
+	pollCtx, cancel := context.WithTimeout(ctx, cfg.Timeout)
+	defer cancel()
+
+	if !sleep(pollCtx, cfg.InitialDelay) {
+		sec.Checks = append(sec.Checks, CheckResult{
+			Name: "min_count", Pass: false, Detail: "context canceled during initial delay",
+		})
+		sec.Elapsed = time.Since(start)
+		return sec
+	}
+
+	var lastResult *PromQLResult
+	var lastErr error
+	deadline := time.Now().Add(cfg.Timeout)
+
+	for backoff := 10 * time.Second; ; {
+		pqResult, err := cfg.Client.QueryPromQL(pollCtx, query)
+		if err != nil {
+			lastErr = err
+		} else {
+			lastResult = pqResult
+			if pqResult.Count >= exp.MinCount {
+				break
+			}
+		}
+		if time.Now().Add(backoff).After(deadline) {
+			break
+		}
+		if !sleep(pollCtx, backoff) {
+			break
+		}
+		backoff *= 2
+		if backoff > 60*time.Second {
+			backoff = 60 * time.Second
+		}
+	}
+
+	sec.Elapsed = time.Since(start)
+
+	if lastResult == nil {
+		sec.Checks = append(sec.Checks, CheckResult{
+			Name: "min_count", Pass: false,
+			Detail: fmt.Sprintf("no successful query: %v", lastErr),
+		})
+		return sec
+	}
+
+	mc := CheckResult{Name: fmt.Sprintf("min_count >= %d", exp.MinCount)}
+	if lastResult.Count >= exp.MinCount {
+		mc.Pass = true
+		mc.Detail = fmt.Sprintf("got %d series", lastResult.Count)
+	} else {
+		mc.Detail = fmt.Sprintf("got %d series after %s", lastResult.Count, sec.Elapsed.Round(time.Second))
+	}
+	sec.Checks = append(sec.Checks, mc)
+
+	// required_labels — every series must have all required labels
+	if len(exp.RequiredLabels) > 0 && lastResult.Count > 0 {
+		for _, label := range exp.RequiredLabels {
+			missing := 0
+			for _, s := range lastResult.Series {
+				if _, ok := s.Metric[label]; !ok {
+					missing++
+				}
+			}
+			cr := CheckResult{Name: fmt.Sprintf("required_label %s", label)}
+			if missing == 0 {
+				cr.Pass = true
+				cr.Detail = fmt.Sprintf("present on all %d series", len(lastResult.Series))
+			} else {
+				cr.Detail = fmt.Sprintf("missing on %d/%d series", missing, len(lastResult.Series))
+			}
+			sec.Checks = append(sec.Checks, cr)
+		}
+	}
+
+	sec.Pass = true
+	for _, c := range sec.Checks {
+		if !c.Pass {
+			sec.Pass = false
+			break
+		}
+	}
+	return sec
+}
+
+// verifyCollectorHealth queries PromQL for otelcol_exporter_send_failed_records_total
+// scoped to this run_id and asserts the sum is <= max_send_failures.
+func verifyCollectorHealth(ctx context.Context, cfg Config, exp *CollectorHealthCheck) SectionResult {
+	start := time.Now()
+	sec := SectionResult{Name: "collector_health"}
+
+	// sum(otelcol_exporter_send_failed_records_total{e2e_run_id="<id>"})
+	// We sum across all exporters/data_types so the threshold is total failures.
+	query := fmt.Sprintf(`sum(otelcol_exporter_send_failed_records_total{e2e_run_id=%q})`, cfg.RunID)
+
+	pollCtx, cancel := context.WithTimeout(ctx, cfg.Timeout)
+	defer cancel()
+
+	pqResult, err := cfg.Client.QueryPromQL(pollCtx, query)
+	sec.Elapsed = time.Since(start)
+
+	cr := CheckResult{Name: fmt.Sprintf("max_send_failures <= %d", exp.MaxSendFailures)}
+	if err != nil {
+		cr.Detail = fmt.Sprintf("query error: %v", err)
+		sec.Checks = []CheckResult{cr}
+		return sec
+	}
+
+	// Empty result = no failures recorded yet (collector never failed to send).
+	// That's a pass.
+	if len(pqResult.Series) == 0 {
+		cr.Pass = true
+		cr.Detail = "no send failures recorded"
+	} else {
+		val := pqResult.Series[0].MetricValue()
+		if int(val) <= exp.MaxSendFailures {
+			cr.Pass = true
+			cr.Detail = fmt.Sprintf("got %.0f failures", val)
+		} else {
+			cr.Detail = fmt.Sprintf("got %.0f failures (limit %d)", val, exp.MaxSendFailures)
+		}
+	}
+
+	sec.Checks = []CheckResult{cr}
+	sec.Pass = cr.Pass
+	return sec
+}
+
+// FailureSummary returns a multi-line human-readable description of failed
+// checks across all sections, suitable for printing to stderr on test failure.
+// Returns empty string if nothing failed.
+func (r ExpectationResult) FailureSummary() string {
+	var b strings.Builder
+	for _, sec := range r.Sections {
+		for _, c := range sec.Checks {
+			if !c.Pass {
+				b.WriteString(fmt.Sprintf("  %s.%s: %s\n", sec.Name, c.Name, c.Detail))
+			}
+		}
+	}
+	return b.String()
+}

--- a/e2e/verify/verify.go
+++ b/e2e/verify/verify.go
@@ -1,0 +1,240 @@
+package verify
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Signal identifies the telemetry signal to verify.
+type Signal string
+
+const (
+	SignalLogs    Signal = "logs"
+	SignalTraces  Signal = "traces"
+	SignalMetrics Signal = "metrics"
+)
+
+// Config controls a verification run.
+type Config struct {
+	Client       *Client       // Coralogix client
+	RunID        string        // unique E2E run identifier (must match resource attribute on telemetry)
+	Since        time.Time     // earliest timestamp to consider data valid
+	Timeout      time.Duration // total time to poll before giving up
+	InitialDelay time.Duration // delay before first poll (default 30s)
+
+	// Filter expressions. The string "{{run_id}}" is replaced with cfg.RunID at query time.
+	// Defaults are set by Defaults() if empty.
+	LogsFilter    string // DataPrime filter clause for logs
+	TracesFilter  string // DataPrime filter clause for spans
+	MetricsFilter string // PromQL selector for metrics
+}
+
+// Defaults fills in zero-value fields with sensible defaults.
+// Note: InitialDelay defaults to 0 (immediate first poll). Callers (e.g. the CLI)
+// should set it explicitly to give the collector time to flush the first batch.
+func (c *Config) Defaults() {
+	if c.Timeout == 0 {
+		c.Timeout = 10 * time.Minute
+	}
+	// DataPrime substring match on the entire $d document. This works because:
+	//   - OTel resource attribute keys can contain dots (e.g. "e2e.run_id"), but
+	//     DataPrime's path access only supports [a-zA-Z0-9_], so structured
+	//     access like $d.resource.attributes.e2e_run_id raises "keypath does not exist"
+	//   - userData is stored as a JSON-encoded string, not a parsed object
+	//   - The run_id value is unique per E2E run, so substring match has no
+	//     false-positive risk in practice
+	if c.LogsFilter == "" {
+		c.LogsFilter = `$d ~~ '{{run_id}}'`
+	}
+	if c.TracesFilter == "" {
+		c.TracesFilter = `$d ~~ '{{run_id}}'`
+	}
+	// PromQL: OTel resource attributes are mapped to Prometheus labels with
+	// dots converted to underscores (e2e.run_id -> e2e_run_id).
+	if c.MetricsFilter == "" {
+		c.MetricsFilter = `{e2e_run_id="{{run_id}}"}`
+	}
+}
+
+// Result is the outcome of a single signal verification.
+type Result struct {
+	Signal  Signal        `json:"signal"`
+	Found   bool          `json:"found"`
+	Count   int           `json:"count"`
+	Sample  string        `json:"sample,omitempty"`
+	Elapsed time.Duration `json:"elapsed"`
+	Error   string        `json:"error,omitempty"`
+}
+
+// VerifyLogs polls DataPrime for logs matching the run ID.
+func VerifyLogs(ctx context.Context, cfg Config) Result {
+	cfg.Defaults()
+	query := fmt.Sprintf("source logs | filter %s | limit 5",
+		substituteRunID(cfg.LogsFilter, cfg.RunID))
+	return pollDataPrime(ctx, cfg, SignalLogs, query)
+}
+
+// VerifyTraces polls DataPrime for spans matching the run ID.
+func VerifyTraces(ctx context.Context, cfg Config) Result {
+	cfg.Defaults()
+	query := fmt.Sprintf("source spans | filter %s | limit 5",
+		substituteRunID(cfg.TracesFilter, cfg.RunID))
+	return pollDataPrime(ctx, cfg, SignalTraces, query)
+}
+
+// VerifyMetrics polls the PromQL endpoint for metrics matching the run ID.
+func VerifyMetrics(ctx context.Context, cfg Config) Result {
+	cfg.Defaults()
+	query := substituteRunID(cfg.MetricsFilter, cfg.RunID)
+	return pollPromQL(ctx, cfg, query)
+}
+
+// VerifyAll runs the requested checks concurrently and returns all results.
+func VerifyAll(ctx context.Context, cfg Config, checks []Signal) []Result {
+	results := make([]Result, len(checks))
+	var wg sync.WaitGroup
+	for i, sig := range checks {
+		wg.Add(1)
+		go func(i int, sig Signal) {
+			defer wg.Done()
+			switch sig {
+			case SignalLogs:
+				results[i] = VerifyLogs(ctx, cfg)
+			case SignalTraces:
+				results[i] = VerifyTraces(ctx, cfg)
+			case SignalMetrics:
+				results[i] = VerifyMetrics(ctx, cfg)
+			default:
+				results[i] = Result{Signal: sig, Error: "unknown signal"}
+			}
+		}(i, sig)
+	}
+	wg.Wait()
+	return results
+}
+
+func substituteRunID(template, runID string) string {
+	return strings.ReplaceAll(template, "{{run_id}}", runID)
+}
+
+// pollDataPrime polls a DataPrime query with exponential backoff until data
+// is found or the timeout expires.
+func pollDataPrime(ctx context.Context, cfg Config, sig Signal, query string) Result {
+	start := time.Now()
+	r := Result{Signal: sig}
+
+	deadline := start.Add(cfg.Timeout)
+	pollCtx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+
+	if !sleep(pollCtx, cfg.InitialDelay) {
+		r.Error = "context canceled during initial delay"
+		r.Elapsed = time.Since(start)
+		return r
+	}
+
+	for backoff := 10 * time.Second; ; {
+		dpResult, err := cfg.Client.QueryDataPrime(pollCtx, query, cfg.Since)
+		if err != nil {
+			// Log the error but keep polling — transient API failures shouldn't
+			// fail the whole verification immediately.
+			r.Error = err.Error()
+		} else if dpResult.Count > 0 {
+			r.Found = true
+			r.Count = dpResult.Count
+			r.Sample = truncate(dpResult.Sample, 500)
+			r.Error = ""
+			r.Elapsed = time.Since(start)
+			return r
+		}
+
+		if time.Now().Add(backoff).After(deadline) {
+			r.Elapsed = time.Since(start)
+			if r.Error == "" {
+				r.Error = fmt.Sprintf("no data found within timeout (%s)", cfg.Timeout)
+			}
+			return r
+		}
+		if !sleep(pollCtx, backoff) {
+			r.Elapsed = time.Since(start)
+			r.Error = "context canceled while waiting"
+			return r
+		}
+		backoff *= 2
+		if backoff > 60*time.Second {
+			backoff = 60 * time.Second
+		}
+	}
+}
+
+// pollPromQL polls a PromQL query with exponential backoff.
+func pollPromQL(ctx context.Context, cfg Config, query string) Result {
+	start := time.Now()
+	r := Result{Signal: SignalMetrics}
+
+	deadline := start.Add(cfg.Timeout)
+	pollCtx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+
+	if !sleep(pollCtx, cfg.InitialDelay) {
+		r.Error = "context canceled during initial delay"
+		r.Elapsed = time.Since(start)
+		return r
+	}
+
+	for backoff := 10 * time.Second; ; {
+		pqResult, err := cfg.Client.QueryPromQL(pollCtx, query)
+		if err != nil {
+			r.Error = err.Error()
+		} else if pqResult.Count > 0 {
+			r.Found = true
+			r.Count = pqResult.Count
+			r.Sample = truncate(pqResult.Sample, 500)
+			r.Error = ""
+			r.Elapsed = time.Since(start)
+			return r
+		}
+
+		if time.Now().Add(backoff).After(deadline) {
+			r.Elapsed = time.Since(start)
+			if r.Error == "" {
+				r.Error = fmt.Sprintf("no metrics found within timeout (%s)", cfg.Timeout)
+			}
+			return r
+		}
+		if !sleep(pollCtx, backoff) {
+			r.Elapsed = time.Since(start)
+			r.Error = "context canceled while waiting"
+			return r
+		}
+		backoff *= 2
+		if backoff > 60*time.Second {
+			backoff = 60 * time.Second
+		}
+	}
+}
+
+// sleep waits for d or until ctx is canceled. Returns true if d elapsed normally.
+func sleep(ctx context.Context, d time.Duration) bool {
+	if d <= 0 {
+		return true
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-t.C:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/e2e/verify/verify_test.go
+++ b/e2e/verify/verify_test.go
@@ -1,0 +1,139 @@
+package verify
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVerifyLogs_FoundOnFirstPoll(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"result":{"results":[{"foo":"bar"}]}}`))
+	}))
+	defer srv.Close()
+
+	cfg := Config{
+		Client:       newTestClient(srv),
+		RunID:        "abc",
+		Since:        time.Now().Add(-1 * time.Hour),
+		Timeout:      30 * time.Second,
+		InitialDelay: 0, // no delay for tests
+	}
+
+	res := VerifyLogs(context.Background(), cfg)
+	assert.True(t, res.Found, "expected logs to be found")
+	assert.Equal(t, 1, res.Count)
+	assert.Equal(t, SignalLogs, res.Signal)
+	assert.Empty(t, res.Error)
+}
+
+func TestVerifyLogs_FoundAfterRetry(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n < 2 {
+			_, _ = w.Write([]byte(`{"result":{"results":[]}}`)) // empty first time
+			return
+		}
+		_, _ = w.Write([]byte(`{"result":{"results":[{"x":1}]}}`)) // found second time
+	}))
+	defer srv.Close()
+
+	cfg := Config{
+		Client:       newTestClient(srv),
+		RunID:        "abc",
+		Since:        time.Now().Add(-1 * time.Hour),
+		Timeout:      30 * time.Second,
+		InitialDelay: 0,
+	}
+
+	// Override the initial backoff to make the test fast — we use a custom timeout
+	// short enough that we know it had to retry at least once.
+	res := VerifyLogs(context.Background(), cfg)
+	assert.True(t, res.Found)
+	assert.GreaterOrEqual(t, atomic.LoadInt32(&calls), int32(2))
+}
+
+func TestVerifyLogs_TimeoutNoData(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"result":{"results":[]}}`))
+	}))
+	defer srv.Close()
+
+	cfg := Config{
+		Client:       newTestClient(srv),
+		RunID:        "abc",
+		Since:        time.Now().Add(-1 * time.Hour),
+		Timeout:      2 * time.Second, // very short
+		InitialDelay: 0,
+	}
+
+	res := VerifyLogs(context.Background(), cfg)
+	assert.False(t, res.Found)
+	assert.Contains(t, res.Error, "no data found")
+}
+
+func TestVerifyMetrics_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[{"metric":{"x":"y"}}]}}`))
+	}))
+	defer srv.Close()
+
+	cfg := Config{
+		Client:       newTestClient(srv),
+		RunID:        "abc",
+		Since:        time.Now().Add(-1 * time.Hour),
+		Timeout:      30 * time.Second,
+		InitialDelay: 0,
+	}
+
+	res := VerifyMetrics(context.Background(), cfg)
+	assert.True(t, res.Found)
+	assert.Equal(t, 1, res.Count)
+	assert.Equal(t, SignalMetrics, res.Signal)
+}
+
+func TestVerifyAll_RunsConcurrently(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Both DataPrime and PromQL endpoints return data
+		if r.Method == http.MethodPost {
+			_, _ = w.Write([]byte(`{"result":{"results":[{"x":1}]}}`))
+		} else {
+			_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[{"y":1}]}}`))
+		}
+	}))
+	defer srv.Close()
+
+	cfg := Config{
+		Client:       newTestClient(srv),
+		RunID:        "abc",
+		Since:        time.Now().Add(-1 * time.Hour),
+		Timeout:      30 * time.Second,
+		InitialDelay: 0,
+	}
+
+	results := VerifyAll(context.Background(), cfg, []Signal{SignalLogs, SignalTraces, SignalMetrics})
+	assert.Len(t, results, 3)
+	for _, r := range results {
+		assert.True(t, r.Found, "signal %s should be found", r.Signal)
+	}
+}
+
+func TestSubstituteRunID(t *testing.T) {
+	got := substituteRunID(`$d.resource.attributes.e2e_run_id == '{{run_id}}'`, "abc-123")
+	assert.Equal(t, `$d.resource.attributes.e2e_run_id == 'abc-123'`, got)
+}
+
+func TestDefaults(t *testing.T) {
+	cfg := Config{}
+	cfg.Defaults()
+	assert.Equal(t, 10*time.Minute, cfg.Timeout)
+	assert.Equal(t, time.Duration(0), cfg.InitialDelay, "InitialDelay defaults to 0; CLI sets it explicitly")
+	assert.Contains(t, cfg.LogsFilter, "{{run_id}}")
+	assert.Contains(t, cfg.MetricsFilter, "{{run_id}}")
+}


### PR DESCRIPTION
## Summary

  Adds the foundation for a new unified E2E framework.
  The framework will eventually cover all required deployment targets (K8S, ECS, Linux, Windows...) using a single shared verification module, per-target
  expectation files, and per-target jobs in a single GitHub Actions workflow.

  ## What this PR adds

  ```
  e2e/
  ├── go.mod / go.sum                       # Go module: coralogix.com/telemetry-shippers/e2e
  ├── verify/
  │   ├── coralogix.go                      # DataPrime + PromQL HTTP clients (with parsed-row access)
  │   ├── coralogix_test.go
  │   ├── verify.go                         # Verify{Logs,Traces,Metrics} with backoff polling
  │   ├── verify_test.go
  │   ├── expectations.go                   # YAML schema + loader for per-target expectations
  │   ├── expectations_verify.go            # VerifyExpectations() runs structured assertions
  │   └── expectations_test.go
  ├── cmd/e2e-verify/
  │   └── main.go                           # CLI wrapping the verify module
  ├── scripts/
  │   ├── patch-config-runid.sh             # Inject e2e.run_id (Linux/macOS)
  │   ├── patch-config-runid.ps1            # Same for Windows
  │   └── wait-healthy.sh                   # Poll collector :13133 until ready
  └── expectations/
      ├── k8s.yaml                          # Per-target assertions
      ├── ecs-ec2.yaml
      ├── linux-standalone.yaml
      ├── windows-standalone.yaml
      └── macos-standalone.yaml
  ```

  ## How it works

  For each E2E test run:

  1. The orchestrator deploys the OTel collector with the chart's `build/otel-config.yaml`, after `patch-config-runid.sh` injects a unique `e2e.run_id` resource
   attribute.
  2. `wait-healthy.sh` polls `:13133/healthcheck` until the collector is ready.
  3. `e2e-verify` queries Coralogix DataPrime + PromQL APIs to confirm telemetry with the matching `e2e.run_id` arrived. Two modes:
     - `--check logs --check traces --check metrics` — existence-only (debugging).
     - `--expectations <file>` — structured per-target checks: `min_count`, `required_attributes` (resource attrs on logs/traces), `required_labels` (PromQL
  labels on metrics), and `collector_health.max_send_failures` (catches collector-side ingest failures via `otelcol_exporter_send_failed_records_total`).
  4. Cleanup (uninstall / `terraform destroy`) runs in `if: always()`.

  The verify CLI is signal-agnostic and works for all future targets without modification — only the per-target `expectations/<target>.yaml` differs.

  ## Expectations schema

  Each per-target file describes what the chart **should** emit. Sections are optional; missing sections aren't checked.

  ```yaml
  logs:
    min_count: 1
    required_attributes:
      - host.name
      - service.name
      - e2e.run_id

  traces:
    min_count: 1
    required_attributes:
      - service.name
      - e2e.run_id

  metrics:
    min_count: 1
    required_labels:
      - cx_application_name
      - host_name
      - e2e_run_id

  collector_health:
    max_send_failures: 0
  ```

  ## Validated end-to-end

  Two manual runs against real Coralogix using `otel-macos-standalone`:

  **Run 1 — existence-only mode (`--check`):**
  ```
  ✅ logs:    found=true, count=5
  ✅ metrics: found=true, count=9137
     OK: all checks passed
  ```

  **Run 2 — expectations mode (`--expectations expectations/macos-standalone.yaml`):**
  ```
  ✅ logs (4 attrs):    100 rows, all attrs present on every row
  ✅ metrics (4 labels): 9265 series, all labels present on every series
  ✅ collector_health:  no send failures
     OK: all expectations met
  ```

  Failure path tested by deliberately requiring an attribute the chart strips (`cx.otel_integration.name`) — produced clear, structured output pinpointing the
  failed assertion.

  ## What's NOT in this PR (follow-up phases)

  - Per-target jobs (K8S, ECS, Linux, Windows, macOS) — separate commits on the same branch
  - ECS bootstrap Terraform (persistent infra) — separate commit
  - Orchestrator workflow (`e2e-otel-release-test.yml`) — added when first job is wired up
  - Nightly cleanup workflow
  - Migration / deprecation of the old ECS test in `aws-lambda-integration-tests/ecs_ec2_test`

  ## Test plan

  - [x] Unit tests pass: `cd e2e && go test ./...` (21 tests: 12 client/verify + 9 expectations)
  - [x] `go vet ./...` clean
  - [x] CLI builds and shows usage
  - [x] `patch-config-runid.sh` tested on all three standalone build configs (linux/windows/macos) — correctly targets `processors."resource/metadata"`,
  preserves existing attributes, idempotent, fails loudly if processor not in any pipeline
  - [x] End-to-end against real Coralogix in **both** modes (existence + expectations) on macOS standalone
  - [x] Failure path tested — required attribute the chart strips → clear structured failure
  - [x] `wait-healthy.sh` timeout path tested

  ## Notes for reviewers

  - **Two API keys are required.** `E2E_CX_API_KEY` (Send-Your-Data) for the collector to ingest into CX. `E2E_CX_LOGS_QUERY_KEY` (Logs Query Key) for the
  verify CLI to query CX. The Send-Your-Data key alone cannot query.
  - DataPrime auth header is the raw key (no `Bearer` prefix). PromQL auth header uses `Bearer <key>`. Both confirmed against real CX.
  - Default `--window` is 24h to handle cases where the collector picks up pre-existing log files with old timestamps.
  - `InitialDelay` defaults to 0 in the Go package; the CLI sets it to 30s explicitly to give the collector time to flush its first batch.
  - **DataPrime path-syntax quirk:** structured paths only support `[a-zA-Z0-9_]`, so OTel attribute keys with dots (e.g. `e2e.run_id`) cannot be queried via
  `$d.resource.attributes.X` — this returns `keypath does not exist`. The default logs/traces filter uses DataPrime's `~~` substring operator on `$d`, which is
  reliable since run_ids are unique. Filters are overridable via `--logs-filter`, `--traces-filter`, `--metrics-filter` flags using `{{run_id}}` as the
  placeholder.
  - **`collector_health` limitation:** `otelcol_exporter_send_failed_records_total` only increments for collector-side failures (network, auth, dropped queue).
  Coralogix-side rejection of oversized labels (e.g. `max_label_length` fair-usage breach) does **not** increment this metric — the collector successfully sends
   the data, CX silently drops the offending labels. A separate check that queries CX warning logs would be needed for full coverage; out of scope for this PR.

  ## Side finding (separate ticket worth filing)

  The `otel-macos-standalone` chart emits per-process metrics with `process.command_line` labels that exceed Coralogix's 1024-char limit on desktops with many
  GUI apps (Chrome, Slack, Electron). During validation this caused 1,212 `max_label_length` fair-usage breaches. Suggested fix: add a transform processor to
  truncate `process.command_line` to ~256 chars in the chart, or restrict the process scraper. Worth filing for chart owners — exactly the kind of regression
  release E2E should surface.
