### PR TITLE
chore(ecs-ec2): add application_name_attributes for e2e cluster name support

### DIFF
--- a/.github/workflows/sync-ecs-ec2-otel-config.yaml
+++ b/.github/workflows/sync-ecs-ec2-otel-config.yaml
@@ -50,20 +50,18 @@ jobs:
           echo "Generated config:"
           cat examples/otel-config.yaml
 
-      - name: Patch config for e2e compatibility
+      - name: Patch config for e2e testing
         run: |
-          # Replace static application_name with env var for e2e testing
-          # Production deployments can set CX_APPLICATION_NAME env var, otherwise defaults to 'otel'
-          yq -i '.exporters.coralogix.application_name = "${env:CX_APPLICATION_NAME:-otel}"' \
+          # Add aws.ecs.cluster to application_name_attributes for logs support
+          # The ecsattributesprocessor sets aws.ecs.cluster (for logs)
+          # The awsecscontainermetricsd sets aws.ecs.cluster.name (for metrics)
+          # Both are needed for cx_application_name to use cluster name across all pipelines
+          yq -i '.exporters.coralogix.application_name_attributes = ["aws.ecs.cluster.name", "aws.ecs.cluster", "aws.ecs.task.definition.family"]' \
             otel-ecs-ec2/examples/otel-config.yaml
           
-          # Remove application_name_attributes so env var takes effect
-          # (attributes override application_name when present on data)
-          yq -i 'del(.exporters.coralogix.application_name_attributes)' \
-            otel-ecs-ec2/examples/otel-config.yaml
-          
-          echo "✓ Patched application_name to use env var with 'otel' default"
-          echo "✓ Removed application_name_attributes to allow env var control"
+          echo "✓ Patched application_name_attributes to include aws.ecs.cluster"
+          echo "Updated config:"
+          yq '.exporters.coralogix.application_name_attributes' otel-ecs-ec2/examples/otel-config.yaml
 
       - name: Upload config to S3
         run: |

--- a/.github/workflows/sync-ecs-ec2-otel-config.yaml
+++ b/.github/workflows/sync-ecs-ec2-otel-config.yaml
@@ -52,16 +52,19 @@ jobs:
 
       - name: Patch config for e2e testing
         run: |
-          # Add aws.ecs.cluster to application_name_attributes for logs support
+          # Set application_name with env var fallback for non-ECS telemetry (hostmetrics, prometheus, etc.)
+          yq -i '.exporters.coralogix.application_name = "${env:CX_APPLICATION_NAME:-otel}"' \
+            otel-ecs-ec2/examples/otel-config.yaml
+          
+          # Add application_name_attributes for ECS telemetry to use cluster name
           # The ecsattributesprocessor sets aws.ecs.cluster (for logs)
           # The awsecscontainermetricsd sets aws.ecs.cluster.name (for metrics)
-          # Both are needed for cx_application_name to use cluster name across all pipelines
+          # Attributes take precedence when present; otherwise falls back to application_name
           yq -i '.exporters.coralogix.application_name_attributes = ["aws.ecs.cluster.name", "aws.ecs.cluster", "aws.ecs.task.definition.family"]' \
             otel-ecs-ec2/examples/otel-config.yaml
           
-          echo "✓ Patched application_name_attributes to include aws.ecs.cluster"
-          echo "Updated config:"
-          yq '.exporters.coralogix.application_name_attributes' otel-ecs-ec2/examples/otel-config.yaml
+          echo "✓ Patched application_name with env var fallback"
+          echo "✓ Added application_name_attributes for ECS cluster name support"
 
       - name: Upload config to S3
         run: |


### PR DESCRIPTION
## Summary
Fixes e2e tests failing with cx_application_name="otel" instead of cluster name
Sets application_name_attributes to extract cluster name from telemetry data
## Changes
The S3 config sync workflow was deleting application_name_attributes, causing the collector to fall back to "otel". Now it sets:

aws.ecs.cluster.name - metrics (awsecscontainermetricsd)
aws.ecs.cluster - logs (ecsattributesprocessor)
aws.ecs.task.definition.family - fallback
## Test
Manually updated S3 config and ran e2e: 4 passed