### PR TITLE
docs: add dispatch trigger for otel-ecs-fargate and otel-eks-fargate README sync

### DIFF
--- a/.github/workflows/sync-fargate-docs.yml
+++ b/.github/workflows/sync-fargate-docs.yml
@@ -18,7 +18,11 @@ jobs:
     steps:
       - name: trigger ci action in documentation repo
         run: |
-          curl -X POST -H "Authorization: token ${{ secrets.GH_TOKEN }}" \
+          # --fail-with-body: curl exits non-zero on HTTP 4xx/5xx (e.g. expired
+          # GH_TOKEN, missing repo permissions) instead of silently treating
+          # the dispatch as successful and leaving the docs deploy unfired.
+          curl --fail-with-body -X POST \
+               -H "Authorization: token ${{ secrets.GH_TOKEN }}" \
                -H "Accept: application/vnd.github.v3+json" \
                https://api.github.com/repos/coralogix/documentation/dispatches \
                -d '{

--- a/.github/workflows/sync-fargate-docs.yml
+++ b/.github/workflows/sync-fargate-docs.yml
@@ -1,0 +1,26 @@
+name: Trigger Fargate Documentation Sync
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+    paths:
+      - 'otel-ecs-fargate/README.md'
+      - 'otel-eks-fargate/README.md'
+
+permissions:
+  contents: read
+
+jobs:
+  trigger_action:
+    runs-on: ubuntu-latest
+    steps:
+      - name: trigger ci action in documentation repo
+        run: |
+          curl -X POST -H "Authorization: token ${{ secrets.GH_TOKEN }}" \
+               -H "Accept: application/vnd.github.v3+json" \
+               https://api.github.com/repos/coralogix/documentation/dispatches \
+               -d '{
+                     "event_type": "trigger-deploy"
+                   }'


### PR DESCRIPTION
## Summary

- Adds new `sync-fargate-docs.yml` workflow that triggers a Coralogix docs redeploy when `otel-ecs-fargate/README.md` or `otel-eks-fargate/README.md` change on master
- These READMEs are now synced into the Coralogix docs repo as hybrid-sync external pages

## Why

The Coralogix documentation pages for OTel ECS Fargate and EKS Fargate link to these upstream READMEs as external synced content. Without this trigger, README updates would not propagate to the docs site automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)