### PR TITLE
Enable database spans sanitization for span metrics

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemetry-Integration
 
+### v0.0.309 / 2026-05-14
+
+- [Breaking] Enable database sanitization for spans by default when span metrics are generated. See the [About span metrics](https://github.com/coralogix/telemetry-shippers/blob/master/otel-integration/k8s-helm/README.md#about-span-metrics) documentation for details.
+
 ### v0.0.308 / 2026-05-13
 
 - [Chore] Bump chart dependency to opentelemetry-collector 0.131.3

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.309
+version: 0.0.310
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.308
+version: 0.0.309
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/README.md
+++ b/otel-integration/k8s-helm/README.md
@@ -1706,6 +1706,41 @@ This feature is enabled by default and can be disabled by setting the `spanmetri
 
 Beware that enabling the feature will result in creation of additional metrics. Depending on how you instrument your applications, this can result in a significant increase in the number of metrics. This is especially true for cases where the span name includes specific values, such as user IDs or UUIDs. Such instrumentation practice is [strongly discouraged](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#span).
 
+To reduce this risk, the chart also enables **span metrics sanitization** automatically when `spanMetrics` or `spanMetricsMulti` is enabled. This wires the collector redaction processor into trace pipelines before span-to-metric conversion.
+
+Sanitization matters because span metrics use span names and span attributes as metric dimensions. If those fields contain raw IDs, URLs, SQL statements, Redis commands, Mongo queries, or OpenSearch/Elasticsearch request bodies, the span metrics connector can emit a new time series for each unique value. That causes three problems:
+
+- Metric cardinality grows very quickly, which increases cost and memory usage.
+- Aggregated request/error/duration metrics become fragmented across many near-unique series.
+- Database metrics become harder to use because query text or command payloads dominate the dimensions instead of stable operation names.
+
+By default, span metrics sanitization:
+
+- Normalizes URL-like span names and HTTP URL attributes when `sanitize_url: true`.
+- Sanitizes database statements and commands for `sql`, `redis`, `memcached`, `mongo`, `opensearch`, and `es`.
+- Applies database span name sanitization only when the span carries `db.system` or `db.system.name`, so non-database spans are not rewritten accidentally.
+
+If your instrumentation is already stable, or if you need raw values for troubleshooting, you can disable the feature entirely:
+
+```yaml
+opentelemetry-agent:
+  presets:
+    spanMetricsSanitization:
+      enabled: false
+```
+
+You can also disable only part of it:
+
+```yaml
+opentelemetry-agent:
+  presets:
+    spanMetricsSanitization:
+      enabled: true
+      sanitize_url: false
+      sanitizeDatabases: []
+```
+
+
 In such cases, we recommend to either correct your instrumentation or to use the `spanMetrics.spanNameReplacePattern` parameter, to replace the problematic values with a generic placeholder. For example, if your span name corresponds to template `user-1234`, you can use the following pattern to replace the user ID with a generic placeholder. See the following configuration:
 
 ```yaml

--- a/otel-integration/k8s-helm/README.md
+++ b/otel-integration/k8s-helm/README.md
@@ -1740,7 +1740,6 @@ opentelemetry-agent:
       sanitizeDatabases: []
 ```
 
-
 In such cases, we recommend to either correct your instrumentation or to use the `spanMetrics.spanNameReplacePattern` parameter, to replace the problematic values with a generic placeholder. For example, if your span name corresponds to template `user-1234`, you can use the following pattern to replace the user ID with a generic placeholder. See the following configuration:
 
 ```yaml

--- a/otel-integration/k8s-helm/README.md
+++ b/otel-integration/k8s-helm/README.md
@@ -1720,6 +1720,8 @@ By default, span metrics sanitization:
 - Sanitizes database statements and commands for `sql`, `redis`, `memcached`, `mongo`, `opensearch`, and `es`.
 - Applies database span name sanitization only when the span carries `db.system` or `db.system.name`, so non-database spans are not rewritten accidentally.
 
+Under the hood, this uses backend-specific sanitizers rather than a single generic regex. The URL sanitizer detects path-like span names and URL attributes, then replaces variable-looking path segments, IDs, UUIDs, timestamps, and query-string values with stable placeholders while keeping the route shape intact. The database sanitizer uses protocol-specific obfuscators: SQL literals are parameterized, Redis and Memcached command arguments are scrubbed, and MongoDB/OpenSearch/Elasticsearch JSON payload values are redacted while preserving the overall query structure.
+
 If your instrumentation is already stable, or if you need raw values for troubleshooting, you can disable the feature entirely:
 
 ```yaml

--- a/otel-integration/k8s-helm/e2e-test/run-all.sh
+++ b/otel-integration/k8s-helm/e2e-test/run-all.sh
@@ -78,6 +78,7 @@ declare -a TEST_CONFIGS=(
     "TestE2E_TransactionsPreset:./values.yaml ./e2e-test/testdata/values-e2e-test.yaml:component=agent-collector:"
     "TestE2E_DeltaToCumulativePreset:./values.yaml ./e2e-test/testdata/values-e2e-test.yaml:component=agent-collector:"
     "TestE2E_SpanMetricsConnector:./values.yaml ./e2e-test/testdata/values-e2e-span-metrics.yaml:component=agent-collector:"
+    "TestE2E_SpanSanitization:./values.yaml ./e2e-test/testdata/values-e2e-test.yaml:component=agent-collector:"
 )
 
 # Parse command line arguments

--- a/otel-integration/k8s-helm/e2e-test/span_sanitization_test.go
+++ b/otel-integration/k8s-helm/e2e-test/span_sanitization_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/xk8stest"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -77,11 +76,19 @@ func TestE2E_SpanSanitization(t *testing.T) {
 
 	waitForTraces(t, 1, tracesConsumer)
 
-	assertSanitizedTraces(t, tracesConsumer.AllTraces(), expectations)
+	assertSanitizedTraces(t, tracesConsumer, expectations)
 	assertSanitizedSpanMetrics(t, metricsConsumer, expectations)
 }
 
-func assertSanitizedTraces(t *testing.T, batches []ptrace.Traces, expectations []spanSanitizationExpectation) {
+func assertSanitizedTraces(t *testing.T, tracesConsumer *consumertest.TracesSink, expectations []spanSanitizationExpectation) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		return sanitizedTracesPresent(t, tracesConsumer.AllTraces(), expectations)
+	}, 2*time.Minute, 2*time.Second, "sanitized traces not observed in time")
+}
+
+func sanitizedTracesPresent(t *testing.T, batches []ptrace.Traces, expectations []spanSanitizationExpectation) bool {
 	t.Helper()
 
 	serviceSpanNames := map[string]map[string]struct{}{}
@@ -117,11 +124,19 @@ func assertSanitizedTraces(t *testing.T, batches []ptrace.Traces, expectations [
 
 	for _, exp := range expectations {
 		names, ok := serviceSpanNames[exp.serviceName]
-		require.Truef(t, ok, "no spans received for service %s", exp.serviceName)
+		if !ok {
+			t.Logf("trace for service %s not yet observed", exp.serviceName)
+			return false
+		}
 
 		_, hasExpected := names[exp.sanitizedName]
-		assert.Truef(t, hasExpected, "sanitized span name %q not found for service %s (found: %v)", exp.sanitizedName, exp.serviceName, mapKeysFromSet(names))
+		if !hasExpected {
+			t.Logf("sanitized span name %q for service %s not yet observed (found: %v)", exp.sanitizedName, exp.serviceName, mapKeysFromSet(names))
+			return false
+		}
 	}
+
+	return true
 }
 
 func mapKeysFromSet(m map[string]struct{}) []string {

--- a/otel-integration/k8s-helm/e2e-test/span_sanitization_test.go
+++ b/otel-integration/k8s-helm/e2e-test/span_sanitization_test.go
@@ -1,0 +1,507 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/xk8stest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc"
+)
+
+type spanSanitizationExpectation struct {
+	serviceName   string
+	sanitizedName string
+}
+
+func TestE2E_SpanSanitization(t *testing.T) {
+	require.Equal(t, xk8stest.HostEndpoint(t), os.Getenv("HOSTENDPOINT"), "HostEndpoints does not match env and detected")
+
+	kubeconfigPath := testKubeConfig
+	if kubeConfigFromEnv := os.Getenv(kubeConfigEnvVar); kubeConfigFromEnv != "" {
+		kubeconfigPath = kubeConfigFromEnv
+	}
+
+	k8sClient, err := xk8stest.NewK8sClient(kubeconfigPath)
+	require.NoError(t, err)
+	t.Logf("Connected to cluster using kubeconfig %q", kubeconfigPath)
+
+	metricsConsumer := new(consumertest.MetricsSink)
+	tracesConsumer := new(consumertest.TracesSink)
+	shutdownSinks := StartUpSinks(t, ReceiverSinks{
+		Metrics: &MetricSinkConfig{
+			Consumer: metricsConsumer,
+			Ports: &ReceiverPorts{
+				Grpc: 4317,
+			},
+		},
+		Traces: &TraceSinkConfig{
+			Consumer: tracesConsumer,
+			Ports: &ReceiverPorts{
+				Grpc: 4321,
+			},
+		},
+	})
+	defer shutdownSinks()
+
+	testID := uuid.NewString()[:8]
+	spanInputs, expectations := buildSanitizationSpanInputs(testID)
+
+	agentNamespace := agentCollectorNamespace()
+	t.Logf("Using agent collector namespace %q", agentNamespace)
+	waitForAgentCollectorPod(t, k8sClient, agentNamespace)
+	t.Logf("Agent collector pod is running")
+	agentService := agentServiceName()
+	t.Logf("Using agent collector service %q", agentService)
+	otlpPort, stopPF := startPortForward(t, kubeconfigPath, agentNamespace, fmt.Sprintf("svc/%s", agentService), 4317)
+	defer stopPF()
+	t.Logf("Established port-forward to service %s:%d via local port %d", agentService, 4317, otlpPort)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+	require.NoError(t, emitSyntheticSpans(t, ctx, fmt.Sprintf("127.0.0.1:%d", otlpPort), spanInputs))
+
+	waitForTraces(t, 1, tracesConsumer)
+
+	assertSanitizedTraces(t, tracesConsumer.AllTraces(), expectations)
+	assertSanitizedSpanMetrics(t, metricsConsumer, expectations)
+}
+
+func assertSanitizedTraces(t *testing.T, batches []ptrace.Traces, expectations []spanSanitizationExpectation) {
+	t.Helper()
+
+	serviceSpanNames := map[string]map[string]struct{}{}
+
+	for _, batch := range batches {
+		current := ptrace.NewTraces()
+		batch.CopyTo(current)
+
+		for i := 0; i < current.ResourceSpans().Len(); i++ {
+			rs := current.ResourceSpans().At(i)
+			resource := rs.Resource()
+			serviceName, ok := resource.Attributes().Get(serviceNameAttribute)
+			if !ok {
+				continue
+			}
+			if _, exists := serviceSpanNames[serviceName.AsString()]; !exists {
+				serviceSpanNames[serviceName.AsString()] = make(map[string]struct{})
+			}
+
+			for j := 0; j < rs.ScopeSpans().Len(); j++ {
+				scopeSpans := rs.ScopeSpans().At(j)
+				for k := 0; k < scopeSpans.Spans().Len(); k++ {
+					span := scopeSpans.Spans().At(k)
+					name := span.Name()
+					require.NotEqual(t, "...", name, "span name must not be ellipsis")
+					require.NotEqual(t, "*", name, "span name must not be wildcard star")
+
+					serviceSpanNames[serviceName.AsString()][name] = struct{}{}
+				}
+			}
+		}
+	}
+
+	for _, exp := range expectations {
+		names, ok := serviceSpanNames[exp.serviceName]
+		require.Truef(t, ok, "no spans received for service %s", exp.serviceName)
+
+		_, hasExpected := names[exp.sanitizedName]
+		assert.Truef(t, hasExpected, "sanitized span name %q not found for service %s (found: %v)", exp.sanitizedName, exp.serviceName, mapKeysFromSet(names))
+	}
+}
+
+func mapKeysFromSet(m map[string]struct{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+func assertSanitizedSpanMetrics(t *testing.T, metricsConsumer *consumertest.MetricsSink, expectations []spanSanitizationExpectation) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		return sanitizedSpanMetricsPresent(t, metricsConsumer.AllMetrics(), expectations)
+	}, 2*time.Minute, 2*time.Second, "sanitized span metrics not observed in time")
+}
+
+func sanitizedSpanMetricsPresent(t *testing.T, batches []pmetric.Metrics, expectations []spanSanitizationExpectation) bool {
+	t.Helper()
+
+	expectedMap := make(map[string]bool, len(expectations))
+	for _, exp := range expectations {
+		key := fmt.Sprintf("%s|%s", exp.serviceName, exp.sanitizedName)
+		expectedMap[key] = false
+	}
+
+	for _, batch := range batches {
+		current := pmetric.NewMetrics()
+		batch.CopyTo(current)
+
+		for i := 0; i < current.ResourceMetrics().Len(); i++ {
+			rm := current.ResourceMetrics().At(i)
+			for j := 0; j < rm.ScopeMetrics().Len(); j++ {
+				sm := rm.ScopeMetrics().At(j)
+				for k := 0; k < sm.Metrics().Len(); k++ {
+					metric := sm.Metrics().At(k)
+					if metric.Name() != "calls" || metric.Type() != pmetric.MetricTypeSum {
+						continue
+					}
+					sum := metric.Sum()
+					for dpIdx := 0; dpIdx < sum.DataPoints().Len(); dpIdx++ {
+						dp := sum.DataPoints().At(dpIdx)
+						spanName, ok := dp.Attributes().Get("span.name")
+						if !ok {
+							continue
+						}
+						require.NotEqual(t, "...", spanName.AsString(), "spanmetrics span.name must not be ellipsis")
+						require.NotEqual(t, "*", spanName.AsString(), "spanmetrics span.name must not be wildcard star")
+
+						serviceName, ok := dp.Attributes().Get(serviceNameAttribute)
+						if !ok {
+							continue
+						}
+
+						key := fmt.Sprintf("%s|%s", serviceName.AsString(), spanName.AsString())
+						if _, expExists := expectedMap[key]; expExists {
+							expectedMap[key] = true
+						}
+					}
+				}
+			}
+		}
+	}
+
+	for key, found := range expectedMap {
+		if !found {
+			t.Logf("spanmetrics datapoint for %s not yet observed", key)
+			return false
+		}
+	}
+
+	return true
+}
+
+type syntheticSpan struct {
+	serviceName string
+	name        string
+	kind        trace.SpanKind
+	attributes  []attribute.KeyValue
+}
+
+func buildSanitizationSpanInputs(testID string) ([]syntheticSpan, []spanSanitizationExpectation) {
+	service := func(label string) string {
+		return fmt.Sprintf("span-sanitization-%s-%s", label, testID)
+	}
+
+	longURLSpan := "/api/" + strings.Repeat("segment/", 100) + "end"
+
+	cases := []struct {
+		serviceName string
+		name        string
+		kind        trace.SpanKind
+		attrs       []attribute.KeyValue
+		sanitized   string
+	}{
+		{
+			serviceName: service("okey"),
+			name:        "okey-dokey-0",
+			kind:        trace.SpanKindClient,
+			attrs: []attribute.KeyValue{
+				attribute.String("http.method", "GET"),
+				attribute.String("http.request.method", "GET"),
+			},
+			sanitized: "okey-dokey-0",
+		},
+		{
+			serviceName: service("http"),
+			name:        "GET /orders/123456/detail/7890",
+			kind:        trace.SpanKindServer,
+			attrs: []attribute.KeyValue{
+				attribute.String("http.method", "GET"),
+				attribute.String("url.full", "https://shop.example.com/orders/123456/detail/7890?card=4111111111111111"),
+			},
+			sanitized: "GET /orders/*/detail/*",
+		},
+		{
+			serviceName: service("http-path-only"),
+			name:        "/users/123/profile",
+			kind:        trace.SpanKindClient,
+			sanitized:   "/users/*/profile",
+		},
+		{
+			serviceName: service("http-unicode"),
+			name:        "/users/测试/profile",
+			kind:        trace.SpanKindClient,
+			sanitized:   "/users/*/profile",
+		},
+		{
+			serviceName: service("http-special"),
+			name:        "/api/v1/items/@special/data",
+			kind:        trace.SpanKindClient,
+			sanitized:   "/api/v1/items/*/data",
+		},
+		{
+			serviceName: service("http-fragment"),
+			name:        "GET /page/123#section",
+			kind:        trace.SpanKindClient,
+			sanitized:   "GET /page/*",
+		},
+		{
+			serviceName: service("http-long"),
+			name:        longURLSpan,
+			kind:        trace.SpanKindClient,
+			sanitized:   "/api/segment/segment/segment/segment/segment/segment/segment/segment",
+		},
+		{
+			serviceName: service("http-internal"),
+			name:        "/internal/process/123",
+			kind:        trace.SpanKindInternal,
+			sanitized:   "/internal/process/123",
+		},
+		{
+			serviceName: service("sql"),
+			name:        "SELECT balance FROM accounts WHERE account_id = 123456",
+			kind:        trace.SpanKindClient,
+			attrs: []attribute.KeyValue{
+				attribute.String("db.statement", "SELECT balance FROM accounts WHERE account_id = 123456"),
+				attribute.String("db.system", "mysql"),
+				attribute.String("db.system.name", "mysql"),
+			},
+			sanitized: "SELECT balance FROM accounts WHERE account_id = ?",
+		},
+		{
+			serviceName: service("sql-postgresql"),
+			name:        "SELECT * FROM users WHERE id = 42",
+			kind:        trace.SpanKindClient,
+			attrs: []attribute.KeyValue{
+				attribute.String("db.system", "postgresql"),
+			},
+			sanitized: "SELECT * FROM users WHERE id = ?",
+		},
+		{
+			serviceName: service("sql-mariadb"),
+			name:        "UPDATE accounts SET balance = 100 WHERE id = 7",
+			kind:        trace.SpanKindClient,
+			attrs: []attribute.KeyValue{
+				attribute.String("db.system", "mariadb"),
+			},
+			sanitized: "UPDATE accounts SET balance = ? WHERE id = ?",
+		},
+		{
+			serviceName: service("sql-sqlite"),
+			name:        "DELETE FROM sessions WHERE expired < 1234567890",
+			kind:        trace.SpanKindClient,
+			attrs: []attribute.KeyValue{
+				attribute.String("db.system", "sqlite"),
+			},
+			sanitized: "DELETE FROM sessions WHERE expired < ?",
+		},
+		{
+			serviceName: service("redis"),
+			name:        "SET cart:user:12345 top-secret",
+			kind:        trace.SpanKindClient,
+			attrs: []attribute.KeyValue{
+				attribute.String("db.system", "redis"),
+				attribute.String("db.system.name", "redis"),
+			},
+			sanitized: "SET cart:user:12345 ?",
+		},
+		{
+			serviceName: service("memcached"),
+			name:        "set key 0 60 5\r\nsecret\r\n",
+			kind:        trace.SpanKindClient,
+			attrs: []attribute.KeyValue{
+				attribute.String("db.system", "memcached"),
+				attribute.String("db.system.name", "memcached"),
+			},
+			sanitized: "set key 0 60 5",
+		},
+		{
+			serviceName: service("mongo"),
+			name:        `{"find":"users","filter":{"name":"alice"}}`,
+			kind:        trace.SpanKindClient,
+			attrs: []attribute.KeyValue{
+				attribute.String("db.system", "mongodb"),
+				attribute.String("db.system.name", "mongodb"),
+			},
+			sanitized: `{"find":"?","filter":{"name":"?"}}`,
+		},
+		{
+			serviceName: service("opensearch"),
+			name:        `{"query":{"match":{"title":"classified"}}}`,
+			kind:        trace.SpanKindClient,
+			attrs: []attribute.KeyValue{
+				attribute.String("db.system", "opensearch"),
+				attribute.String("db.system.name", "opensearch"),
+			},
+			sanitized: `{"query":{"match":{"title":"?"}}}`,
+		},
+		{
+			serviceName: service("elasticsearch"),
+			name:        `{"query":{"match":{"title":"hidden"}}}`,
+			kind:        trace.SpanKindClient,
+			attrs: []attribute.KeyValue{
+				attribute.String("db.system", "elasticsearch"),
+				attribute.String("db.system.name", "elasticsearch"),
+			},
+			sanitized: `{"query":{"match":{"title":"?"}}}`,
+		},
+		{
+			serviceName: service("url-query"),
+			name:        "GET /reports/7?sql=SELECT+1",
+			kind:        trace.SpanKindServer,
+			attrs: []attribute.KeyValue{
+				attribute.String("http.method", "GET"),
+			},
+			sanitized: "GET /reports/*",
+		},
+		{
+			serviceName: service("sql-newlines"),
+			name:        "SELECT *\nFROM users\nWHERE id = 42",
+			kind:        trace.SpanKindClient,
+			attrs: []attribute.KeyValue{
+				attribute.String("db.system", "mysql"),
+			},
+			sanitized: "SELECT *\nFROM users\nWHERE id = ?",
+		},
+		{
+			serviceName: service("db-system-name-only"),
+			name:        "SELECT count(*) FROM payments WHERE user_id = 42",
+			kind:        trace.SpanKindClient,
+			attrs: []attribute.KeyValue{
+				attribute.String("db.system.name", "postgresql"),
+			},
+			sanitized: "SELECT count(*) FROM payments WHERE user_id = ?",
+		},
+		{
+			serviceName: service("no-db-system"),
+			name:        "SELECT * FROM cache WHERE key = 'user:123'",
+			kind:        trace.SpanKindClient,
+			sanitized:   "SELECT * FROM cache WHERE key = 'user:123'",
+		},
+		{
+			serviceName: service("invalid-json"),
+			name:        `{"find":"users"`,
+			kind:        trace.SpanKindClient,
+			attrs: []attribute.KeyValue{
+				attribute.String("db.system", "mongodb"),
+				attribute.String("db.system.name", "mongodb"),
+			},
+			sanitized: `{"find":"users"`,
+		},
+		{
+			serviceName: service("http-service-identifiers"),
+			name:        "payments-dev-sql-adapter-queue /api/process/123",
+			kind:        trace.SpanKindServer,
+			attrs: []attribute.KeyValue{
+				attribute.String("http.method", "POST"),
+			},
+			sanitized: "payments-dev-sql-adapter-queue /api/process/*",
+		},
+		{
+			serviceName: service("http-no-slash"),
+			name:        "payments-dev-sql-adapter-queue process",
+			kind:        trace.SpanKindServer,
+			attrs: []attribute.KeyValue{
+				attribute.String("http.method", "POST"),
+			},
+			sanitized: "payments-dev-sql-adapter-queue process",
+		},
+		{
+			serviceName: service("json-like"),
+			name:        `{"message":"hello"}`,
+			kind:        trace.SpanKindClient,
+			sanitized:   `{"message":"hello"}`,
+		},
+		{
+			serviceName: service("slash-only"),
+			name:        "/",
+			kind:        trace.SpanKindClient,
+			sanitized:   "/",
+		},
+	}
+
+	spans := make([]syntheticSpan, 0, len(cases))
+	expectations := make([]spanSanitizationExpectation, 0, len(cases))
+	for _, c := range cases {
+		spans = append(spans, syntheticSpan{
+			serviceName: c.serviceName,
+			name:        c.name,
+			kind:        c.kind,
+			attributes:  c.attrs,
+		})
+		expectations = append(expectations, spanSanitizationExpectation{
+			serviceName:   c.serviceName,
+			sanitizedName: c.sanitized,
+		})
+	}
+
+	return spans, expectations
+}
+
+func emitSyntheticSpans(t *testing.T, ctx context.Context, endpoint string, spans []syntheticSpan) error {
+	for _, span := range spans {
+		start := time.Now()
+		if err := emitSingleSpan(ctx, endpoint, span); err != nil {
+			return err
+		}
+		t.Logf("sent synthetic span %q for service %q in %s", span.name, span.serviceName, time.Since(start))
+	}
+	return nil
+}
+
+func emitSingleSpan(parent context.Context, endpoint string, testSpan syntheticSpan) error {
+	ctx, cancel := context.WithTimeout(parent, 30*time.Second)
+	defer cancel()
+
+	exporter, err := otlptracegrpc.New(ctx,
+		otlptracegrpc.WithEndpoint(endpoint),
+		otlptracegrpc.WithInsecure(),
+		otlptracegrpc.WithDialOption(grpc.WithBlock()),
+	)
+	if err != nil {
+		return fmt.Errorf("create exporter: %w", err)
+	}
+
+	res, err := resource.Merge(resource.Default(), resource.NewWithAttributes(
+		"",
+		attribute.String(serviceNameAttribute, testSpan.serviceName),
+	))
+	if err != nil {
+		return fmt.Errorf("build resource: %w", err)
+	}
+
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(exporter),
+		sdktrace.WithResource(res),
+	)
+	tracer := tp.Tracer("span-sanitization-e2e")
+
+	_, span := tracer.Start(ctx, testSpan.name, trace.WithSpanKind(testSpan.kind))
+	span.SetAttributes(testSpan.attributes...)
+	span.End()
+
+	shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancelShutdown()
+
+	if err := tp.Shutdown(shutdownCtx); err != nil {
+		return fmt.Errorf("shutdown tracer provider: %w", err)
+	}
+	return nil
+}

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "info"
   collectionInterval: "30s"
-  version: "0.0.308"
+  version: "0.0.309"
   deploymentEnvironmentName: ""
 
   extensions:

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "info"
   collectionInterval: "30s"
-  version: "0.0.309"
+  version: "0.0.310"
   deploymentEnvironmentName: ""
 
   extensions:

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -233,6 +233,17 @@ opentelemetry-agent:
       #    histogramBuckets: [1s, 2s]
       #  - selector: route() where attributes["service.name"] == "two"
       #    histogramBuckets: [5s, 10s]
+    # Sanitizes high-cardinality span names and selected span attributes before
+    # spans are converted into span metrics.
+    # Default: auto-enabled when spanMetrics or spanMetricsMulti is enabled.
+    # Set enabled=false to disable the feature completely.
+    # Set sanitize_url=false to keep URL-style span names and URL attributes unchanged.
+    # Set sanitizeDatabases=[] to keep database statements/commands unchanged.
+    spanMetricsSanitization:
+      enabled: auto
+      sanitize_url: true
+      sanitizeDatabases:
+        [sql, redis, memcached, mongo, opensearch, es]
     # Removes uids and other uneeded attributes from metric resources.
     # This reduces target_info cardinality.
     # reduceResourceAttributes:


### PR DESCRIPTION
# Description

Enable database span sanitization when span metrics is enabled.

Also, created documentation about sanitization feature.

CX-41252 and CX-41254.

# How Has This Been Tested?
- Manually and E2E tests

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

