### PR TITLE
fix(otel-integration): default centralized collectors to empty tolerations

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemetry-Integration
 
+### v0.0.316 / 2026-06-04
+
+- [Fix] Default `tolerations` to `[]` for the centralized `cluster-collector`, `gateway`, and `receiver` Deployments so they only schedule on healthy, untainted nodes instead of tolerating all taints via the previous blanket `operator: Exists`. The agent DaemonSet keeps `operator: Exists` for full node-level telemetry coverage.
+
 ### v0.0.315 / 2026-05-27
 
 - [Chore] Bump chart dependency to opentelemetry-collector 0.131.8

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.315
+version: 0.0.316
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "info"
   collectionInterval: "30s"
-  version: "0.0.315"
+  version: "0.0.316"
   deploymentEnvironmentName: ""
 
   extensions:

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -560,8 +560,9 @@ opentelemetry-cluster-collector:
           processors:
             - memory_limiter
           # receivers: []
-  tolerations:
-    - operator: Exists
+  # Centralized collector: schedule only on healthy, untainted nodes.
+  # Override to add tolerations for dedicated node pools if required.
+  tolerations: []
 
   startupProbe:
     failureThreshold: 4
@@ -731,8 +732,9 @@ opentelemetry-gateway:
             - tail_sampling
           # receivers: []
 
-  tolerations:
-    - operator: Exists
+  # Centralized gateway: schedule only on healthy, untainted nodes.
+  # Override to add tolerations for dedicated node pools if required.
+  tolerations: []
   ports:
     otlp-http:
       enabled: false
@@ -851,8 +853,9 @@ opentelemetry-receiver:
             - memory_limiter
           # receivers: []
 
-  tolerations:
-    - operator: Exists
+  # Centralized receiver: schedule only on healthy, untainted nodes.
+  # Override to add tolerations for dedicated node pools if required.
+  tolerations: []
   ports:
     otlp-http:
       enabled: false


### PR DESCRIPTION
## Summary

Fixes the default `tolerations` configuration in the `otel-integration` Helm chart (CDS-3017).

The `cluster-collector`, `gateway`, and `receiver` components shipped a blanket default:

```yaml
tolerations:
  - operator: Exists
```

With `operator: Exists` and no `key`/`effect`, this tolerates **all** taints, so these centralized **Deployments** can be scheduled onto cordoned, draining, or otherwise tainted nodes (e.g. `node.kubernetes.io/unschedulable:NoSchedule`). This causes instability and conflicts with autoscalers / node lifecycle managers (e.g. Karpenter, Cluster Autoscaler) that use taints intentionally to keep workloads off nodes slated for termination.

## Changes

- `values.yaml` — set `tolerations: []` for the three centralized Deployments:
  - `opentelemetry-cluster-collector`
  - `opentelemetry-gateway`
  - `opentelemetry-receiver`
- `Chart.yaml` — bump version `0.0.315` → `0.0.316`.

## Why the agent DaemonSet is intentionally left unchanged

The reporter's recommendation also proposed narrowing the agent DaemonSet, but that is intentionally **not** done here:

1. **DaemonSets already tolerate cordon.** The DaemonSet controller auto-injects tolerations for `unschedulable` (cordon), `not-ready`, `unreachable`, and the pressure taints — so the cordon concern doesn't apply to a DaemonSet; it runs there regardless of this default.
2. **The proposed snippet is technically incorrect.** It pins `effect: NoSchedule` on `not-ready`/`unreachable`, but the node controller applies those taints with `effect: NoExecute`, so the proposed tolerations would not match.
3. **Blanket `Exists` on a node-level agent is intentional.** It ensures telemetry coverage on custom-tainted node pools (GPU, spot, dedicated). Narrowing it would create observability blind spots and would be a breaking change.

## Validation

- `helm template` renders cleanly.
- The cluster-collector Deployment now renders with **no** `tolerations` block (the upstream `{{- with .Values.tolerations }}` guard omits an empty list), so it falls back to normal scheduling.
- The agent DaemonSet still renders `operator: Exists` as expected.

Refs CDS-3017

🤖 Generated with [Claude Code](https://claude.com/claude-code)