### PR TITLE
CX-41498 [otel-integration] Bump collector dependency to 0.134.0

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 ## OpenTelemetry-Integration
 
-### v0.0.315 / 2026-05-27
+### v0.0.318 / 2026-05-27
 
-- [Chore] Bump chart dependency to opentelemetry-collector 0.131.8
+- [Chore] Bump chart dependency to opentelemetry-collector 0.134.0
 
-#### Changes from opentelemetry-collector 0.131.8:
-- [Fix] Wrap the chart-managed `health_check` extension endpoint in IPv6 bracket notation when `networkMode: ipv6` is used, aligning it with the other IPv6-safe listener endpoints and allowing the collector to start and pass health probes on IPv6-only clusters.
+#### Changes from opentelemetry-collector 0.134.0:
+- [Feat] Extend `presets.kubernetesApiServerMetrics` with first-class managed control-plane metric discovery for kube-controller-manager, kube-scheduler, kube-proxy, and etcd, with per-component toggles and curated default metric sets.
 
 ### v0.0.314 / 2026-05-21
 

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.315
+version: 0.0.318
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -11,37 +11,37 @@ keywords:
 dependencies:
   - name: opentelemetry-collector
     alias: opentelemetry-agent
-    version: "0.131.8"
+    version: "0.134.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-windows
-    version: "0.131.8"
+    version: "0.134.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-windows.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-cluster-collector
-    version: "0.131.8"
+    version: "0.134.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-cluster-collector.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-receiver
-    version: "0.131.8"
+    version: "0.134.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-receiver.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-gateway
-    version: "0.131.8"
+    version: "0.134.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-gateway.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-eks-fargate
-    version: "0.131.8"
+    version: "0.134.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-eks-fargate.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-agent-eks-fargate-monitoring
-    version: "0.131.8"
+    version: "0.134.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-agent-eks-fargate-monitoring.enabled
   - name: coralogix-ebpf-profiler
@@ -51,7 +51,7 @@ dependencies:
     condition: coralogix-ebpf-profiler.enabled
   - name: opentelemetry-collector
     alias: opentelemetry-ebpf-profiler
-    version: "0.131.8"
+    version: "0.134.0"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
     condition: opentelemetry-ebpf-profiler.enabled
   - name: opentelemetry-ebpf-instrumentation

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "info"
   collectionInterval: "30s"
-  version: "0.0.315"
+  version: "0.0.318"
   deploymentEnvironmentName: ""
 
   extensions:


### PR DESCRIPTION
## Summary
- bump `otel-integration` to use `opentelemetry-collector` chart `0.134.0`
- update the chart version, `global.version`, and changelog
- validate that the integration chart still renders the managed control-plane metrics wiring

## Ticket
- CX-41498

## Testing
- packaged the local `opentelemetry-collector` chart and vendored it into `otel-integration/k8s-helm/charts`
- `helm template example . --set global.domain=coralogix.com --set global.clusterName=kind --set opentelemetry-agent.presets.kubernetesApiServerMetrics.enabled=true --set opentelemetry-agent.presets.kubernetesApiServerMetrics.controllerManager.enabled=true --set opentelemetry-agent.presets.kubernetesApiServerMetrics.scheduler.enabled=true --set opentelemetry-agent.presets.kubernetesApiServerMetrics.proxy.enabled=true --set opentelemetry-agent.presets.kubernetesApiServerMetrics.etcd.enabled=true`
- verified the rendered config contains the expected `receiver_creator` jobs for controller-manager, scheduler, kube-proxy, and etcd
