### PR TITLE
Set eBPF profiler fullname and disable profiler resource detection

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - [Chore] Bump chart dependency to opentelemetry-collector 0.131.1
 - [Breaking] eBPF profiler profiles are now sent through the node-local agent `profilesCollection` pipeline for Kubernetes enrichment and Coralogix export. Previously, the profiler sent profiles directly to Coralogix, so installations that customize the profiler or agent profile pipeline should update their configuration to route profiles through the agent.
+- [Fix] Keep the eBPF profiler resource detection preset disabled; forwarded profiles are enriched by the node-local agent instead.
 
 #### Changes from opentelemetry-collector 0.131.1:
 - [Feat] Support forwarding eBPF profiler profiles to the node-local agent with the `otlpExporter` preset.

--- a/otel-integration/k8s-helm/README.md
+++ b/otel-integration/k8s-helm/README.md
@@ -1440,7 +1440,7 @@ opentelemetry-ebpf-profiler:
 
   presets:
     resourceDetection:
-      enabled: true
+      enabled: false
     ebpfProfiler:
       enabled: true
     otlpExporter:

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -874,6 +874,7 @@ coralogix-ebpf-profiler:
 opentelemetry-ebpf-profiler:
   enabled: false
   mode: daemonset
+  fullnameOverride: coralogix-opentelemetry-ebpf-profiler
   extraEnvs:
     - name: CORALOGIX_PRIVATE_KEY
       valueFrom:
@@ -893,6 +894,8 @@ opentelemetry-ebpf-profiler:
       enabled: true
 
   presets:
+    resourceDetection:
+      enabled: false
     ebpfProfiler:
       enabled: true
     fleetManagement:


### PR DESCRIPTION
## Summary
- Set the OpenTelemetry eBPF profiler subchart fullnameOverride to use the Coralogix-prefixed resource name
- Align profiler resource naming with the existing agent and cluster collector defaults

## Validation
- Rendered the chart with opentelemetry-ebpf-profiler.enabled=true and confirmed the DaemonSet name is coralogix-opentelemetry-ebpf-profiler-agent