### PR TITLE
Bump Windows collector and target allocator images

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## OpenTelemetry-Integration
 
+### v0.0.306 / 2026-05-11
+
+- [Chore] Update Windows collector image to v0.151.0.
+- [Chore] Update target allocator image to v0.150.0.
+
 ### v0.0.305 / 2026-05-04
 
 - [Chore] Bump chart dependency to opentelemetry-collector 0.131.1

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.305
+version: 0.0.306
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/e2e-test/target_allocator_servicemonitor_test.go
+++ b/otel-integration/k8s-helm/e2e-test/target_allocator_servicemonitor_test.go
@@ -57,8 +57,7 @@ func TestE2E_TargetAllocator_ServiceMonitorMetrics(t *testing.T) {
 	})
 	defer shutdownSink()
 
-	waitForMetrics(t, 5, metricsConsumer)
-	require.NoError(t, checkTargetAllocatorServiceMonitorMetrics(metricsConsumer.AllMetrics()))
+	waitForTargetAllocatorServiceMonitorMetrics(t, metricsConsumer)
 }
 
 func waitForKubeletServiceMonitor(t *testing.T, k8sClient *xk8stest.K8sClient) {
@@ -84,6 +83,25 @@ func waitForKubeletServiceMonitor(t *testing.T, k8sClient *xk8stest.K8sClient) {
 		}
 		return false
 	}, 3*time.Minute, 2*time.Second, "kubelet ServiceMonitor was not found")
+}
+
+func waitForTargetAllocatorServiceMonitorMetrics(t *testing.T, metricsConsumer *consumertest.MetricsSink) {
+	t.Helper()
+
+	var lastErr error
+	var lastBatchCount int
+	deadline := time.Now().Add(3 * time.Minute)
+	for time.Now().Before(deadline) {
+		actual := metricsConsumer.AllMetrics()
+		lastBatchCount = len(actual)
+		lastErr = checkTargetAllocatorServiceMonitorMetrics(actual)
+		if lastErr == nil {
+			return
+		}
+		time.Sleep(2 * time.Second)
+	}
+
+	require.NoErrorf(t, lastErr, "failed to observe ServiceMonitor-derived kubelet metrics; got %d metric batches", lastBatchCount)
 }
 
 func checkTargetAllocatorServiceMonitorMetrics(actual []pmetric.Metrics) error {

--- a/otel-integration/k8s-helm/e2e-test/testdata/values-e2e-target-allocator-servicemonitor.yaml
+++ b/otel-integration/k8s-helm/e2e-test/testdata/values-e2e-target-allocator-servicemonitor.yaml
@@ -37,7 +37,7 @@ opentelemetry-agent:
     allocationStrategy: "per-node"
     prometheusCR:
       enabled: true
-      scrapeInterval: 30s
+      scrapeInterval: 10s
 
   config:
     exporters:

--- a/otel-integration/k8s-helm/values-windows-tailsampling.yaml
+++ b/otel-integration/k8s-helm/values-windows-tailsampling.yaml
@@ -23,7 +23,7 @@ opentelemetry-agent-windows:
     repository: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "0.147.0-windows-2019-amd64"
+    tag: "0.151.0-windows-2019-amd64"
     # When digest is set to a non-empty value, images will be pulled by digest (regardless of tag value).
     digest: ""
   extraVolumes:

--- a/otel-integration/k8s-helm/values-windows.yaml
+++ b/otel-integration/k8s-helm/values-windows.yaml
@@ -23,7 +23,7 @@ opentelemetry-agent-windows:
     repository: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "0.147.0-windows-2019-amd64"
+    tag: "0.151.0-windows-2019-amd64"
     # When digest is set to a non-empty value, images will be pulled by digest (regardless of tag value).
     digest: ""
 

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -80,7 +80,7 @@ opentelemetry-agent:
       scrapeInterval: 30s
     image:
       repository: ghcr.io/open-telemetry/opentelemetry-operator/target-allocator
-      tag: v0.146.0
+      tag: v0.150.0
 
   # serviceAccount:
   #   # Specifies whether a service account should be created

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "info"
   collectionInterval: "30s"
-  version: "0.0.305"
+  version: "0.0.306"
   deploymentEnvironmentName: ""
 
   extensions:

--- a/otel-integration/testing/windows-eks/README.md
+++ b/otel-integration/testing/windows-eks/README.md
@@ -49,7 +49,7 @@ Defaults used by the Makefile (override as needed):
 - Cluster name: `otel-integration-windows-cluster`
 - Namespace: `coralogix-otel`
 - Helm release: `otel-windows`
-- Windows collector image tag: `0.147.0-windows-2019-amd64`
+- Windows collector image tag: `0.151.0-windows-2019-amd64`
 - Windows log marker: `WINDOWS-OTEL-LOG-CHECK`
 
 ## Plan of Work


### PR DESCRIPTION
## Summary
- Bump otel-integration chart version to 0.0.306.
- Update Windows collector image tag to 0.151.0-windows-2019-amd64.
- Update target allocator image tag to v0.150.0.
- Update Windows EKS test README default image tag.

## Testing
- installed eks cluster with windows and deployed