### PR TITLE
Only sync fleet manager via its Helm data repo

### DIFF
--- a/.github/workflows/sync-fleet-manager.yml
+++ b/.github/workflows/sync-fleet-manager.yml
@@ -42,7 +42,7 @@ on:
         default: "master"
         required: false
       create_pr:
-        description: "If true, create commit/push and open PR in Fleet Manager"
+        description: "If true, create commit/push and open PR in Fleet Manager Helm Data"
         type: boolean
         default: false
 
@@ -157,25 +157,6 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GH_TOKEN }}
 
-      - name: Prepare Fleet Manager branch
-        env:
-          FLEET_MANAGER_REF: ${{ inputs.fleet_manager_ref || 'master' }}
-        run: |
-          set -euo pipefail
-          repo_dir="$GITHUB_WORKSPACE/fleet-manager"
-          branch="bot/sync-fleet-manager-artifacts"
-
-          git -C "$repo_dir" config user.name "github-actions[bot]"
-          git -C "$repo_dir" config user.email "github-actions[bot]@users.noreply.github.com"
-
-          if git -C "$repo_dir" ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
-            git -C "$repo_dir" fetch origin "$branch"
-            git -C "$repo_dir" checkout "$branch"
-            git -C "$repo_dir" rebase "origin/$FLEET_MANAGER_REF"
-          else
-            git -C "$repo_dir" checkout -b "$branch"
-          fi
-
       - name: Checkout Fleet Manager Helm Data
         uses: actions/checkout@v4
         with:
@@ -238,45 +219,6 @@ jobs:
             echo "changed_files=" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Copy changelog artifacts when changed
-        id: update_changelog
-        run: |
-          set -euo pipefail
-          mappings=(
-            "otel_integration_changelog.json:pkg/helm/data/otel_integration_changelog.json"
-            "otel_linux_standalone_changelog.json:pkg/helm/data/otel_linux_standalone_changelog.json"
-            "otel_macos_standalone_changelog.json:pkg/helm/data/otel_macos_standalone_changelog.json"
-            "otel_windows_standalone_changelog.json:pkg/helm/data/otel_windows_standalone_changelog.json"
-            "otel_linux_standalone_chart_versions_map.json:pkg/helm/data/otel_linux_standalone_chart_versions_map.json"
-            "otel_windows_standalone_chart_versions_map.json:pkg/helm/data/otel_windows_standalone_chart_versions_map.json"
-            "otel_macos_standalone_chart_versions_map.json:pkg/helm/data/otel_macos_standalone_chart_versions_map.json"
-          )
-
-          changed_files=()
-          for mapping in "${mappings[@]}"; do
-            src_name="${mapping%%:*}"
-            dst_name="${mapping##*:}"
-            src="$RUNNER_TEMP/$src_name"
-            dst="$GITHUB_WORKSPACE/fleet-manager/$dst_name"
-
-            if [ -f "$dst" ] && cmp -s "$src" "$dst"; then
-              continue
-            fi
-
-            mkdir -p "$(dirname "$dst")"
-            cp "$src" "$dst"
-            changed_files+=("$dst_name")
-          done
-
-          if [ "${#changed_files[@]}" -eq 0 ]; then
-            echo "updated=false" >> "$GITHUB_OUTPUT"
-            echo "changed_files=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "updated=true" >> "$GITHUB_OUTPUT"
-          printf 'changed_files=%s\n' "${changed_files[*]}" >> "$GITHUB_OUTPUT"
-
       - name: Copy artifacts to Fleet Manager Helm Data
         id: update_helm_data
         run: |
@@ -324,101 +266,6 @@ jobs:
 
           echo "updated=true" >> "$GITHUB_OUTPUT"
           printf 'changed_files=%s\n' "${changed_files[*]}" >> "$GITHUB_OUTPUT"
-
-      - name: Commit, push, and create/update PR
-        if: steps.update_map.outputs.updated == 'true' || steps.update_changelog.outputs.updated == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          CREATE_PR: ${{ github.event_name != 'workflow_dispatch' || inputs.create_pr }}
-          FLEET_MANAGER_REPO: ${{ inputs.fleet_manager_repo || 'coralogix/fleet-manager' }}
-          FLEET_MANAGER_REF: ${{ inputs.fleet_manager_ref || 'master' }}
-          INTEGRATION_CHART_VERSION: ${{ steps.detect.outputs.integration_chart_version }}
-          COLLECTOR_CHART_VERSION: ${{ steps.detect.outputs.collector_chart_version }}
-        run: |
-          set -euo pipefail
-
-          repo_dir="$GITHUB_WORKSPACE/fleet-manager"
-          branch="bot/sync-fleet-manager-artifacts"
-
-          map_files="${{ steps.update_map.outputs.changed_files }}"
-          changelog_files="${{ steps.update_changelog.outputs.changed_files }}"
-          map_updated="${{ steps.update_map.outputs.updated }}"
-          changelog_updated="${{ steps.update_changelog.outputs.updated }}"
-
-          declare -A file_set=()
-          read -r -a map_list <<< "$map_files"
-          read -r -a changelog_list <<< "$changelog_files"
-          for file in "${map_list[@]}"; do
-            [ -n "$file" ] && file_set["$file"]=1
-          done
-          for file in "${changelog_list[@]}"; do
-            [ -n "$file" ] && file_set["$file"]=1
-          done
-
-          files=()
-          for file in "${!file_set[@]}"; do
-            files+=("$file")
-          done
-
-          if [ "${#files[@]}" -eq 0 ]; then
-            echo "No files to stage."
-            exit 0
-          fi
-
-          git -C "$repo_dir" add "${files[@]}"
-          if git -C "$repo_dir" diff --cached --quiet; then
-            echo "No changes to commit."
-            exit 0
-          fi
-
-          if [ "${CREATE_PR:-false}" != "true" ]; then
-            echo "CREATE_PR is false; skipping commit/push/PR. (Dry run complete.)"
-            echo ""
-            echo "Changed files in Fleet Manager:"
-            git -C "$repo_dir" --no-pager diff --cached --stat
-            echo ""
-            echo "Full staged diff:"
-            git -C "$repo_dir" --no-pager diff --cached
-            exit 0
-          fi
-
-          if [ -z "${GH_TOKEN:-}" ]; then
-            echo "Missing GH_TOKEN secret"
-            exit 1
-          fi
-
-          git -C "$repo_dir" commit -m "Sync Fleet Manager artifacts from telemetry-shippers"
-          git -C "$repo_dir" push --force-with-lease -u origin "$branch"
-
-          existing_pr="$(gh pr list -R "$FLEET_MANAGER_REPO" --head "$branch" --state open --json number --jq '.[0].number')"
-          if [ -n "$existing_pr" ]; then
-            echo "PR already exists: #$existing_pr"
-            exit 0
-          fi
-
-          pr_body="$RUNNER_TEMP/fleet-manager-sync-pr-body.md"
-          {
-            echo "Automated synchronization from telemetry-shippers."
-            echo ""
-            if [ "$map_updated" = "true" ]; then
-              echo "## Collector chart map"
-              printf -- '- otel-integration chart: `%s`\n' "$INTEGRATION_CHART_VERSION"
-              printf -- '- opentelemetry-collector chart: `%s`\n' "$COLLECTOR_CHART_VERSION"
-              echo ""
-            fi
-            if [ "$changelog_updated" = "true" ]; then
-              echo "## OTEL changelog artifacts"
-              echo '- Updated changelog JSON artifacts under `pkg/helm/data`.'
-              echo ""
-            fi
-          } > "$pr_body"
-
-          gh pr create \
-            -R "$FLEET_MANAGER_REPO" \
-            --base "$FLEET_MANAGER_REF" \
-            --head "$branch" \
-            --title "Sync Fleet Manager artifacts from telemetry-shippers" \
-            --body-file "$pr_body"
 
       - name: Commit, push, and create/update Fleet Manager Helm Data PR
         if: steps.update_helm_data.outputs.updated == 'true'


### PR DESCRIPTION
# Description

Fixes CX-38458.

The files have been already removed from the Fleet Manager and it relies on the data synced to the new repo. We can stop the automated PRs to the main Fleet Manager repo.

# How Has This Been Tested?

# Checklist:
- [ ] I have updated the relevant Helm chart(s) version(s)
- [ ] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
