### PR TITLE
CX-41495 [otel-integration] Bump collector dependency to 0.132.0

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## OpenTelemetry-Integration
 
+### v0.0.315 / 2026-05-27
+
+- [Chore] Bump chart dependency to opentelemetry-collector 0.132.0
+
+#### Changes from opentelemetry-collector 0.132.0:
+- [Feat] Add first-class managed-K8s DNS metric discovery under `presets.kubernetesApiServerMetrics.dns`, with `auto` selection between `kubedns` on GKE and `coredns` elsewhere so DNS control-plane metrics can be enabled without custom Prometheus jobs.
+
 ### v0.0.314 / 2026-05-21
 
 - [Chore] Bump chart dependency to opentelemetry-collector 0.131.7

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.314
+version: 0.0.315
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -11,38 +11,38 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.131.7"
-    repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
+    version: "0.132.0"
+    repository: file:///tmp/local-collector-repo
     condition: opentelemetry-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-windows
-    version: "0.131.7"
-    repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
+    version: "0.132.0"
+    repository: file:///tmp/local-collector-repo
     condition: opentelemetry-agent-windows.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-cluster-collector
-    version: "0.131.7"
-    repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
+    version: "0.132.0"
+    repository: file:///tmp/local-collector-repo
     condition: opentelemetry-cluster-collector.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-receiver
-    version: "0.131.7"
-    repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
+    version: "0.132.0"
+    repository: file:///tmp/local-collector-repo
     condition: opentelemetry-receiver.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-gateway
-    version: "0.131.7"
-    repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
+    version: "0.132.0"
+    repository: file:///tmp/local-collector-repo
     condition: opentelemetry-gateway.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-eks-fargate
-    version: "0.131.7"
-    repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
+    version: "0.132.0"
+    repository: file:///tmp/local-collector-repo
     condition: opentelemetry-agent-eks-fargate.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-eks-fargate-monitoring
-    version: "0.131.7"
-    repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
+    version: "0.132.0"
+    repository: file:///tmp/local-collector-repo
     condition: opentelemetry-agent-eks-fargate-monitoring.enabled
   - name: coralogix-ebpf-profiler
     alias: coralogix-ebpf-profiler
@@ -51,8 +51,8 @@ dependencies:
     condition: coralogix-ebpf-profiler.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-ebpf-profiler
-    version: "0.131.7"
-    repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
+    version: "0.132.0"
+    repository: file:///tmp/local-collector-repo
     condition: opentelemetry-ebpf-profiler.enabled
   - name: opentelemetry-ebpf-instrumentation
     alias: opentelemetry-ebpf-instrumentation
@@ -62,7 +62,7 @@ dependencies:
   - name: coralogix-operator
     alias: coralogix-operator
     version: "2.1.0"
-    repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
+    repository: file:///tmp/local-collector-repo
     condition: coralogix-operator.enabled
 sources:
   - https://github.com/coralogix/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "info"
   collectionInterval: "30s"
-  version: "0.0.314"
+  version: "0.0.315"
   deploymentEnvironmentName: ""
 
   extensions:


### PR DESCRIPTION
## Summary
- bump `otel-integration` to use `opentelemetry-collector` chart `0.132.0`
- update the chart version, `global.version`, and changelog
- validate that the integration chart still renders the new managed DNS metrics preset wiring

## Ticket
- CX-41495

## Testing
- packaged the local `opentelemetry-collector` chart and vendored it into `otel-integration/k8s-helm/charts`
- `helm template example . --set global.domain=coralogix.com --set global.clusterName=kind --set distribution=gke --set opentelemetry-agent.presets.kubernetesApiServerMetrics.enabled=true --set opentelemetry-agent.presets.kubernetesApiServerMetrics.dns.enabled=true`
- verified the rendered config contains `receiver_creator`, `prometheus/k8s_dns_metrics`, and `filter/k8s_dns_metrics`
