### PR TITLE
Route eBPF profiles through agent profiles pipeline

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## OpenTelemetry-Integration
 
+### v0.0.305 / 2026-05-04
+
+- [Chore] Bump chart dependency to opentelemetry-collector 0.131.1
+- [Breaking] eBPF profiler profiles are now sent through the node-local agent `profilesCollection` pipeline for Kubernetes enrichment and Coralogix export. Previously, the profiler sent profiles directly to Coralogix, so installations that customize the profiler or agent profile pipeline should update their configuration to route profiles through the agent.
+
+#### Changes from opentelemetry-collector 0.131.1:
+- [Feat] Support forwarding eBPF profiler profiles to the node-local agent with the `otlpExporter` preset.
+- [Feat] Add the `x-coralogix-ingress: otlp/v1.10.0` header to Coralogix profile exports.
+- [Fix] Split profile Kubernetes pod association so `container.id` matching is attempted before falling back to connection metadata.
+- [Fix] Scope profile Kubernetes RBAC to the presets that configure `k8sattributes/profiles` and keep OTLP ports controlled by values.
+
 ### v0.0.304 / 2026-04-30
 
 - [Chore] Bump chart dependency to opentelemetry-collector 0.131.0

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.304
+version: 0.0.305
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -11,37 +11,37 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.131.0"
+    version: "0.131.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-windows
-    version: "0.131.0"
+    version: "0.131.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-windows.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-cluster-collector
-    version: "0.131.0"
+    version: "0.131.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-cluster-collector.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-receiver
-    version: "0.131.0"
+    version: "0.131.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-receiver.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-gateway
-    version: "0.131.0"
+    version: "0.131.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-gateway.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-eks-fargate
-    version: "0.131.0"
+    version: "0.131.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-eks-fargate.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-eks-fargate-monitoring
-    version: "0.131.0"
+    version: "0.131.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-eks-fargate-monitoring.enabled
   - name: coralogix-ebpf-profiler
@@ -51,7 +51,7 @@ dependencies:
     condition: coralogix-ebpf-profiler.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-ebpf-profiler
-    version: "0.131.0"
+    version: "0.131.1"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-ebpf-profiler.enabled
   - name: opentelemetry-ebpf-instrumentation

--- a/otel-integration/k8s-helm/README.md
+++ b/otel-integration/k8s-helm/README.md
@@ -1423,12 +1423,9 @@ The generated `kubernetes_sd_configs` is a common configuration syntax for disco
 
 The OpenTelemetry eBPF Profiler Collector runs the [otelcol-ebpf-profiler distribution](https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-ebpf-profiler) as a DaemonSet to collect CPU profiles with eBPF and emit OTLP profiles. It is deployed as the `opentelemetry-ebpf-profiler` subchart and uses the same base chart values as the other collectors.
 
-The `ebpfProfiler` and `profilesK8sAttributes` presets are intended for the eBPF profiler distribution. Use the `metadata` preset to attach Coralogix integration attributes. If you export directly to Coralogix, enable the `otlpExporter` preset. To expose profiler metrics for scraping, enable `collectorMetrics` with `disablePrometheusReceiver: true` and rely on annotation-based discovery from the cluster-collector.
+The `ebpfProfiler` preset is intended for the eBPF profiler distribution. Use the `otlpExporter` preset to forward profiles to the node-local `opentelemetry-agent` over OTLP. Enable `profilesCollection` on the agent to receive profiles, enrich them with Kubernetes metadata, map `service.name`, and export them to Coralogix through the regular Coralogix exporter. To expose profiler metrics for scraping, enable `collectorMetrics` with `disablePrometheusReceiver: true` and rely on annotation-based discovery from the cluster-collector.
 
-To find your Coralogix OTLP endpoint, see [Identify your Coralogix domain](https://coralogix.com/docs/integrations/coralogix-endpoints/#1-identify-your-coralogix-domain).
-For OTLP over gRPC, use port `443` on the ingress endpoint (for example, `ingress.eu1.coralogix.com:443`).
-
-The legacy `coralogix-ebpf-profiler` chart configuration is still available for compatibility. See `k8s-helm/values-ebpf-profiler.yaml` for the legacy setup and `testing/ebpf-profiler-eks/values-ebpf-profiler.yaml` for the collector-based setup used in EKS testing.
+The legacy `coralogix-ebpf-profiler` chart configuration is still available for compatibility. See `k8s-helm/values-ebpf-profiler.yaml` for the legacy setup.
 
 Example configuration (only overrides; default values from `k8s-helm/values.yaml` are omitted):
 
@@ -1444,7 +1441,20 @@ opentelemetry-ebpf-profiler:
   presets:
     resourceDetection:
       enabled: true
-    profilesK8sAttributes:
+    ebpfProfiler:
+      enabled: true
+    otlpExporter:
+      enabled: true
+      endpoint: ${env:K8S_NODE_IP}:4317
+      pipelines: ["profiles"]
+      tls:
+        insecure: true
+
+opentelemetry-agent:
+  enabled: true
+  presets:
+    profilesCollection:
+      enabled: true
       serviceLabels:
         - tag_name: service.label
           key: app.kubernetes.io/name
@@ -1453,13 +1463,10 @@ opentelemetry-ebpf-profiler:
         - tag_name: service.annotation
           key: app.coralogix.com/service
           from: pod
-    otlpExporter:
+    otlpReceiver:
       enabled: true
-      endpoint: "ingress.eu1.coralogix.com:443"
-      headers:
-        Authorization: "Bearer ${env:CORALOGIX_PRIVATE_KEY}"
-        CX-Application-Name: "otel"
-        CX-Subsystem-Name: "integration"
+    coralogixExporter:
+      enabled: true
 
 opentelemetry-cluster-collector:
   enabled: true
@@ -1470,12 +1477,9 @@ opentelemetry-cluster-collector:
       observePods: true
       observeServices: false
       enableServiceRule: false
-
-opentelemetry-agent:
-  enabled: true
 ```
 
-See `testing/ebpf-profiler-eks/values-ebpf-profiler.yaml` for a full example and the base [opentelemetry-collector chart](https://github.com/coralogix/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector) for additional values.
+See the base [opentelemetry-collector chart](https://github.com/coralogix/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector) for additional values.
 
 ### eBPF profiler metrics scrape via cluster-collector annotation discovery
 

--- a/otel-integration/k8s-helm/e2e-test/testdata/values-e2e-test.yaml
+++ b/otel-integration/k8s-helm/e2e-test/testdata/values-e2e-test.yaml
@@ -20,6 +20,8 @@ opentelemetry-agent:
       collectionInterval: "30s"
     spanMetrics:
       enabled: true
+    profilesCollection:
+      enabled: false
   config:
     exporters:
       debug:

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "info"
   collectionInterval: "30s"
-  version: "0.0.304"
+  version: "0.0.305"
   deploymentEnvironmentName: ""
 
   extensions:
@@ -272,6 +272,18 @@ opentelemetry-agent:
     # Adds the OTLP receiver to the traces, metrics, and logs pipelines.
     otlpReceiver:
       enabled: true
+    # Configures the agent to receive eBPF profiler profiles from the node-local
+    # profiler collector and enrich them with Kubernetes metadata before export.
+    profilesCollection:
+      enabled: true
+      serviceLabels:
+        - tag_name: service.label
+          key: app.kubernetes.io/name
+          from: pod
+      serviceAnnotations:
+        - tag_name: service.annotation
+          key: app.coralogix.com/service
+          from: pod
     # Configures the collector to receive StatsD metrics.
     # Adds the statsd receiver to the metrics pipeline.
     statsdReceiver:
@@ -883,8 +895,6 @@ opentelemetry-ebpf-profiler:
   presets:
     ebpfProfiler:
       enabled: true
-    profilesK8sAttributes:
-      enabled: true
     fleetManagement:
       enabled: true
       agentType: "ebpf-profiler"
@@ -894,7 +904,11 @@ opentelemetry-ebpf-profiler:
       clusterName: "{{.Values.global.clusterName}}"
       integrationName: "coralogix-integration-helm"
     otlpExporter:
-      enabled: false
+      enabled: true
+      endpoint: ${env:K8S_NODE_IP}:4317
+      pipelines: ["profiles"]
+      tls:
+        insecure: true
     otlpReceiver:
       enabled: false
     collectorMetrics:
@@ -909,12 +923,6 @@ opentelemetry-ebpf-profiler:
           cx.agent.type: "ebpf-profiler"
         logs:
           level: "{{ .Values.global.logLevel }}"
-      pipelines:
-        profiles:
-          exporters:
-            - debug
-          processors:
-            - memory_limiter
 
 opentelemetry-ebpf-instrumentation:
   enabled: false


### PR DESCRIPTION
## Summary
- bump otel-integration to 0.0.305 and opentelemetry-collector dependencies to 0.131.1
- enable agent `profilesCollection` so forwarded profiler profiles are enriched and exported by the node-local agent
- configure the eBPF profiler collector to export profiles to the node-local agent with `otlpExporter`
- update the eBPF profiler documentation and changelog to match the final collector chart behavior
