### PR TITLE
ci(sync-otel-*): fail loudly on dispatch HTTP errors

### DIFF
--- a/.github/workflows/sync-otel-installer-docs.yml
+++ b/.github/workflows/sync-otel-installer-docs.yml
@@ -19,7 +19,11 @@ jobs:
     steps:
       - name: trigger ci action in documentation repo
         run: |
-          curl -X POST -H "Authorization: token ${{ secrets.GH_TOKEN }}" \
+          # --fail-with-body: curl exits non-zero on HTTP 4xx/5xx (e.g. expired
+          # GH_TOKEN, missing repo permissions) instead of silently treating
+          # the dispatch as successful and leaving the docs deploy unfired.
+          curl --fail-with-body -X POST \
+               -H "Authorization: token ${{ secrets.GH_TOKEN }}" \
                -H "Accept: application/vnd.github.v3+json" \
                https://api.github.com/repos/coralogix/documentation/dispatches \
                -d '{

--- a/.github/workflows/sync-otel-integration-docs.yml
+++ b/.github/workflows/sync-otel-integration-docs.yml
@@ -17,7 +17,11 @@ jobs:
     steps:
       - name: trigger ci action in documentation repo
         run: |
-          curl -X POST -H "Authorization: token ${{ secrets.GH_TOKEN }}" \
+          # --fail-with-body: curl exits non-zero on HTTP 4xx/5xx (e.g. expired
+          # GH_TOKEN, missing repo permissions) instead of silently treating
+          # the dispatch as successful and leaving the docs deploy unfired.
+          curl --fail-with-body -X POST \
+               -H "Authorization: token ${{ secrets.GH_TOKEN }}" \
                -H "Accept: application/vnd.github.v3+json" \
                https://api.github.com/repos/coralogix/documentation/dispatches \
                -d '{


### PR DESCRIPTION
## Problem

Same issue codex flagged on #903, but in the two existing sync workflows that have been on master for a while:

- `sync-otel-integration-docs.yml` — fires on `otel-integration/k8s-helm/README.md` changes
- `sync-otel-installer-docs.yml` — fires on `otel-installer/{standalone,docker,windows}/README.md` changes

Both issue `curl -X POST …` against the docs dispatch API without `--fail`/`--fail-with-body`. A 4xx/5xx response (expired `GH_TOKEN`, missing repo permissions) exits 0, so the workflow goes green while the docs deploy never fires. Silently stale docs.

## Fix

Add `--fail-with-body` to the curl invocation in both files. Bad responses now surface as real CI failures with the API's error body in the log.

No behaviour change on the happy path.

## Related

- [#902](https://github.com/coralogix/telemetry-shippers/pull/902) — adds Chart.yaml version-bump notifier (got the same fix preemptively)
- [#903](https://github.com/coralogix/telemetry-shippers/pull/903) — adds Fargate README dispatch (codex flagged the same bug there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)