### PR TITLE
Implemented linters in CI

### DIFF
--- a/.github/scripts/check-helm-golden-renders.sh
+++ b/.github/scripts/check-helm-golden-renders.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CHART_DIR="${CHART_DIR:-otel-integration/k8s-helm}"
+GOLDEN_DIR="${GOLDEN_DIR:-${CHART_DIR}/tests/golden}"
+RELEASE_NAME="${HELM_GOLDEN_RELEASE_NAME:-render-check}"
+DOMAIN="${HELM_GOLDEN_DOMAIN:-eu2.coralogix.com}"
+CLUSTER_NAME="${HELM_GOLDEN_CLUSTER_NAME:-golden-render}"
+UPDATE_GOLDEN=false
+
+cases=(
+  "tail-sampling:tail-sampling-values.yaml"
+  "windows:values-windows.yaml"
+  "eks-fargate:values-eks-fargate.yaml"
+  "ebpf-profiler:values-ebpf-profiler.yaml"
+)
+
+usage() {
+  cat <<'EOF'
+Usage: .github/scripts/check-helm-golden-renders.sh [--update]
+
+Renders high-risk otel-integration Helm presets and compares them with the
+checked-in golden files.
+
+  --update   Regenerate the checked-in golden files instead of diffing them.
+EOF
+}
+
+while (($#)); do
+  case "$1" in
+    --update)
+      UPDATE_GOLDEN=true
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Missing required command: $cmd" >&2
+    exit 1
+  fi
+}
+
+render_case() {
+  local name="$1"
+  local values_file="$2"
+  local output_file="$3"
+
+  helm template "$RELEASE_NAME" "$CHART_DIR" \
+    -f "${CHART_DIR}/values.yaml" \
+    -f "${CHART_DIR}/${values_file}" \
+    --set-string "global.domain=${DOMAIN}" \
+    --set-string "global.clusterName=${CLUSTER_NAME}" |
+    sed -e 's/[[:blank:]]*$//' \
+    | awk '
+        /^$/ { blanks++; next }
+        /^---$/ { blanks = 0; print; next }
+        {
+          while (blanks > 0) {
+            print "";
+            blanks--;
+          }
+          print;
+        }
+        END {
+          while (blanks > 0) {
+            print "";
+            blanks--;
+          }
+        }
+      ' \
+    > "$output_file"
+}
+
+require_cmd helm
+require_cmd diff
+require_cmd sed
+require_cmd awk
+
+helm repo add --force-update open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts >/dev/null
+helm repo add --force-update coralogix-charts-virtual https://cgx.jfrog.io/artifactory/coralogix-charts-virtual >/dev/null
+helm repo add --force-update coralogix-charts https://cgx.jfrog.io/artifactory/coralogix-charts >/dev/null
+helm repo update >/dev/null
+helm dependency build "$CHART_DIR"
+
+if [ "$UPDATE_GOLDEN" = true ]; then
+  mkdir -p "$GOLDEN_DIR"
+fi
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+failed=0
+for case in "${cases[@]}"; do
+  name="${case%%:*}"
+  values_file="${case#*:}"
+  actual="${tmpdir}/${name}.yaml"
+  expected="${GOLDEN_DIR}/${name}.yaml"
+
+  if [ "$UPDATE_GOLDEN" = true ]; then
+    render_case "$name" "$values_file" "$expected"
+    echo "Rendered ${expected}"
+    continue
+  fi
+
+  if [ ! -f "$expected" ]; then
+    echo "Missing golden render: $expected" >&2
+    failed=1
+    continue
+  fi
+
+  render_case "$name" "$values_file" "$actual"
+
+  if ! diff -u "$expected" "$actual"; then
+    echo "Golden render mismatch for ${name}. Re-render with .github/scripts/check-helm-golden-renders.sh --update after reviewing the manifest change." >&2
+    failed=1
+  fi
+done
+
+exit "$failed"

--- a/.github/workflows/chart-version-bump-check.yml
+++ b/.github/workflows/chart-version-bump-check.yml
@@ -15,6 +15,7 @@ jobs:
     - uses: dorny/paths-filter@v2
       id: filter
       with:
+        predicate-quantifier: every
         filters: | # Determine where the chart change occured and run the appropriate check.
           logs-fluent-bit-coralogix:
             - 'logs/fluent-bit/k8s-helm/coralogix/**'
@@ -30,6 +31,8 @@ jobs:
             - 'otel-infrastructure-collector/k8s-helm/**'
           otel-integration:
             - 'otel-integration/k8s-helm/**'
+            - '!otel-integration/k8s-helm/tests/**'
+            - '!otel-integration/k8s-helm/e2e-test/**'
           metrics-prometheus-agent:
             - 'metrics/prometheus-agent/**'
           metrics-prometheus-operator:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -52,7 +52,7 @@ jobs:
           otel-windows-standalone/CHANGELOG.md
 
   check-changelog-updates:
-    if: github.event.label.name != 'skip changelog'
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip changelog') }}
     runs-on: ubuntu-latest
     name: Check changelog update
     steps:
@@ -62,6 +62,7 @@ jobs:
     - uses: dorny/paths-filter@v2
       id: filter
       with:
+        predicate-quantifier: every
         filters: | # Determine where the change occured and run the appropriate check.
           logs-fluent-bit-coralogix:
             - 'logs/fluent-bit/k8s-helm/coralogix/**'
@@ -79,6 +80,8 @@ jobs:
             - 'otel-infrastructure-collector/k8s-helm/**'
           otel-integration:
             - 'otel-integration/k8s-helm/**'
+            - '!otel-integration/k8s-helm/tests/**'
+            - '!otel-integration/k8s-helm/e2e-test/**'
           metrics-prometheus-agent:
             - 'metrics/prometheus-agent/**'
           metrics-prometheus-operator:

--- a/.github/workflows/otel-infra-helm-test.yml
+++ b/.github/workflows/otel-infra-helm-test.yml
@@ -18,7 +18,6 @@ jobs:
         with:
           create-kind-cluster: "true"
       - name: Setup Secret
-        run: kubectl create secret generic coralogix-keys --from-literal=PRIVATE_KEY=123
+        run: kubectl create secret generic coralogix-keys --from-literal=PRIVATE_KEY=fake
       - name: Run chart-testing (install)
         run: ct lint-and-install --namespace default --charts otel-infrastructure-collector/k8s-helm
-

--- a/.github/workflows/otel-integration-e2e-test.yml
+++ b/.github/workflows/otel-integration-e2e-test.yml
@@ -35,7 +35,7 @@ jobs:
           chmod +x ./get_host_endpoint.sh
           ./get_host_endpoint.sh
       - name: Setup Secret
-        run: kubectl create secret generic coralogix-keys --from-literal=PRIVATE_KEY=123
+        run: kubectl create secret generic coralogix-keys --from-literal=PRIVATE_KEY=fake
       - name: Install chart for testing
         env:
           HOSTENDPOINT: ${{ env.HOSTENDPOINT }}
@@ -125,7 +125,7 @@ jobs:
           chmod +x ./get_host_endpoint.sh
           ./get_host_endpoint.sh
       - name: Setup Secret
-        run: kubectl create secret generic coralogix-keys --from-literal=PRIVATE_KEY=123
+        run: kubectl create secret generic coralogix-keys --from-literal=PRIVATE_KEY=fake
       - name: Install chart for supervisor testing
         env:
           HOSTENDPOINT: ${{ env.HOSTENDPOINT }}
@@ -205,7 +205,7 @@ jobs:
           chmod +x ./get_host_endpoint.sh
           ./get_host_endpoint.sh
       - name: Setup Secret
-        run: kubectl create secret generic coralogix-keys --from-literal=PRIVATE_KEY=123
+        run: kubectl create secret generic coralogix-keys --from-literal=PRIVATE_KEY=fake
       - name: Install chart for tail-sampling test
         env:
           HOSTENDPOINT: ${{ env.HOSTENDPOINT }}
@@ -267,7 +267,7 @@ jobs:
           chmod +x ./get_host_endpoint.sh
           ./get_host_endpoint.sh
       - name: Setup Secret
-        run: kubectl create secret generic coralogix-keys --from-literal=PRIVATE_KEY=123
+        run: kubectl create secret generic coralogix-keys --from-literal=PRIVATE_KEY=fake
       - name: Install chart for span-metrics test
         env:
           HOSTENDPOINT: ${{ env.HOSTENDPOINT }}
@@ -327,7 +327,7 @@ jobs:
           chmod +x ./get_host_endpoint.sh
           ./get_host_endpoint.sh
       - name: Setup Secret
-        run: kubectl create secret generic coralogix-keys --from-literal=PRIVATE_KEY=123
+        run: kubectl create secret generic coralogix-keys --from-literal=PRIVATE_KEY=fake
       - name: Install cert-manager
         run: |
           helm repo add jetstack https://charts.jetstack.io

--- a/.github/workflows/otel-integration-helm-test.yml
+++ b/.github/workflows/otel-integration-helm-test.yml
@@ -18,6 +18,6 @@ jobs:
         with:
           create-kind-cluster: "true"
       - name: Setup Secret
-        run: kubectl create secret generic coralogix-keys --from-literal=PRIVATE_KEY=123
+        run: kubectl create secret generic coralogix-keys --from-literal=PRIVATE_KEY=fake
       - name: Run chart-testing (install)
         run: ct lint-and-install --namespace default --charts otel-integration/k8s-helm

--- a/.github/workflows/security-hygiene.yml
+++ b/.github/workflows/security-hygiene.yml
@@ -1,0 +1,93 @@
+name: Security and Hygiene
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+env:
+  GITLEAKS_VERSION: 8.24.3
+  SHELLCHECK_VERSION: 0.10.0
+  HADOLINT_VERSION: 2.12.0
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    name: gitleaks PR secret scan
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install gitleaks
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/bin"
+          curl -sSfL \
+            -o "${RUNNER_TEMP}/gitleaks.tar.gz" \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          tar -xzf "${RUNNER_TEMP}/gitleaks.tar.gz" -C "${RUNNER_TEMP}/bin" gitleaks
+          echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
+
+      - name: Scan current tree
+        run: gitleaks detect --no-git --source . --redact --verbose
+
+  shellcheck:
+    runs-on: ubuntu-latest
+    name: shellcheck checked-in scripts
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install shellcheck
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/bin"
+          curl -sSfL \
+            -o "${RUNNER_TEMP}/shellcheck.tar.xz" \
+            "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
+          tar -xJf "${RUNNER_TEMP}/shellcheck.tar.xz" \
+            -C "${RUNNER_TEMP}/bin" \
+            --strip-components=1 \
+            "shellcheck-v${SHELLCHECK_VERSION}/shellcheck"
+          echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
+
+      - name: Lint checked-in shell scripts
+        run: |
+          set -euo pipefail
+          mapfile -d '' scripts < <(find . -type f -name '*.sh' -not -path './tmp/*' -print0)
+          shellcheck "${scripts[@]}"
+
+  hadolint:
+    runs-on: ubuntu-latest
+    name: hadolint Dockerfiles
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install hadolint
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/bin"
+          curl -sSfL \
+            -o "${RUNNER_TEMP}/bin/hadolint" \
+            "https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-Linux-x86_64"
+          chmod +x "${RUNNER_TEMP}/bin/hadolint"
+          echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
+
+      - name: Lint Dockerfiles
+        run: |
+          set -euo pipefail
+          mapfile -d '' dockerfiles < <(find . -type f \( -name 'Dockerfile' -o -name 'Dockerfile.*' \) -print0)
+          hadolint "${dockerfiles[@]}"
+
+  helm-golden-render:
+    runs-on: ubuntu-latest
+    name: Helm golden renders
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.12.1
+
+      - name: Check high-risk preset renders
+        run: .github/scripts/check-helm-golden-renders.sh

--- a/logs/fluent-bit/image/Dockerfile
+++ b/logs/fluent-bit/image/Dockerfile
@@ -1,6 +1,10 @@
 FROM fluent/fluent-bit:3.2.10
 ARG TARGETARCH
+# DL3048: Invalid label key.
+# hadolint ignore=DL3048
 LABEL Maintainer="Coralogix Inc. <info@coralogix.com>"
+# DL3048: Invalid label key.
+# hadolint ignore=DL3048
 LABEL Description="Special Fluent-Bit image for Coralogix integration" Vendor="Coralogix Inc." Version="3.2.10"
 COPY ./functions.lua /fluent-bit/etc/
 CMD ["/fluent-bit/bin/fluent-bit", "-c", "/fluent-bit/etc/fluent-bit.yaml"]

--- a/logs/fluentd/aws-ecs/image/Dockerfile
+++ b/logs/fluentd/aws-ecs/image/Dockerfile
@@ -1,8 +1,15 @@
 FROM coralogixrepo/coralogix-fluentd-multiarch:v1.18.0-4
+# DL3002: Last USER should not be root.
+# hadolint ignore=DL3002
 USER root
-RUN gem install fluent-plugin-docker_metadata_filter
-RUN gem install fluent-plugin-script
-RUN apt update && apt install -y curl
+# DL3028: Pin versions in gem install.
+# DL3009: Delete apt lists after installing packages.
+# DL3015: Use --no-install-recommends.
+# hadolint ignore=DL3028,DL3009,DL3015
+RUN gem install fluent-plugin-docker_metadata_filter \
+    && gem install fluent-plugin-script \
+    && apt-get update \
+    && apt-get install -y curl=7.88.1-10+deb12u14
 COPY fargate.rb /fluentd/etc/
 COPY fluent.conf /fluentd/etc/
 COPY firelens.conf /fluentd/etc/

--- a/logs/fluentd/image/Dockerfile
+++ b/logs/fluentd/image/Dockerfile
@@ -1,26 +1,31 @@
             ARG IMAGE_VERSION=v1.18.0-debian-forward-1.4
+            # DL3006: Always tag the version of an image explicitly.
+            # hadolint ignore=DL3006
             FROM fluent/fluentd-kubernetes-daemonset:${IMAGE_VERSION}
 
 # Image description labels
+# DL3048: Invalid label key.
+# hadolint ignore=DL3048
 LABEL Description="Multi-Arch FluentD image for Coralogix integration" \
       Vendor="Coralogix Inc." \
       Version="1.18.0-4" \
       Maintainer="Coralogix Inc. <info@coralogix.com>"
 
 # Change user
+# DL3002: Last USER should not be root.
+# hadolint ignore=DL3002
 USER root
 
 # Installing dependencies and plugins
-RUN gem install elasticsearch -v 8.11
-
-RUN gem install fluent-plugin-coralogix \
-      fluent-plugin-parser-cri \
-      fluent-plugin-sampling-filter \
-      fluent-plugin-concat \
-      fluent-plugin-rewrite-tag-filter \
-      fluent-plugin-detect-exceptions \
-      fluent-plugin-elasticsearch
-
-
-RUN gem install fluent-plugin-kubernetes_metadata_filter -v 3.4.0
-RUN gem install fluent-plugin-prometheus -v 2.1.0
+# DL3028: Pin versions in gem install.
+# hadolint ignore=DL3028
+RUN gem install elasticsearch -v 8.11 \
+      && gem install fluent-plugin-coralogix \
+        fluent-plugin-parser-cri \
+        fluent-plugin-sampling-filter \
+        fluent-plugin-concat \
+        fluent-plugin-rewrite-tag-filter \
+        fluent-plugin-detect-exceptions \
+        fluent-plugin-elasticsearch \
+      && gem install fluent-plugin-kubernetes_metadata_filter -v 3.4.0 \
+      && gem install fluent-plugin-prometheus -v 2.1.0

--- a/logs/fluentd/standalone-image/Dockerfile
+++ b/logs/fluentd/standalone-image/Dockerfile
@@ -1,16 +1,24 @@
 ARG IMAGE_VERSION=v1.14.0-debian-1.0
+# DL3006: Always tag the version of an image explicitly.
+# hadolint ignore=DL3006
 FROM fluent/fluentd:${IMAGE_VERSION}
 
 # Image description labels
+# DL3048: Invalid label key.
+# hadolint ignore=DL3048
 LABEL Description="Multi-Arch FluentD image for Standalone Coralogix integration" \
       Vendor="Coralogix Inc." \
       Version="1.0.0" \
       Maintainer="Coralogix Inc. <info@coralogix.com>"
 
 # Change user
+# DL3002: Last USER should not be root.
+# hadolint ignore=DL3002
 USER root
 
 # Installing dependencies and plugins
+# DL3028: Pin versions in gem install.
+# hadolint ignore=DL3028
 RUN gem install fluent-plugin-coralogix \
       fluent-plugin-prometheus \
       fluent-plugin-parser-cri \
@@ -19,4 +27,3 @@ RUN gem install fluent-plugin-coralogix \
       fluent-plugin-rewrite-tag-filter \
       fluent-plugin-detect-exceptions \
       fluent-plugin-redis-store
-

--- a/logs/logstash/image/Dockerfile
+++ b/logs/logstash/image/Dockerfile
@@ -3,14 +3,17 @@ FROM logstash:7.17.2
 USER root
 
 
-
-RUN apt update && apt install -y python ruby
-
-RUN chown logstash:root /usr/share/logstash/config/logstash.yml
+# DL3008: Pin apt packages.
+# DL3009: Delete apt lists after installing packages.
+# DL3015: Use --no-install-recommends.
+# hadolint ignore=DL3008,DL3009,DL3015
+RUN apt-get update \
+    && apt-get install -y python ruby \
+    && chown logstash:root /usr/share/logstash/config/logstash.yml
 
 USER logstash
-RUN logstash-plugin install logstash-output-coralogix
-RUN logstash-plugin install logstash-filter-json_encode
+RUN logstash-plugin install logstash-output-coralogix \
+    && logstash-plugin install logstash-filter-json_encode
 
 EXPOSE 5044 9600
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint"]

--- a/metrics/prometheus/aws-ecs/image/Dockerfile
+++ b/metrics/prometheus/aws-ecs/image/Dockerfile
@@ -1,6 +1,8 @@
 FROM prom/prometheus:v2.37.1
-ADD prometheus.yml /etc/prometheus/
+COPY prometheus.yml /etc/prometheus/
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+# DL3002: Last USER should not be root.
+# hadolint ignore=DL3002
 USER root
 RUN chmod +x /usr/local/bin/entrypoint.sh
 

--- a/metrics/prometheus/aws-ecs/image/entrypoint.sh
+++ b/metrics/prometheus/aws-ecs/image/entrypoint.sh
@@ -1,45 +1,46 @@
 #!/bin/sh
+# shellcheck disable=SC2117,SC2068
 set -xv
 
 # check for SCRAPE_CONFIG env variable, if not, configure default values
 # else use the value of SCRAPE_CONFIG as the prometheus yaml config.
-if [[ -z "${SCRAPE_CONFIG}" ]]; then
+if [ -z "${SCRAPE_CONFIG}" ]; then
   # Get docker host 
-  DOCKERHOST=`cat /hostetc/hostname`
+  DOCKERHOST=$(cat /hostetc/hostname)
 
   # Get Cluster name from the ecs-agent
-  CLUSTERNAME=`wget -qO- http://172.17.0.1:51678/v1/metadata | sed -e 's/[{}]/''/g' | awk -F , '{split($1,a,"\"");print a[4]}'`
+  CLUSTERNAME=$(wget -qO- http://172.17.0.1:51678/v1/metadata | sed -e 's/[{}]/''/g' | awk -F , '{split($1,a,"\"");print a[4]}')
 
   # Get host public ip
-  HOSTPUBLICIP=`wget -qO- http://checkip.amazonaws.com`
+  HOSTPUBLICIP=$(wget -qO- http://checkip.amazonaws.com)
 
   # Variables check
-  if [[ -z $CORALOGIX_PRIVATEKEY ]]; then
+  if [ -z "$CORALOGIX_PRIVATEKEY" ]; then
     echo "CORALOGIX_PRIVATEKEY environment variable must be set"
     exit 1
   fi
 
-  if [[ -z $CORALOGIX_ENDPOINT ]]; then
+  if [ -z "$CORALOGIX_ENDPOINT" ]; then
     echo "CORALOGIX_ENDPOINT environment variable must be set"
     exit 1
   fi
 
-  if [[ -z $SCRAPE_INTERVAL ]]; then
+  if [ -z "$SCRAPE_INTERVAL" ]; then
     echo "SCRAPE_INTERVAL environment variable must be set"
     exit 1
   fi
 
-  if [[ -z $DOCKERHOST ]]; then
+  if [ -z "$DOCKERHOST" ]; then
     echo "error while retrieving instance hostname, verify that /etc/hostname is mounted"
     exit 1
   fi
 
-  if [[ -z $CLUSTERNAME ]]; then
+  if [ -z "$CLUSTERNAME" ]; then
     echo "error while retrieving clustername from ecs-agent"
     exit 1
   fi
 
-  if [[ -z $HOSTPUBLICIP ]]; then
+  if [ -z "$HOSTPUBLICIP" ]; then
     echo "error while retrieving host public ip, verify that host has outgoing ports (80,443) open"
     exit 1
   fi

--- a/otel-collector-windows-image/Dockerfile
+++ b/otel-collector-windows-image/Dockerfile
@@ -2,17 +2,25 @@
 # For Windows 2022, use `mcr.microsoft.com/windows/servercore:ltsc2022`
 ARG WIN_BASE_IMAGE=mcr.microsoft.com/windows/servercore:ltsc2019
 
+# DL3006: Always tag the version of an image explicitly.
+# DL3029: Do not use --platform= with FROM.
+# hadolint ignore=DL3006,DL3029
 FROM --platform=$BUILDPLATFORM curlimages/curl AS build
 WORKDIR /src
-RUN curl -Lo otelcol.tar.gz https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.121.0/otelcol-contrib_0.121.0_windows_amd64.tar.gz
-RUN tar -xzvf otelcol.tar.gz
+RUN curl -Lo otelcol.tar.gz https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.121.0/otelcol-contrib_0.121.0_windows_amd64.tar.gz && tar -xzvf otelcol.tar.gz
 
 ##
+# DL3006: Always tag the version of an image explicitly.
+# hadolint ignore=DL3006
 FROM ${WIN_BASE_IMAGE}
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
+# DL3045: COPY to a relative destination without WORKDIR.
+# hadolint ignore=DL3045
 COPY --from=build /src/otelcol-contrib.exe ./
+# DL3045: COPY to a relative destination without WORKDIR.
+# hadolint ignore=DL3045
 COPY configs/otelcol-contrib.yaml config.yaml
 
 ENV NO_WINDOWS_SERVICE=1

--- a/otel-ecs-supervisor/terraform.tfvars.example
+++ b/otel-ecs-supervisor/terraform.tfvars.example
@@ -13,12 +13,12 @@ ecs_capacity_count = 1
 
 # Coralogix configuration
 coralogix_domain                      = "eu2.coralogix.com"
-coralogix_private_key   = "cxtp_8DgfhFf49DQHgXPvrVmVCaLqjvwl0A"
+coralogix_private_key   = "replace-with-coralogix-private-key"
 application_name                      = "my-app"
 subsystem_name                        = "ecs"
 
 # Optional: Use Secrets Manager instead of SSM
-# coralogix_private_key_secret_arn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:coralogix-key-abc123"
+# coralogix_private_key_secret_arn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:example-key"
 
 # Resource configuration
 name_prefix    = "coralogix"

--- a/otel-installer/docker/docker-install.sh
+++ b/otel-installer/docker/docker-install.sh
@@ -88,7 +88,7 @@ get_version() {
 }
 
 fetch_supervisor_image_version() {
-    local script_dir version_file version version_url
+    local script_dir version_file version
 
     script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     version_file="${script_dir}/../../otel-supervised-collector/CURRENT_IMAGE_VERSION"
@@ -142,7 +142,7 @@ Options:
     -c, --config <path>         Path to custom configuration file
     -s, --supervisor            Use supervisor mode (requires CORALOGIX_DOMAIN)
     --memory-limit <MiB>        Total memory in MiB to allocate to the collector (default: 512)
-                                Config must reference: ${env:OTEL_MEMORY_LIMIT_MIB}
+                                Config must reference: \${env:OTEL_MEMORY_LIMIT_MIB}
                                 (ignored in supervisor mode)
     --supervisor-base-config <path>  Path to base collector config for supervisor mode
                                       Merged with remote config from Fleet Manager
@@ -627,4 +627,3 @@ Remove the 'opamp' extension from your config file: $SUPERVISOR_BASE_CONFIG_PATH
 }
 
 main "$@"
-

--- a/otel-installer/standalone/coralogix-otel-collector.sh
+++ b/otel-installer/standalone/coralogix-otel-collector.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2034,SC1091,SC2015,SC2317,SC2064
 #
 # Coralogix OpenTelemetry Collector Installer
 # Supports Linux and macOS

--- a/otel-integration/k8s-helm/e2e-test/run-all.sh
+++ b/otel-integration/k8s-helm/e2e-test/run-all.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2094,SC2012,SC2086,SC2046
 
 set -e
 
@@ -295,7 +296,7 @@ setup_helm_repos() {
 # Create secret
 create_secret() {
     log_info "Creating secret..."
-    kubectl create secret generic coralogix-keys --from-literal=PRIVATE_KEY=123 --dry-run=client -o yaml | kubectl apply -f -
+    kubectl create secret generic coralogix-keys --from-literal=PRIVATE_KEY=fake --dry-run=client -o yaml | kubectl apply -f -
     log_success "Secret created/updated"
 }
 
@@ -314,7 +315,8 @@ uninstall_chart() {
         sleep 5
 
         # Verify pods are gone
-        local remaining_pods=$(kubectl get pods -l "app.kubernetes.io/instance=${HELM_RELEASE_NAME}" --no-headers 2>/dev/null | wc -l | tr -d ' ')
+        local remaining_pods
+        remaining_pods=$(kubectl get pods -l "app.kubernetes.io/instance=${HELM_RELEASE_NAME}" --no-headers 2>/dev/null | wc -l | tr -d ' ')
         if [ "$remaining_pods" -gt 0 ]; then
             log_warning "Still ${remaining_pods} pod(s) remaining after uninstall, waiting additional 10 seconds..."
             sleep 10
@@ -460,7 +462,8 @@ build_helm_dependencies() {
     fi
 
     # Check for opentelemetry-collector charts (required dependencies)
-    local collector_charts=$(ls charts/opentelemetry-collector-*.tgz 2>/dev/null | wc -l | tr -d ' ')
+    local collector_charts
+    collector_charts=$(ls charts/opentelemetry-collector-*.tgz 2>/dev/null | wc -l | tr -d ' ')
     if [ "$collector_charts" -eq 0 ]; then
         log_error "No opentelemetry-collector charts found in charts/ directory"
         log_error "This may indicate that local file paths in Chart.yaml are not resolving correctly"
@@ -610,16 +613,18 @@ run_test() {
 
     # Run the test
     log_info "Executing: go test -v -run='${test_regex}' ${test_package}"
-    local test_start_time=$(date +%s)
+    local test_start_time
+    test_start_time=$(date +%s)
 
     # Run test and capture exit code properly (tee doesn't preserve exit codes)
-    go test -v -run="${test_regex}" ${test_package} 2>&1 | tee /tmp/test-${test_name}-output.log
+    go test -v -run="${test_regex}" ${test_package} 2>&1 | tee "/tmp/test-${test_name}-output.log"
     local test_exit_code=${PIPESTATUS[0]}
 
-    local test_end_time=$(date +%s)
+    local test_end_time
+    test_end_time=$(date +%s)
     local test_duration=$((test_end_time - test_start_time))
 
-    if [ $test_exit_code -eq 0 ]; then
+    if [ "$test_exit_code" -eq 0 ]; then
         log_success "✓ Test ${test_name} PASSED (duration: ${test_duration}s)"
         TEST_RESULTS+=("PASS")
         ((++PASSED_TESTS))
@@ -633,7 +638,7 @@ run_test() {
         # Show test output
         log_error "Test output saved to: /tmp/test-${test_name}-output.log"
         log_error "Last 50 lines of test output:"
-        tail -50 /tmp/test-${test_name}-output.log || true
+        tail -50 "/tmp/test-${test_name}-output.log" || true
 
         # Collect pod logs on failure
         log_warning "Collecting pod logs..."

--- a/otel-integration/k8s-helm/tests/golden/ebpf-profiler.yaml
+++ b/otel-integration/k8s-helm/tests/golden/ebpf-profiler.yaml
@@ -1,0 +1,2277 @@
+---
+# Source: otel-integration/charts/coralogix-ebpf-profiler/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: coralogix-ebpf-profiler
+  namespace: default
+  labels:
+    app: coralogix-ebpf-profiler
+---
+# Source: otel-integration/charts/opentelemetry-agent/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: coralogix-opentelemetry
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-agent-0.132.0
+    app.kubernetes.io/name: opentelemetry-agent
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: otel-integration/charts/opentelemetry-cluster-collector/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: coralogix-opentelemetry-collector
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-cluster-collector-0.132.0
+    app.kubernetes.io/name: opentelemetry-cluster-collector
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: otel-integration/charts/opentelemetry-agent/templates/configmap-agent.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coralogix-opentelemetry-agent
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-agent-0.132.0
+    app.kubernetes.io/name: opentelemetry-agent
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+data:
+  relay: |
+    connectors:
+      forward/compact: {}
+      forward/db: {}
+      forward/db_compact: {}
+      spanmetrics:
+        add_resource_attributes: true
+        aggregation_cardinality_limit: 100000
+        dimensions:
+        - name: http.method
+        - name: cgx.transaction
+        - name: cgx.transaction.root
+        - name: status_code
+        - name: db.namespace
+        - name: db.operation.name
+        - name: db.collection.name
+        - name: db.system
+        - name: http.response.status_code
+        - name: rpc.grpc.status_code
+        - name: service.version
+        exclude_dimensions:
+        - collector.instance.id
+        histogram:
+          explicit:
+            buckets:
+            - 1ms
+            - 4ms
+            - 10ms
+            - 20ms
+            - 50ms
+            - 100ms
+            - 200ms
+            - 500ms
+            - 1s
+            - 2s
+            - 5s
+          unit: ms
+        metrics_expiration: 5m
+        metrics_flush_interval: '30s'
+        namespace: ""
+      spanmetrics/compact:
+        add_resource_attributes: true
+        aggregation_cardinality_limit: 100000
+        exclude_dimensions:
+        - collector.instance.id
+        - span.name
+        histogram:
+          explicit:
+            buckets:
+            - 1ms
+            - 4ms
+            - 10ms
+            - 20ms
+            - 50ms
+            - 100ms
+            - 200ms
+            - 500ms
+            - 1s
+            - 2s
+            - 5s
+          unit: ms
+        metrics_expiration: 5m
+        metrics_flush_interval: '30s'
+        namespace: compact
+      spanmetrics/db:
+        add_resource_attributes: true
+        aggregation_cardinality_limit: 100000
+        dimensions:
+        - name: db.namespace
+        - name: db.operation.name
+        - name: db.collection.name
+        - name: db.system
+        - name: service.version
+        exclude_dimensions:
+        - collector.instance.id
+        histogram:
+          explicit:
+            buckets:
+            - 1ms
+            - 4ms
+            - 10ms
+            - 20ms
+            - 50ms
+            - 100ms
+            - 200ms
+            - 500ms
+            - 1s
+            - 2s
+            - 5s
+          unit: ms
+        metrics_expiration: 5m
+        metrics_flush_interval: '30s'
+        namespace: db
+      spanmetrics/db_compact:
+        add_resource_attributes: true
+        aggregation_cardinality_limit: 100000
+        dimensions:
+        - name: db.namespace
+        - name: db.system
+        exclude_dimensions:
+        - collector.instance.id
+        - span.name
+        - span.kind
+        histogram:
+          explicit:
+            buckets:
+            - 1ms
+            - 4ms
+            - 10ms
+            - 20ms
+            - 50ms
+            - 100ms
+            - 200ms
+            - 500ms
+            - 1s
+            - 2s
+            - 5s
+          unit: ms
+        metrics_expiration: 5m
+        metrics_flush_interval: '30s'
+        namespace: db_compact
+    exporters:
+      coralogix:
+        application_name: otel
+        application_name_attributes:
+        - k8s.namespace.name
+        - service.namespace
+        domain: eu2.coralogix.com
+        domain_settings:
+          keepalive:
+            enabled: true
+            permit_without_stream: false
+            time: 30s
+            timeout: 10s
+        logs:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+        metrics:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+        private_key: ${env:CORALOGIX_PRIVATE_KEY}
+        profiles:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+            x-coralogix-ingress: otlp/v1.10.0
+        sending_queue:
+          batch:
+            flush_timeout: 250ms
+            max_size: 2097152
+            min_size: 1048576
+            sizer: bytes
+          enabled: true
+          num_consumers: 20
+          queue_size: 209715200
+          sizer: bytes
+        subsystem_name: integration
+        subsystem_name_attributes:
+        - k8s.deployment.name
+        - k8s.statefulset.name
+        - k8s.daemonset.name
+        - k8s.cronjob.name
+        - service.name
+        timeout: 30s
+        traces:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+      coralogix/resource_catalog:
+        application_name: resource
+        domain: eu2.coralogix.com
+        logs:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+            x-coralogix-ingress: metadata-as-otlp-logs/v1
+        private_key: ${CORALOGIX_PRIVATE_KEY}
+        sending_queue:
+          batch:
+            flush_timeout: 250ms
+            max_size: 2097152
+            min_size: 1048576
+            sizer: bytes
+          enabled: true
+          num_consumers: 20
+          queue_size: 209715200
+          sizer: bytes
+        subsystem_name: catalog
+        timeout: 30s
+      debug: {}
+    extensions:
+      file_storage:
+        directory: /var/lib/otelcol
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
+      opamp:
+        agent_description:
+          include_resource_attributes: true
+          non_identifying_attributes:
+            cx.agent.type: agent
+            cx.cluster.name: 'golden-render'
+            helm.chart.opentelemetry-agent.version: 0.132.0
+        server:
+          http:
+            endpoint: https://ingress.eu2.coralogix.com/opamp/v1
+            headers:
+              Authorization: Bearer ${env:CORALOGIX_PRIVATE_KEY}
+            polling_interval: 2m
+      pprof:
+        endpoint: localhost:1777
+      zpages:
+        endpoint: localhost:55679
+    processors:
+      batch:
+        send_batch_max_size: 2048
+        send_batch_size: 1024
+        timeout: 1s
+      coralogix:
+        transactions:
+          enabled: true
+      filter/db_compact_spanmetrics:
+        traces:
+          span:
+          - span.kind != SPAN_KIND_CLIENT or span.attributes["db.namespace"] == nil or
+            span.attributes["db.system"] == nil
+      filter/db_spanmetrics:
+        traces:
+          span:
+          - span.attributes["db.system"] == nil
+      filter/k8s_extra_metrics:
+        metrics:
+          metric:
+          - resource.attributes["service.name"] == "kubernetes-cadvisor" and (metric.name
+            != "container_fs_writes_total" and metric.name != "container_fs_reads_total"
+            and metric.name != "container_fs_writes_bytes_total" and metric.name != "container_fs_reads_bytes_total"
+            and metric.name != "container_fs_usage_bytes" and metric.name != "container_cpu_cfs_throttled_periods_total"
+            and metric.name != "container_cpu_cfs_periods_total")
+      groupbytrace/transactions:
+        wait_duration: 30s
+      k8sattributes:
+        extract:
+          deployment_name_from_replicaset: true
+          metadata:
+          - k8s.namespace.name
+          - k8s.deployment.name
+          - k8s.statefulset.name
+          - k8s.daemonset.name
+          - k8s.cronjob.name
+          - k8s.job.name
+          - k8s.node.name
+          - k8s.pod.name
+        filter:
+          node_from_env_var: K8S_NODE_NAME
+        passthrough: false
+        pod_association:
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.ip
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.uid
+        - sources:
+          - from: connection
+        - sources:
+          - from: resource_attribute
+            name: k8s.job.name
+      k8sattributes/profiles:
+        extract:
+          annotations:
+          - from: pod
+            key: app.coralogix.com/service
+            tag_name: service.annotation
+          labels:
+          - from: pod
+            key: app.kubernetes.io/name
+            tag_name: k8s.label.name
+          - from: pod
+            key: app.kubernetes.io/instance
+            tag_name: k8s.label.instance
+          - from: pod
+            key: app.kubernetes.io/name
+            tag_name: service.label
+          metadata:
+          - k8s.namespace.name
+          - k8s.replicaset.name
+          - k8s.statefulset.name
+          - k8s.daemonset.name
+          - k8s.deployment.name
+          - k8s.cronjob.name
+          - k8s.job.name
+          - k8s.pod.name
+          - k8s.node.name
+          - container.id
+          - k8s.container.name
+          - service.version
+          otel_annotations: true
+        filter:
+          node_from_env_var: K8S_NODE_NAME
+        passthrough: false
+        pod_association:
+        - sources:
+          - from: resource_attribute
+            name: container.id
+        - sources:
+          - from: connection
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
+      redaction/spanname:
+        allow_all_keys: true
+        db_sanitizer:
+          es:
+            attributes:
+            - db.statement
+            - elasticsearch.body
+            enabled: true
+          memcached:
+            attributes:
+            - db.statement
+            - memcached.command
+            enabled: true
+          mongo:
+            attributes:
+            - db.statement
+            - mongodb.query
+            enabled: true
+          opensearch:
+            attributes:
+            - db.statement
+            - opensearch.body
+            enabled: true
+          redis:
+            attributes:
+            - db.statement
+            - redis.command
+            enabled: true
+          sql:
+            attributes:
+            - db.statement
+            - db.query
+            enabled: true
+        url_sanitizer:
+          enabled: true
+      resource/metadata:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: 'golden-render'
+        - action: upsert
+          key: cx.otel_integration.name
+          value: coralogix-integration-helm
+      resourcedetection/entity:
+        detectors:
+        - system
+        - env
+        override: false
+        system:
+          resource_attributes:
+            host.cpu.cache.l2.size:
+              enabled: true
+            host.cpu.family:
+              enabled: true
+            host.cpu.model.id:
+              enabled: true
+            host.cpu.model.name:
+              enabled: true
+            host.cpu.stepping:
+              enabled: true
+            host.cpu.vendor.id:
+              enabled: true
+            host.id:
+              enabled: true
+            host.ip:
+              enabled: true
+            host.mac:
+              enabled: true
+            os.description:
+              enabled: true
+        timeout: 2s
+      resourcedetection/env:
+        detectors:
+        - system
+        - env
+        override: false
+        system:
+          resource_attributes:
+            host.id:
+              enabled: true
+        timeout: 2s
+      resourcedetection/region:
+        detectors:
+        - gcp
+        - ec2
+        - azure
+        - eks
+        eks:
+          node_from_env_var: K8S_NODE_NAME
+        override: true
+        timeout: 2s
+      transform/compact:
+        trace_statements:
+        - context: resource
+          statements:
+          - keep_keys(resource.attributes, ["service.name", "k8s.cluster.name", "host.name",
+            "deployment.environment.name"])
+      transform/db_compact:
+        trace_statements:
+        - context: resource
+          statements:
+          - keep_keys(resource.attributes, ["service.name", "k8s.cluster.name", "host.name",
+            "deployment.environment.name"])
+        - context: span
+          statements:
+          - keep_keys(span.attributes, ["db.namespace", "db.system"])
+      transform/entity-event:
+        error_mode: silent
+        log_statements:
+        - context: log
+          statements:
+          - set(log.attributes["otel.entity.id"]["host.id"], resource.attributes["host.id"])
+          - merge_maps(log.attributes, resource.attributes, "insert")
+        - context: resource
+          statements:
+          - keep_keys(resource.attributes, [""])
+      transform/kubeletstatscpu:
+        error_mode: ignore
+        metric_statements:
+        - context: metric
+          statements:
+          - set(metric.unit, "1") where metric.name == "container.cpu.usage"
+          - set(metric.name, "container.cpu.utilization") where metric.name == "container.cpu.usage"
+          - set(metric.unit, "1") where metric.name == "k8s.pod.cpu.usage"
+          - set(metric.name, "k8s.pod.cpu.utilization") where metric.name == "k8s.pod.cpu.usage"
+          - set(metric.unit, "1") where metric.name == "k8s.node.cpu.usage"
+          - set(metric.name, "k8s.node.cpu.utilization") where metric.name == "k8s.node.cpu.usage"
+      transform/profiles:
+        profile_statements:
+        - set(resource.attributes["service.name"], resource.attributes["service.annotation"])
+          where resource.attributes["service.name"] == nil and resource.attributes["service.annotation"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["service.label"])
+          where resource.attributes["service.name"] == nil and resource.attributes["service.label"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["k8s.label.instance"])
+          where resource.attributes["service.name"] == nil and resource.attributes["k8s.label.instance"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["k8s.label.name"])
+          where resource.attributes["service.name"] == nil and resource.attributes["k8s.label.name"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["k8s.deployment.name"])
+          where resource.attributes["service.name"] == nil and resource.attributes["k8s.deployment.name"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["k8s.replicaset.name"])
+          where resource.attributes["service.name"] == nil and resource.attributes["k8s.replicaset.name"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["k8s.statefulset.name"])
+          where resource.attributes["service.name"] == nil and resource.attributes["k8s.statefulset.name"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["k8s.daemonset.name"])
+          where resource.attributes["service.name"] == nil and resource.attributes["k8s.daemonset.name"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["k8s.cronjob.name"])
+          where resource.attributes["service.name"] == nil and resource.attributes["k8s.cronjob.name"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["k8s.job.name"])
+          where resource.attributes["service.name"] == nil and resource.attributes["k8s.job.name"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["k8s.pod.name"])
+          where resource.attributes["service.name"] == nil and resource.attributes["k8s.pod.name"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["k8s.container.name"])
+          where resource.attributes["service.name"] == nil and resource.attributes["k8s.container.name"]
+          != nil
+      transform/prometheus:
+        error_mode: ignore
+        metric_statements:
+        - context: metric
+          statements:
+          - replace_pattern(metric.name, "_total$", "") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_cpu_seconds_seconds$", "otelcol_process_cpu_seconds")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_runtime_heap_alloc_bytes_bytes$",
+            "otelcol_process_runtime_heap_alloc_bytes") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_runtime_total_alloc_bytes_bytes$",
+            "otelcol_process_runtime_total_alloc_bytes") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_runtime_total_sys_memory_bytes_bytes$",
+            "otelcol_process_runtime_total_sys_memory_bytes") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_fileconsumer_open_files$", "otelcol_fileconsumer_open_files_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_fileconsumer_reading_files$", "otelcol_fileconsumer_reading_files_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_ip_lookup_miss$", "otelcol_otelsvc_k8s_ip_lookup_miss_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_pod_added$", "otelcol_otelsvc_k8s_pod_added_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_pod_updated$", "otelcol_otelsvc_k8s_pod_updated_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_pod_deleted$", "otelcol_otelsvc_k8s_pod_deleted_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_processor_filter_spans\\.filtered$",
+            "otelcol_processor_filter_spans.filtered_ratio") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+        - context: resource
+          statements:
+          - set(resource.attributes["k8s.pod.ip"], resource.attributes["net.host.name"])
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - delete_key(resource.attributes, "service_name") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+        - context: datapoint
+          statements:
+          - delete_key(datapoint.attributes, "service_name") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - delete_key(datapoint.attributes, "otel_scope_name") where datapoint.attributes["service.name"]
+            == "opentelemetry-collector"
+      transform/semconv:
+        error_mode: ignore
+        trace_statements:
+        - context: span
+          statements:
+          - set(span.attributes["http.method"], span.attributes["http.request.method"])
+            where span.attributes["http.request.method"] != nil
+      transform/spanmetrics:
+        error_mode: silent
+        metric_statements:
+        - context: datapoint
+          statements:
+          - set(datapoint.attributes["status.code"], "STATUS_CODE_ERROR") where datapoint.attributes["status.code"]
+            == nil and instrumentation_scope.name == "spanmetricsconnector" and datapoint.attributes["otel.status_code"]
+            == "ERROR"
+          - set(datapoint.attributes["status.code"], "STATUS_CODE_OK") where datapoint.attributes["status.code"]
+            == nil and instrumentation_scope.name == "spanmetricsconnector" and datapoint.attributes["otel.status_code"]
+            == "OK"
+          - set(datapoint.attributes["status.code"], "STATUS_CODE_UNSET") where datapoint.attributes["status.code"]
+            == nil and instrumentation_scope.name == "spanmetricsconnector" and (datapoint.attributes["otel.status_code"]
+            == "UNSET" or datapoint.attributes["otel.status_code"] == nil)
+    receivers:
+      filelog:
+        exclude: []
+        force_flush_period: 0
+        include:
+        - /var/log/pods/*/*/*.log
+        include_file_name: false
+        include_file_path: true
+        operators:
+        - id: get-format
+          routes:
+          - expr: body matches "^\\{"
+            output: parser-docker
+          - expr: body matches "^[^ Z]+ "
+            output: parser-crio
+          - expr: body matches "^[^ Z]+Z"
+            output: parser-containerd
+          type: router
+        - id: parser-crio
+          regex: ^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$
+          timestamp:
+            layout: 2006-01-02T15:04:05.999999999Z07:00
+            layout_type: gotime
+            parse_from: attributes.time
+          type: regex_parser
+        - combine_field: attributes.log
+          combine_with: ""
+          id: crio-recombine
+          is_last_entry: attributes.logtag == 'F'
+          max_batch_size: 1000
+          max_log_size: 1048576
+          output: handle_empty_log
+          source_identifier: attributes["log.file.path"]
+          type: recombine
+        - id: parser-containerd
+          regex: ^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$
+          timestamp:
+            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+            parse_from: attributes.time
+          type: regex_parser
+        - combine_field: attributes.log
+          combine_with: ""
+          id: containerd-recombine
+          is_last_entry: attributes.logtag == 'F'
+          max_batch_size: 1000
+          max_log_size: 1048576
+          output: handle_empty_log
+          source_identifier: attributes["log.file.path"]
+          type: recombine
+        - id: parser-docker
+          timestamp:
+            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+            parse_from: attributes.time
+          type: json_parser
+        - combine_field: attributes.log
+          combine_with: ""
+          id: docker-recombine
+          is_last_entry: attributes.log endsWith "\n"
+          max_batch_size: 1000
+          max_log_size: 1048576
+          output: handle_empty_log
+          source_identifier: attributes["log.file.path"]
+          type: recombine
+        - field: attributes.log
+          id: handle_empty_log
+          if: attributes.log == nil
+          type: add
+          value: ""
+        - parse_from: attributes["log.file.path"]
+          regex: ^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]+)\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$
+          type: regex_parser
+        - from: attributes.stream
+          to: attributes["log.iostream"]
+          type: move
+        - from: attributes.container_name
+          to: resource["k8s.container.name"]
+          type: move
+        - from: attributes.namespace
+          to: resource["k8s.namespace.name"]
+          type: move
+        - from: attributes.pod_name
+          to: resource["k8s.pod.name"]
+          type: move
+        - from: attributes.restart_count
+          to: resource["k8s.container.restart_count"]
+          type: move
+        - from: attributes.uid
+          to: resource["k8s.pod.uid"]
+          type: move
+        - from: attributes.log
+          id: clean-up-log-record
+          to: body
+          type: move
+        - default: skip-collector-logs-recombine
+          routes:
+          - expr: (attributes["log.file.path"] matches "/var/log/pods/default_coralogix-opentelemetry.*_.*/opentelemetry-agent/.*.log")
+            output: collector-logs-recombine
+          type: router
+        - combine_field: body
+          combine_with: |2+
+
+          id: collector-logs-recombine
+          is_first_entry: body matches "^\\{"
+          max_batch_size: 1000
+          max_log_size: 1048576
+          source_identifier: attributes["log.file.path"]
+          type: recombine
+        - id: skip-collector-logs-recombine
+          type: noop
+        - field: body
+          if: (attributes["log.file.path"] matches "/var/log/pods/default_coralogix-opentelemetry.*_.*/opentelemetry-agent/.*.log")
+          regex: (?s)("stacktrace":"[^"]*)"}\n(.*)$
+          replace_with: $${1}\\n$${2}"}
+          type: regex_replace
+        - drop_ratio: 1
+          expr: (attributes["log.file.path"] matches "/var/log/pods/default_coralogix-opentelemetry.*_.*/opentelemetry-agent/.*.log")
+            and ((body contains "logRecord") or (body contains "ResourceLog"))
+          type: filter
+        - default: logs-collection-continue
+          routes:
+          - expr: (body matches "\"resource\":{.*?},?") and not (body matches "\"logger\":\"supervisor\\.collector\"")
+            output: parse-body
+          type: router
+        - id: parse-body
+          if: (attributes["log.file.path"] matches "/var/log/pods/default_coralogix-opentelemetry.*_.*/.*/.*.log")
+            and not (body matches "\"logger\":\"supervisor\\.collector\"")
+          on_error: send_quiet
+          parse_to: attributes["parsed_body_tmp"]
+          type: json_parser
+        - field: body
+          if: (attributes["log.file.path"] matches "/var/log/pods/default_coralogix-opentelemetry.*_.*/.*/.*.log")
+            and not (body matches "\"logger\":\"supervisor\\.collector\"")
+          on_error: send_quiet
+          regex: \"resource\":{.*?},?
+          replace_with: ""
+          type: regex_replace
+        - from: attributes["parsed_body_tmp"]["resource"]
+          if: (attributes["log.file.path"] matches "/var/log/pods/default_coralogix-opentelemetry.*_.*/.*/.*.log")
+            and not (body matches "\"logger\":\"supervisor\\.collector\"")
+          on_error: send_quiet
+          to: resource["attributes_tmp"]
+          type: move
+        - field: attributes["parsed_body_tmp"]
+          if: (attributes["log.file.path"] matches "/var/log/pods/default_coralogix-opentelemetry.*_.*/.*/.*.log")
+            and not (body matches "\"logger\":\"supervisor\\.collector\"")
+          on_error: send_quiet
+          type: remove
+        - field: resource["attributes_tmp"]
+          id: flatten-resource
+          if: (attributes["log.file.path"] matches "/var/log/pods/default_coralogix-opentelemetry.*_.*/.*/.*.log")
+            and not (body matches "\"logger\":\"supervisor\\.collector\"")
+          on_error: send_quiet
+          type: flatten
+        - id: logs-collection-continue
+          type: noop
+        retry_on_failure:
+          enabled: true
+        start_at: beginning
+        storage: file_storage
+      hostmetrics:
+        collection_interval: '30s'
+        root_path: /hostfs
+        scrapers:
+          cpu:
+            metrics:
+              system.cpu.utilization:
+                enabled: true
+          disk: null
+          filesystem:
+            exclude_fs_types:
+              fs_types:
+              - autofs
+              - binfmt_misc
+              - bpf
+              - cgroup2
+              - configfs
+              - debugfs
+              - devpts
+              - devtmpfs
+              - fusectl
+              - hugetlbfs
+              - iso9660
+              - mqueue
+              - nsfs
+              - overlay
+              - proc
+              - procfs
+              - pstore
+              - rpc_pipefs
+              - securityfs
+              - selinuxfs
+              - squashfs
+              - sysfs
+              - tracefs
+              match_type: strict
+            exclude_mount_points:
+              match_type: regexp
+              mount_points:
+              - /dev/*
+              - /proc/*
+              - /sys/*
+              - /run/k3s/containerd/*
+              - /run/containerd/runc/*
+              - /var/lib/docker/*
+              - /var/lib/kubelet/*
+              - /snap/*
+          load: null
+          memory:
+            metrics:
+              system.memory.utilization:
+                enabled: true
+          network: null
+      jaeger:
+        protocols:
+          grpc:
+            endpoint: ${env:MY_POD_IP}:14250
+          thrift_binary:
+            endpoint: ${env:MY_POD_IP}:6832
+          thrift_compact:
+            endpoint: ${env:MY_POD_IP}:6831
+          thrift_http:
+            endpoint: ${env:MY_POD_IP}:14268
+      kubeletstats:
+        auth_type: serviceAccount
+        collect_all_network_interfaces:
+          node: true
+          pod: true
+        collection_interval: '30s'
+        endpoint: ${env:K8S_NODE_IP}:10250
+        insecure_skip_verify: true
+      otlp:
+        protocols:
+          grpc:
+            endpoint: ${env:MY_POD_IP}:4317
+            max_recv_msg_size_mib: 20
+          http:
+            endpoint: ${env:MY_POD_IP}:4318
+      prometheus:
+        config:
+          scrape_configs:
+          - job_name: opentelemetry-collector
+            scrape_interval: '30s'
+            static_configs:
+            - targets:
+              - ${env:MY_POD_IP}:8888
+      prometheus/k8s_extra_metrics:
+        config:
+          scrape_configs:
+          - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            honor_timestamps: true
+            job_name: kubernetes-cadvisor
+            metrics_path: /metrics/cadvisor
+            scheme: https
+            static_configs:
+            - targets:
+              - ${env:K8S_NODE_IP}:10250
+            tls_config:
+              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              insecure_skip_verify: true
+      statsd:
+        endpoint: ${env:MY_POD_IP}:8125
+      zipkin:
+        endpoint: ${env:MY_POD_IP}:9411
+    service:
+      extensions:
+      - health_check
+      - file_storage
+      - opamp
+      - zpages
+      - pprof
+      pipelines:
+        logs:
+          exporters:
+          - coralogix
+          processors:
+          - memory_limiter
+          - resourcedetection/region
+          - resourcedetection/env
+          - resource/metadata
+          - k8sattributes
+          - batch
+          receivers:
+          - filelog
+          - otlp
+        logs/resource_catalog:
+          exporters:
+          - coralogix/resource_catalog
+          processors:
+          - memory_limiter
+          - resource/metadata
+          - k8sattributes
+          - resourcedetection/entity
+          - resourcedetection/region
+          - transform/entity-event
+          receivers:
+          - hostmetrics
+        metrics:
+          exporters:
+          - coralogix
+          processors:
+          - memory_limiter
+          - resourcedetection/region
+          - resourcedetection/env
+          - resource/metadata
+          - k8sattributes
+          - transform/kubeletstatscpu
+          - filter/k8s_extra_metrics
+          - transform/spanmetrics
+          - transform/prometheus
+          - batch
+          receivers:
+          - hostmetrics
+          - kubeletstats
+          - prometheus/k8s_extra_metrics
+          - spanmetrics
+          - spanmetrics/db
+          - prometheus
+          - otlp
+          - statsd
+        metrics/compact:
+          exporters:
+          - coralogix
+          processors:
+          - memory_limiter
+          - transform/spanmetrics
+          - batch
+          receivers:
+          - spanmetrics/compact
+        metrics/db_compact:
+          exporters:
+          - coralogix
+          processors:
+          - memory_limiter
+          - transform/spanmetrics
+          - batch
+          receivers:
+          - spanmetrics/db_compact
+        profiles:
+          exporters:
+          - coralogix
+          processors:
+          - memory_limiter
+          - resourcedetection/region
+          - resourcedetection/env
+          - k8sattributes/profiles
+          - resource/metadata
+          - transform/profiles
+          receivers:
+          - otlp
+        traces:
+          exporters:
+          - spanmetrics
+          - forward/db
+          - forward/compact
+          - forward/db_compact
+          - coralogix
+          processors:
+          - memory_limiter
+          - resourcedetection/region
+          - resourcedetection/env
+          - resource/metadata
+          - k8sattributes
+          - transform/spanmetrics
+          - redaction/spanname
+          - transform/semconv
+          - groupbytrace/transactions
+          - coralogix
+          - batch
+          receivers:
+          - jaeger
+          - zipkin
+          - otlp
+        traces/compact:
+          exporters:
+          - spanmetrics/compact
+          processors:
+          - transform/compact
+          - batch
+          receivers:
+          - forward/compact
+        traces/db:
+          exporters:
+          - spanmetrics/db
+          processors:
+          - filter/db_spanmetrics
+          - batch
+          receivers:
+          - forward/db
+        traces/db_compact:
+          exporters:
+          - spanmetrics/db_compact
+          processors:
+          - filter/db_compact_spanmetrics
+          - transform/db_compact
+          - batch
+          receivers:
+          - forward/db_compact
+      telemetry:
+        logs:
+          encoding: json
+          level: 'info'
+        metrics:
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: ${env:MY_POD_IP}
+                  port: 8888
+                  without_scope_info: false
+                  without_type_suffix: false
+                  without_units: false
+        resource:
+          cx.agent.type: agent
+          k8s.daemonset.name: coralogix-opentelemetry
+          k8s.namespace.name: default
+          k8s.node.name: ${env:KUBE_NODE_NAME}
+          k8s.pod.name: ${env:KUBE_POD_NAME}
+          service.name: opentelemetry-collector
+---
+# Source: otel-integration/charts/opentelemetry-cluster-collector/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coralogix-opentelemetry-collector
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-cluster-collector-0.132.0
+    app.kubernetes.io/name: opentelemetry-cluster-collector
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+data:
+  relay: |
+    exporters:
+      coralogix:
+        application_name: otel
+        application_name_attributes:
+        - k8s.namespace.name
+        - service.namespace
+        domain: eu2.coralogix.com
+        domain_settings:
+          keepalive:
+            enabled: true
+            permit_without_stream: false
+            time: 30s
+            timeout: 10s
+        logs:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+        metrics:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+        private_key: ${env:CORALOGIX_PRIVATE_KEY}
+        profiles:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+            x-coralogix-ingress: otlp/v1.10.0
+        sending_queue:
+          batch:
+            flush_timeout: 250ms
+            max_size: 2097152
+            min_size: 1048576
+            sizer: bytes
+          enabled: true
+          num_consumers: 20
+          queue_size: 209715200
+          sizer: bytes
+        subsystem_name: integration
+        subsystem_name_attributes:
+        - k8s.deployment.name
+        - k8s.statefulset.name
+        - k8s.daemonset.name
+        - k8s.cronjob.name
+        - service.name
+        timeout: 30s
+        traces:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+      coralogix/resource_catalog:
+        application_name: resource
+        domain: eu2.coralogix.com
+        logs:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+            x-coralogix-ingress: metadata-as-otlp-logs/v1
+        private_key: ${CORALOGIX_PRIVATE_KEY}
+        sending_queue:
+          batch:
+            flush_timeout: 250ms
+            max_size: 2097152
+            min_size: 1048576
+            sizer: bytes
+          enabled: true
+          num_consumers: 20
+          queue_size: 209715200
+          sizer: bytes
+        subsystem_name: catalog
+        timeout: 30s
+      debug: {}
+    extensions:
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
+      k8s_observer:
+        auth_type: serviceAccount
+        observe_pods: true
+      opamp:
+        agent_description:
+          include_resource_attributes: true
+          non_identifying_attributes:
+            cx.agent.type: cluster-collector
+            cx.cluster.name: 'golden-render'
+            helm.chart.opentelemetry-cluster-collector.version: 0.132.0
+        server:
+          http:
+            endpoint: https://ingress.eu2.coralogix.com/opamp/v1
+            headers:
+              Authorization: Bearer ${env:CORALOGIX_PRIVATE_KEY}
+            polling_interval: 2m
+      pprof:
+        endpoint: localhost:1777
+      zpages:
+        endpoint: localhost:55679
+    processors:
+      batch:
+        send_batch_max_size: 2048
+        send_batch_size: 1024
+        timeout: 1s
+      filter/k8s_apiserver_metrics:
+        metrics:
+          metric:
+          - resource.attributes["service.name"] == "kubernetes-apiserver" and metric.name
+            != "kubernetes_build_info"
+      filter/workflow:
+        error_mode: silent
+        logs:
+          log_record:
+          - log.body["object"]["kind"] == "Pod" and not IsMatch(String(log.body["object"]["metadata"]["ownerReferences"]),
+            ".*StatefulSet.*|.*ReplicaSet.*|.*Job.*|.*DaemonSet.*")
+          - log.body["kind"] == "Pod" and not IsMatch(String(log.body["metadata"]["ownerReferences"]),
+            ".*StatefulSet.*|.*ReplicaSet.*|.*Job.*|.*DaemonSet.*")
+      k8sattributes:
+        extract:
+          deployment_name_from_replicaset: true
+          metadata:
+          - k8s.namespace.name
+          - k8s.deployment.name
+          - k8s.statefulset.name
+          - k8s.daemonset.name
+          - k8s.cronjob.name
+          - k8s.job.name
+          - k8s.node.name
+          - k8s.pod.name
+        passthrough: false
+        pod_association:
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.ip
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.uid
+        - sources:
+          - from: connection
+        - sources:
+          - from: resource_attribute
+            name: k8s.job.name
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
+      metricstransform/k8s-dashboard:
+        transforms:
+        - action: insert
+          include: k8s.pod.phase
+          match_type: strict
+          new_name: kube_pod_status_qos_class
+        - action: insert
+          include: k8s.pod.status_reason
+          match_type: strict
+          new_name: kube_pod_status_reason
+        - action: insert
+          include: k8s.node.allocatable_cpu
+          match_type: strict
+          new_name: kube_node_info
+        - action: insert
+          include: k8s.container.ready
+          match_type: strict
+          new_name: k8s.container.status.last_terminated_reason
+      resource/kube-events:
+        attributes:
+        - action: upsert
+          key: service.name
+          value: kube-events
+        - action: upsert
+          key: k8s.cluster.name
+          value: golden-render
+      resource/metadata:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: 'golden-render'
+        - action: upsert
+          key: cx.otel_integration.name
+          value: coralogix-integration-helm
+      resourcedetection/env:
+        detectors:
+        - system
+        - env
+        override: false
+        system:
+          resource_attributes:
+            host.id:
+              enabled: true
+        timeout: 2s
+      resourcedetection/region:
+        detectors:
+        - gcp
+        - ec2
+        - azure
+        - eks
+        eks:
+          node_from_env_var: K8S_NODE_NAME
+        override: true
+        timeout: 2s
+      resourcedetection/resource_catalog:
+        azure:
+          resource_attributes:
+            azure.resourcegroup.name:
+              enabled: false
+            azure.vm.name:
+              enabled: false
+            azure.vm.scaleset.name:
+              enabled: false
+            azure.vm.size:
+              enabled: false
+            host.id:
+              enabled: false
+            host.name:
+              enabled: false
+        detectors:
+        - gcp
+        - ec2
+        - azure
+        - eks
+        ec2:
+          resource_attributes:
+            host.id:
+              enabled: false
+            host.image.id:
+              enabled: false
+            host.name:
+              enabled: false
+            host.type:
+              enabled: false
+        eks:
+          node_from_env_var: K8S_NODE_NAME
+        gcp:
+          resource_attributes:
+            host.id:
+              enabled: false
+            host.name:
+              enabled: false
+            host.type:
+              enabled: false
+            k8s.cluster.name:
+              enabled: false
+        override: true
+        timeout: 2s
+      transform/entity-event:
+        error_mode: silent
+        log_statements:
+        - context: log
+          statements:
+          - set(log.attributes["otel.entity.interval"], Milliseconds(Duration("1h")))
+      transform/k8s-dashboard:
+        error_mode: ignore
+        metric_statements:
+        - context: metric
+          statements:
+          - set(metric.unit, "1") where metric.name == "k8s.pod.phase"
+          - set(metric.unit, "") where metric.name == "kube_node_info"
+          - set(metric.unit, "") where metric.name == "k8s.container.status.last_terminated_reason"
+        - context: datapoint
+          statements:
+          - set(datapoint.value_int, 1) where metric.name == "kube_pod_status_qos_class"
+          - set(datapoint.attributes["qos_class"], resource.attributes["k8s.pod.qos_class"])
+            where metric.name == "kube_pod_status_qos_class"
+          - set(datapoint.attributes["pod"], resource.attributes["k8s.pod.name"]) where
+            metric.name == "kube_pod_status_reason"
+          - set(datapoint.attributes["reason"], "Evicted") where metric.name == "kube_pod_status_reason"
+            and datapoint.value_int == 1
+          - set(datapoint.attributes["reason"], "NodeAffinity") where metric.name == "kube_pod_status_reason"
+            and datapoint.value_int == 2
+          - set(datapoint.attributes["reason"], "NodeLost") where metric.name == "kube_pod_status_reason"
+            and datapoint.value_int == 3
+          - set(datapoint.attributes["reason"], "Shutdown") where metric.name == "kube_pod_status_reason"
+            and datapoint.value_int == 4
+          - set(datapoint.attributes["reason"], "UnexpectedAdmissionError") where metric.name
+            == "kube_pod_status_reason" and datapoint.value_int == 5
+          - set(datapoint.value_int, 0) where metric.name == "kube_pod_status_reason"
+            and datapoint.value_int == 6
+          - set(datapoint.value_int, 1) where metric.name == "kube_pod_status_reason"
+            and datapoint.value_int != 0
+          - set(datapoint.value_int, 1) where metric.name == "kube_node_info"
+          - set(datapoint.attributes["kubelet_version"], resource.attributes["k8s.kubelet.version"])
+            where metric.name == "kube_node_info"
+          - set(datapoint.value_int, 1) where metric.name == "k8s.container.status.last_terminated_reason"
+          - set(datapoint.attributes["reason"], "") where metric.name == "k8s.container.status.last_terminated_reason"
+          - set(datapoint.attributes["reason"], resource.attributes["k8s.container.status.last_terminated_reason"])
+            where metric.name == "k8s.container.status.last_terminated_reason"
+        - context: resource
+          statements:
+          - delete_key(resource.attributes, "k8s.container.status.last_terminated_reason")
+          - delete_key(resource.attributes, "k8s.pod.qos_class")
+          - delete_key(resource.attributes, "k8s.kubelet.version")
+      transform/kube-events:
+        log_statements:
+        - context: log
+          statements:
+          - keep_keys(log.body["object"], ["type", "eventTime", "reason", "regarding",
+            "note", "metadata", "deprecatedFirstTimestamp", "deprecatedLastTimestamp"])
+            where IsMap(log.body) and IsMap(log.body["object"])
+          - keep_keys(log.body["object"]["metadata"], ["creationTimestamp"]) where IsMap(log.body)
+            and IsMap(log.body["object"]) and IsMap(log.body["object"]["metadata"])
+          - keep_keys(log.body["object"]["regarding"], ["kind", "name", "namespace"])
+            where IsMap(log.body) and IsMap(log.body["object"]) and IsMap(log.body["object"]["regarding"])
+      transform/prometheus:
+        error_mode: ignore
+        metric_statements:
+        - context: metric
+          statements:
+          - replace_pattern(metric.name, "_total$", "") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_cpu_seconds_seconds$", "otelcol_process_cpu_seconds")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_runtime_heap_alloc_bytes_bytes$",
+            "otelcol_process_runtime_heap_alloc_bytes") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_runtime_total_alloc_bytes_bytes$",
+            "otelcol_process_runtime_total_alloc_bytes") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_runtime_total_sys_memory_bytes_bytes$",
+            "otelcol_process_runtime_total_sys_memory_bytes") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_fileconsumer_open_files$", "otelcol_fileconsumer_open_files_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_fileconsumer_reading_files$", "otelcol_fileconsumer_reading_files_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_ip_lookup_miss$", "otelcol_otelsvc_k8s_ip_lookup_miss_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_pod_added$", "otelcol_otelsvc_k8s_pod_added_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_pod_updated$", "otelcol_otelsvc_k8s_pod_updated_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_pod_deleted$", "otelcol_otelsvc_k8s_pod_deleted_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_processor_filter_spans\\.filtered$",
+            "otelcol_processor_filter_spans.filtered_ratio") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+        - context: resource
+          statements:
+          - set(resource.attributes["k8s.pod.ip"], resource.attributes["net.host.name"])
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - delete_key(resource.attributes, "service_name") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+        - context: datapoint
+          statements:
+          - delete_key(datapoint.attributes, "service_name") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - delete_key(datapoint.attributes, "otel_scope_name") where datapoint.attributes["service.name"]
+            == "opentelemetry-collector"
+    receivers:
+      k8s_cluster:
+        allocatable_types_to_report:
+        - cpu
+        - memory
+        collection_interval: '30s'
+        metrics:
+          k8s.pod.status_reason:
+            enabled: true
+        resource_attributes:
+          k8s.container.status.last_terminated_reason:
+            enabled: true
+          k8s.kubelet.version:
+            enabled: true
+          k8s.pod.qos_class:
+            enabled: true
+      k8sobjects:
+        objects:
+        - exclude_watch_type:
+          - DELETED
+          group: events.k8s.io
+          mode: watch
+          name: events
+      k8sobjects/resource_catalog:
+        objects:
+        - group: ""
+          mode: pull
+          name: namespaces
+        - group: ""
+          mode: pull
+          name: nodes
+        - group: ""
+          mode: pull
+          name: persistentvolumeclaims
+        - group: ""
+          mode: pull
+          name: persistentvolumes
+        - group: ""
+          mode: pull
+          name: pods
+        - group: ""
+          mode: pull
+          name: services
+        - group: apps
+          mode: pull
+          name: daemonsets
+        - group: apps
+          mode: pull
+          name: deployments
+        - group: apps
+          mode: pull
+          name: replicasets
+        - group: apps
+          mode: pull
+          name: statefulsets
+        - group: autoscaling
+          mode: pull
+          name: horizontalpodautoscalers
+        - group: batch
+          mode: pull
+          name: cronjobs
+        - group: batch
+          mode: pull
+          name: jobs
+        - group: extensions
+          mode: pull
+          name: ingresses
+        - group: networking.k8s.io
+          mode: pull
+          name: ingresses
+        - group: policy
+          mode: pull
+          name: poddisruptionbudgets
+        - group: rbac.authorization.k8s.io
+          mode: pull
+          name: clusterrolebindings
+        - group: rbac.authorization.k8s.io
+          mode: pull
+          name: clusterroles
+        - group: rbac.authorization.k8s.io
+          mode: pull
+          name: rolebindings
+        - group: rbac.authorization.k8s.io
+          mode: pull
+          name: roles
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: ""
+          mode: watch
+          name: namespaces
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: ""
+          mode: watch
+          name: nodes
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: ""
+          mode: watch
+          name: persistentvolumeclaims
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: ""
+          mode: watch
+          name: persistentvolumes
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: ""
+          mode: watch
+          name: pods
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: apps
+          mode: watch
+          name: daemonsets
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: apps
+          mode: watch
+          name: deployments
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: apps
+          mode: watch
+          name: replicasets
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: apps
+          mode: watch
+          name: statefulsets
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: autoscaling
+          mode: watch
+          name: horizontalpodautoscalers
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: batch
+          mode: watch
+          name: cronjobs
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: batch
+          mode: watch
+          name: jobs
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: extensions
+          mode: watch
+          name: ingresses
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: networking.k8s.io
+          mode: watch
+          name: ingresses
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: policy
+          mode: watch
+          name: poddisruptionbudgets
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: rbac.authorization.k8s.io
+          mode: watch
+          name: clusterrolebindings
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: rbac.authorization.k8s.io
+          mode: watch
+          name: clusterroles
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: rbac.authorization.k8s.io
+          mode: watch
+          name: rolebindings
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: rbac.authorization.k8s.io
+          mode: watch
+          name: roles
+      otlp:
+        protocols:
+          grpc:
+            endpoint: ${env:MY_POD_IP}:4317
+            max_recv_msg_size_mib: 20
+          http:
+            endpoint: ${env:MY_POD_IP}:4318
+      prometheus:
+        config:
+          scrape_configs:
+          - job_name: opentelemetry-collector
+            scrape_interval: '30s'
+            static_configs:
+            - targets:
+              - ${env:MY_POD_IP}:8888
+      prometheus/k8s_apiserver_metrics:
+        config:
+          scrape_configs:
+          - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            honor_timestamps: true
+            job_name: kubernetes-apiserver
+            kubernetes_sd_configs:
+            - role: endpoints
+            relabel_configs:
+            - action: keep
+              regex: default;kubernetes;https
+              source_labels:
+              - __meta_kubernetes_namespace
+              - __meta_kubernetes_service_name
+              - __meta_kubernetes_endpoint_port_name
+            scheme: https
+            tls_config:
+              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              insecure_skip_verify: true
+    service:
+      extensions:
+      - health_check
+      - k8s_observer
+      - opamp
+      - zpages
+      - pprof
+      pipelines:
+        logs:
+          exporters:
+          - coralogix
+          processors:
+          - memory_limiter
+          - resource/metadata
+          - resource/kube-events
+          - resourcedetection/region
+          - resourcedetection/env
+          - k8sattributes
+          - transform/kube-events
+          - batch
+          receivers:
+          - k8sobjects
+          - otlp
+        logs/resource_catalog:
+          exporters:
+          - coralogix/resource_catalog
+          processors:
+          - memory_limiter
+          - resourcedetection/resource_catalog
+          - transform/entity-event
+          - filter/workflow
+          - resource/metadata
+          - batch
+          receivers:
+          - k8sobjects/resource_catalog
+        metrics:
+          exporters:
+          - coralogix
+          processors:
+          - memory_limiter
+          - resource/metadata
+          - resourcedetection/region
+          - resourcedetection/env
+          - k8sattributes
+          - metricstransform/k8s-dashboard
+          - transform/k8s-dashboard
+          - filter/k8s_apiserver_metrics
+          - transform/prometheus
+          - batch
+          receivers:
+          - k8s_cluster
+          - prometheus/k8s_apiserver_metrics
+          - prometheus
+          - otlp
+        traces:
+          exporters:
+          - debug
+          - coralogix
+          processors:
+          - memory_limiter
+          - resource/metadata
+          - resourcedetection/region
+          - resourcedetection/env
+          - k8sattributes
+          - batch
+          receivers:
+          - otlp
+      telemetry:
+        logs:
+          encoding: json
+          level: 'info'
+        metrics:
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: ${env:MY_POD_IP}
+                  port: 8888
+                  without_scope_info: false
+                  without_type_suffix: false
+                  without_units: false
+        resource:
+          cx.agent.type: cluster-collector
+          service.name: opentelemetry-collector
+---
+# Source: otel-integration/charts/opentelemetry-agent/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: coralogix-opentelemetry-agent
+  labels:
+    helm.sh/chart: opentelemetry-agent-0.132.0
+    app.kubernetes.io/name: opentelemetry-agent
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "namespaces"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes", "nodes/stats", "nodes/metrics"]
+    verbs: ["get", "watch", "list"]
+  - nonResourceURLs:
+    - "/metrics"
+    verbs: ["get"]
+---
+# Source: otel-integration/charts/opentelemetry-cluster-collector/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: coralogix-opentelemetry-collector
+  labels:
+    helm.sh/chart: opentelemetry-cluster-collector-0.132.0
+    app.kubernetes.io/name: opentelemetry-cluster-collector
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "namespaces"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events", "namespaces", "namespaces/status", "nodes", "nodes/spec", "pods", "pods/status", "replicationcontrollers", "replicationcontrollers/status", "resourcequotas", "services" ]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources: ["daemonsets", "deployments", "replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods", "endpoints", "nodes/stats", "nodes/metrics", "nodes", "services"]
+    verbs: ["get", "watch", "list"]
+  - nonResourceURLs:
+    - "/metrics"
+    verbs: ["get"]
+  - apiGroups: ["events.k8s.io"]
+    resources: ["events"]
+    verbs: ["watch", "list"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["aws-auth"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources:
+    - namespaces
+    - nodes
+    - persistentvolumeclaims
+    - persistentvolumes
+    - pods
+    - services
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources:
+    - daemonsets
+    - deployments
+    - replicasets
+    - statefulsets
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["autoscaling"]
+    resources:
+    - horizontalpodautoscalers
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources:
+    - cronjobs
+    - jobs
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources:
+    - ingresses
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+    - ingresses
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["policy"]
+    resources:
+    - poddisruptionbudgets
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources:
+    - clusterrolebindings
+    - clusterroles
+    - rolebindings
+    - roles
+    verbs: ["get", "list", "watch"]
+---
+# Source: otel-integration/charts/opentelemetry-agent/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: coralogix-opentelemetry-agent
+  labels:
+    helm.sh/chart: opentelemetry-agent-0.132.0
+    app.kubernetes.io/name: opentelemetry-agent
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: coralogix-opentelemetry-agent
+subjects:
+- kind: ServiceAccount
+  name: coralogix-opentelemetry
+  namespace: default
+---
+# Source: otel-integration/charts/opentelemetry-cluster-collector/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: coralogix-opentelemetry-collector
+  labels:
+    helm.sh/chart: opentelemetry-cluster-collector-0.132.0
+    app.kubernetes.io/name: opentelemetry-cluster-collector
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: coralogix-opentelemetry-collector
+subjects:
+- kind: ServiceAccount
+  name: coralogix-opentelemetry-collector
+  namespace: default
+---
+# Source: otel-integration/charts/opentelemetry-cluster-collector/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: coralogix-opentelemetry-collector
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-cluster-collector-0.132.0
+    app.kubernetes.io/name: opentelemetry-cluster-collector
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+    component: standalone-collector
+spec:
+  type: ClusterIP
+  ports:
+
+    - name: otlp
+      port: 4317
+      targetPort: 4317
+      protocol: TCP
+      appProtocol: grpc
+  selector:
+    app.kubernetes.io/name: opentelemetry-cluster-collector
+    app.kubernetes.io/instance: render-check
+    component: standalone-collector
+  internalTrafficPolicy: Cluster
+---
+# Source: otel-integration/charts/coralogix-ebpf-profiler/templates/agent-daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  namespace: default
+  name: coralogix-ebpf-profiler
+  labels:
+    name: coralogix-ebpf-profiler
+    app: coralogix-ebpf-profiler
+    prometheus.io/scrape: "true"
+
+
+  annotations:
+    name: coralogix-ebpf-profiler
+    app: coralogix-ebpf-profiler
+    prometheus.io/scrape: "true"
+
+spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 100%
+  selector:
+    matchLabels:
+      name: coralogix-ebpf-profiler
+  template:
+    metadata:
+      labels:
+        name: coralogix-ebpf-profiler
+    spec:
+      imagePullSecrets:
+        - name: my-registry-secret
+      serviceAccountName: coralogix-ebpf-profiler
+      hostNetwork: false
+      hostPID: true
+      containers:
+        - name: profiling-otel-agent
+          ports:
+            - containerPort: 8000
+              name: http
+              protocol: TCP
+          securityContext:
+            privileged: true
+          image: cgx.jfrog.io/coralogix-docker-images/coralogix-ebpf-profiler:0.0.15
+          imagePullPolicy: Always
+          env:
+            - name: NAMESPACE
+              value: default
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+            - name: CORALOGIX_CONFIG
+              value: config/ebpf-agent.toml
+            - name: OTEL_PROFILING_AGENT_COLLECTION_AGENT
+              value: "$(HOST_IP):4317"
+            - name: OTEL_PROFILING_AGENT_DISABLE_TLS
+              value: "true"
+            - name: OTEL_PROFILING_AGENT_REPORT_INTERVAL
+              value: 5s
+            - name: OTEL_PROFILING_AGENT_SAMPLES_PER_SECOND
+              value: "20"
+          volumeMounts:
+            - mountPath: /sys/kernel/debug
+              name: debug
+            - mountPath: /sys/fs/cgroup
+              name: cgroup
+            - mountPath: /proc
+              name: proc
+          resources:
+            limits:
+              cpu: "1"
+              memory: 2Gi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+      tolerations:
+        []
+      volumes:
+        - hostPath:
+            path: /sys/kernel/debug
+            type: ""
+          name: debug
+        - hostPath:
+            path: /sys/fs/cgroup
+            type: ""
+          name: cgroup
+        - hostPath:
+            path: /proc
+            type: ""
+          name: proc
+---
+# Source: otel-integration/charts/opentelemetry-agent/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: coralogix-opentelemetry-agent
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-agent-0.132.0
+    app.kubernetes.io/name: opentelemetry-agent
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opentelemetry-agent
+      app.kubernetes.io/instance: render-check
+      component: agent-collector
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: 299e68425afc6a5caf121cf9a1691e2ed4160696e92ee3e15bb0c47b7447ace3
+
+      labels:
+        app.kubernetes.io/name: opentelemetry-agent
+        app.kubernetes.io/instance: render-check
+        component: agent-collector
+
+    spec:
+
+      serviceAccountName: coralogix-opentelemetry
+      securityContext:
+        {}
+      containers:
+        - name: opentelemetry-agent
+          command:
+            - /otelcol-contrib
+            - --config=/conf/relay.yaml
+            - --feature-gates=service.profilesSupport
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+          image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.152.1"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: jaeger-binary
+              containerPort: 6832
+              protocol: TCP
+              hostPort: 6832
+            - name: jaeger-compact
+              containerPort: 6831
+              protocol: UDP
+              hostPort: 6831
+            - name: jaeger-grpc
+              containerPort: 14250
+              protocol: TCP
+              hostPort: 14250
+            - name: jaeger-thrift
+              containerPort: 14268
+              protocol: TCP
+              hostPort: 14268
+            - name: otlp
+              containerPort: 4317
+              protocol: TCP
+              hostPort: 4317
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+              hostPort: 4318
+            - name: statsd
+              containerPort: 8125
+              protocol: UDP
+              hostPort: 8125
+            - name: zipkin
+              containerPort: 9411
+              protocol: TCP
+              hostPort: 9411
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: KUBE_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+            - name: GOMEMLIMIT
+              value: "1525MiB"
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "k8s.node.name=$(K8S_NODE_NAME),deployment.environment.name=golden-render"
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: CORALOGIX_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: PRIVATE_KEY
+                  name: coralogix-keys
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          resources:
+            limits:
+              cpu: 1
+              memory: 2G
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          volumeMounts:
+            - mountPath: /conf
+              name: opentelemetry-agent-configmap
+            - name: varlogpods
+              mountPath: /var/log/pods
+              readOnly: true
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+            - name: varlibotelcol
+              mountPath: /var/lib/otelcol
+            - name: hostfs
+              mountPath: /hostfs
+              readOnly: true
+              mountPropagation: HostToContainer
+            - mountPath: /etc/machine-id
+              mountPropagation: HostToContainer
+              name: etcmachineid
+              readOnly: true
+            - mountPath: /var/lib/dbus/machine-id
+              mountPropagation: HostToContainer
+              name: varlibdbusmachineid
+              readOnly: true
+      volumes:
+        - name: opentelemetry-agent-configmap
+          configMap:
+            name: coralogix-opentelemetry-agent
+            items:
+              - key: relay
+                path: relay.yaml
+        - name: varlogpods
+          hostPath:
+            path: /var/log/pods
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+        - name: varlibotelcol
+          hostPath:
+            path: /var/lib/otelcol
+            type: DirectoryOrCreate
+        - name: hostfs
+          hostPath:
+            path: /
+        - name: etcmachineid
+          hostPath:
+            path: /etc/machine-id
+        - name: varlibdbusmachineid
+          hostPath:
+            path: /var/lib/dbus/machine-id
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - operator: Exists
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+---
+# Source: otel-integration/charts/opentelemetry-cluster-collector/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coralogix-opentelemetry-collector
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-cluster-collector-0.132.0
+    app.kubernetes.io/name: opentelemetry-cluster-collector
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opentelemetry-cluster-collector
+      app.kubernetes.io/instance: render-check
+      component: standalone-collector
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: f346bffa0952e83031adfbc9585d6c2c397de31d47c88430d33513ea4ccc3d8e
+
+      labels:
+        app.kubernetes.io/name: opentelemetry-cluster-collector
+        app.kubernetes.io/instance: render-check
+        component: standalone-collector
+
+    spec:
+
+      serviceAccountName: coralogix-opentelemetry-collector
+      securityContext:
+        {}
+      containers:
+        - name: opentelemetry-cluster-collector
+          command:
+            - /otelcol-contrib
+            - --config=/conf/relay.yaml
+          securityContext:
+            {}
+          image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.152.1"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: otlp
+              containerPort: 4317
+              protocol: TCP
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: GOMEMLIMIT
+              value: "1525MiB"
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "deployment.environment.name=golden-render"
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: CORALOGIX_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: PRIVATE_KEY
+                  name: coralogix-keys
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          startupProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            failureThreshold: 4
+            httpGet:
+              port: 13133
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          resources:
+            limits:
+              cpu: 1
+              memory: 2G
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          volumeMounts:
+            - mountPath: /conf
+              name: opentelemetry-cluster-collector-configmap
+            - mountPath: /etc/machine-id
+              mountPropagation: HostToContainer
+              name: etcmachineid
+              readOnly: true
+            - mountPath: /var/lib/dbus/machine-id
+              mountPropagation: HostToContainer
+              name: varlibdbusmachineid
+              readOnly: true
+      volumes:
+        - name: opentelemetry-cluster-collector-configmap
+          configMap:
+            name: coralogix-opentelemetry-collector
+            items:
+              - key: relay
+                path: relay.yaml
+        - name: etcmachineid
+          hostPath:
+            path: /etc/machine-id
+        - name: varlibdbusmachineid
+          hostPath:
+            path: /var/lib/dbus/machine-id
+      nodeSelector:
+        kubernetes.io/os: linux
+      hostNetwork: false

--- a/otel-integration/k8s-helm/tests/golden/eks-fargate.yaml
+++ b/otel-integration/k8s-helm/tests/golden/eks-fargate.yaml
@@ -1,0 +1,1032 @@
+---
+# Source: otel-integration/charts/opentelemetry-agent-eks-fargate-monitoring/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: otel-agent-eks-fargate-monitoring
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-agent-eks-fargate-monitoring-0.132.0
+    app.kubernetes.io/name: opentelemetry-agent-eks-fargate-monitoring
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: otel-integration/charts/opentelemetry-agent-eks-fargate/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: otel-agent-eks-fargate
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-agent-eks-fargate-0.132.0
+    app.kubernetes.io/name: opentelemetry-agent-eks-fargate
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: otel-integration/charts/opentelemetry-agent-eks-fargate-monitoring/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-agent-eks-fargate-monitoring
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-agent-eks-fargate-monitoring-0.132.0
+    app.kubernetes.io/name: opentelemetry-agent-eks-fargate-monitoring
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+data:
+  relay: |
+    exporters:
+      coralogix:
+        application_name: otel
+        application_name_attributes:
+        - k8s.namespace.name
+        - service.namespace
+        domain: eu2.coralogix.com
+        domain_settings:
+          keepalive:
+            enabled: true
+            permit_without_stream: false
+            time: 30s
+            timeout: 10s
+        logs:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+        metrics:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+        private_key: ${env:CORALOGIX_PRIVATE_KEY}
+        profiles:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+            x-coralogix-ingress: otlp/v1.10.0
+        sending_queue:
+          batch:
+            flush_timeout: 250ms
+            max_size: 2097152
+            min_size: 1048576
+            sizer: bytes
+          enabled: true
+          num_consumers: 20
+          queue_size: 209715200
+          sizer: bytes
+        subsystem_name: integration
+        subsystem_name_attributes:
+        - k8s.deployment.name
+        - k8s.statefulset.name
+        - k8s.daemonset.name
+        - k8s.cronjob.name
+        - k8s.job.name
+        - k8s.container.name
+        - k8s.node.name
+        - service.name
+        timeout: 30s
+        traces:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+      debug: {}
+    extensions:
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
+      k8s_observer:
+        auth_type: serviceAccount
+        observe_nodes: true
+        observe_pods: true
+    processors:
+      batch:
+        send_batch_max_size: 2048
+        send_batch_size: 1024
+        timeout: 60s
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
+      resource/metadata:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: 'golden-render'
+        - action: upsert
+          key: cx.otel_integration.name
+          value: coralogix-integration-helm
+      resourcedetection/env:
+        detectors:
+        - system
+        - env
+        override: false
+        system:
+          resource_attributes:
+            host.id:
+              enabled: true
+        timeout: 2s
+      resourcedetection/region:
+        detectors:
+        - env
+        override: true
+        timeout: 2s
+      transform/prometheus:
+        error_mode: ignore
+        metric_statements:
+        - context: metric
+          statements:
+          - replace_pattern(metric.name, "_total$", "") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_cpu_seconds_seconds$", "otelcol_process_cpu_seconds")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_runtime_heap_alloc_bytes_bytes$",
+            "otelcol_process_runtime_heap_alloc_bytes") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_runtime_total_alloc_bytes_bytes$",
+            "otelcol_process_runtime_total_alloc_bytes") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_runtime_total_sys_memory_bytes_bytes$",
+            "otelcol_process_runtime_total_sys_memory_bytes") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_fileconsumer_open_files$", "otelcol_fileconsumer_open_files_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_fileconsumer_reading_files$", "otelcol_fileconsumer_reading_files_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_ip_lookup_miss$", "otelcol_otelsvc_k8s_ip_lookup_miss_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_pod_added$", "otelcol_otelsvc_k8s_pod_added_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_pod_updated$", "otelcol_otelsvc_k8s_pod_updated_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_pod_deleted$", "otelcol_otelsvc_k8s_pod_deleted_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_processor_filter_spans\\.filtered$",
+            "otelcol_processor_filter_spans.filtered_ratio") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+        - context: resource
+          statements:
+          - set(resource.attributes["k8s.pod.ip"], resource.attributes["net.host.name"])
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - delete_key(resource.attributes, "service_name") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+        - context: datapoint
+          statements:
+          - delete_key(datapoint.attributes, "service_name") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - delete_key(datapoint.attributes, "otel_scope_name") where datapoint.attributes["service.name"]
+            == "opentelemetry-collector"
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: ${env:MY_POD_IP}:4317
+            max_recv_msg_size_mib: 20
+          http:
+            endpoint: ${env:MY_POD_IP}:4318
+      prometheus:
+        config:
+          scrape_configs:
+          - job_name: opentelemetry-collector
+            scrape_interval: 30s
+            static_configs:
+            - targets:
+              - ${env:MY_POD_IP}:8888
+      receiver_creator:
+        receivers:
+          kubeletstats:
+            config:
+              auth_type: serviceAccount
+              collection_interval: '30s'
+              endpoint: '`endpoint`:`kubelet_endpoint_port`'
+              extra_metadata_labels:
+              - container.id
+              insecure_skip_verify: true
+              metric_groups:
+              - container
+              - pod
+              - node
+            rule: type == "k8s.node" && labels["OTEL-collector-node"] == "true"
+        watch_observers:
+        - k8s_observer
+    service:
+      extensions:
+      - health_check
+      - k8s_observer
+      pipelines:
+        logs:
+          exporters:
+          - debug
+          - coralogix
+          processors:
+          - memory_limiter
+          - resource/metadata
+          - resourcedetection/region
+          - resourcedetection/env
+          - batch
+          receivers:
+          - otlp
+        metrics:
+          exporters:
+          - debug
+          - coralogix
+          processors:
+          - memory_limiter
+          - resource/metadata
+          - resourcedetection/region
+          - resourcedetection/env
+          - transform/prometheus
+          - batch
+          receivers:
+          - prometheus
+          - otlp
+        metrics/colmon:
+          exporters:
+          - coralogix
+          processors:
+          - memory_limiter
+          - resource/metadata
+          - resourcedetection/region
+          - resourcedetection/env
+          receivers:
+          - receiver_creator
+        traces:
+          exporters:
+          - debug
+          - coralogix
+          processors:
+          - memory_limiter
+          - resource/metadata
+          - resourcedetection/region
+          - resourcedetection/env
+          - batch
+          receivers:
+          - otlp
+      telemetry:
+        logs:
+          encoding: json
+        metrics:
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: ${env:MY_POD_IP}
+                  port: 8888
+                  without_scope_info: false
+                  without_type_suffix: false
+                  without_units: false
+---
+# Source: otel-integration/charts/opentelemetry-agent-eks-fargate/templates/configmap-script.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-agent-eks-fargate-script
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-agent-eks-fargate-0.132.0
+    app.kubernetes.io/name: opentelemetry-agent-eks-fargate
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+    component: script
+data:
+  label-node-script: |
+    #!/bin/bash
+    set +x
+    # Download kubectl
+    # If the latest stable version is not compatible with your cluster, adjust accordingly.
+    curl -LOs "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+
+    # Give execute permissions to kubectl
+    chmod +x kubectl
+
+    # Remove any prior label from other nodes. Label only the current node as the single OTEL-collector-node.
+    ./kubectl label nodes --all OTEL-collector-node-
+    ./kubectl label nodes $K8S_NODE_NAME OTEL-collector-node=true
+---
+# Source: otel-integration/charts/opentelemetry-agent-eks-fargate/templates/configmap-statefulset.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-agent-eks-fargate-statefulset
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-agent-eks-fargate-0.132.0
+    app.kubernetes.io/name: opentelemetry-agent-eks-fargate
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+data:
+  relay: |
+    exporters:
+      coralogix:
+        application_name: otel
+        application_name_attributes:
+        - k8s.namespace.name
+        - service.namespace
+        domain: eu2.coralogix.com
+        domain_settings:
+          keepalive:
+            enabled: true
+            permit_without_stream: false
+            time: 30s
+            timeout: 10s
+        logs:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+        metrics:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+        private_key: ${env:CORALOGIX_PRIVATE_KEY}
+        profiles:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+            x-coralogix-ingress: otlp/v1.10.0
+        sending_queue:
+          batch:
+            flush_timeout: 250ms
+            max_size: 2097152
+            min_size: 1048576
+            sizer: bytes
+          enabled: true
+          num_consumers: 20
+          queue_size: 209715200
+          sizer: bytes
+        subsystem_name: integration
+        subsystem_name_attributes:
+        - k8s.deployment.name
+        - k8s.statefulset.name
+        - k8s.daemonset.name
+        - k8s.cronjob.name
+        - k8s.job.name
+        - k8s.container.name
+        - k8s.node.name
+        - service.name
+        timeout: 30s
+        traces:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+      debug: {}
+    extensions:
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
+      k8s_observer:
+        auth_type: serviceAccount
+        observe_nodes: true
+        observe_pods: true
+    processors:
+      batch:
+        send_batch_max_size: 2048
+        send_batch_size: 1024
+        timeout: 60s
+      k8sattributes:
+        extract:
+          deployment_name_from_replicaset: true
+          metadata:
+          - k8s.namespace.name
+          - k8s.deployment.name
+          - k8s.statefulset.name
+          - k8s.daemonset.name
+          - k8s.cronjob.name
+          - k8s.job.name
+          - k8s.node.name
+          - k8s.pod.name
+          - k8s.pod.uid
+          - k8s.pod.start_time
+        passthrough: false
+        pod_association:
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.ip
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.uid
+        - sources:
+          - from: connection
+        - sources:
+          - from: resource_attribute
+            name: k8s.job.name
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
+      resource/metadata:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: 'golden-render'
+        - action: upsert
+          key: cx.otel_integration.name
+          value: coralogix-integration-helm
+      resourcedetection/env:
+        detectors:
+        - system
+        - env
+        override: false
+        system:
+          resource_attributes:
+            host.id:
+              enabled: true
+        timeout: 2s
+      resourcedetection/region:
+        detectors:
+        - env
+        override: true
+        timeout: 2s
+      transform/prometheus:
+        error_mode: ignore
+        metric_statements:
+        - context: metric
+          statements:
+          - replace_pattern(metric.name, "_total$", "") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_cpu_seconds_seconds$", "otelcol_process_cpu_seconds")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_runtime_heap_alloc_bytes_bytes$",
+            "otelcol_process_runtime_heap_alloc_bytes") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_runtime_total_alloc_bytes_bytes$",
+            "otelcol_process_runtime_total_alloc_bytes") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_runtime_total_sys_memory_bytes_bytes$",
+            "otelcol_process_runtime_total_sys_memory_bytes") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_fileconsumer_open_files$", "otelcol_fileconsumer_open_files_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_fileconsumer_reading_files$", "otelcol_fileconsumer_reading_files_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_ip_lookup_miss$", "otelcol_otelsvc_k8s_ip_lookup_miss_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_pod_added$", "otelcol_otelsvc_k8s_pod_added_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_pod_updated$", "otelcol_otelsvc_k8s_pod_updated_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_pod_deleted$", "otelcol_otelsvc_k8s_pod_deleted_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_processor_filter_spans\\.filtered$",
+            "otelcol_processor_filter_spans.filtered_ratio") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+        - context: resource
+          statements:
+          - set(resource.attributes["k8s.pod.ip"], resource.attributes["net.host.name"])
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - delete_key(resource.attributes, "service_name") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+        - context: datapoint
+          statements:
+          - delete_key(datapoint.attributes, "service_name") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - delete_key(datapoint.attributes, "otel_scope_name") where datapoint.attributes["service.name"]
+            == "opentelemetry-collector"
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: ${env:MY_POD_IP}:4317
+            max_recv_msg_size_mib: 20
+          http:
+            endpoint: ${env:MY_POD_IP}:4318
+      prometheus:
+        config:
+          scrape_configs:
+          - job_name: opentelemetry-collector
+            scrape_interval: 30s
+            static_configs:
+            - targets:
+              - ${env:MY_POD_IP}:8888
+      receiver_creator:
+        receivers:
+          kubeletstats:
+            config:
+              auth_type: serviceAccount
+              collection_interval: '30s'
+              endpoint: '`endpoint`:`kubelet_endpoint_port`'
+              extra_metadata_labels:
+              - container.id
+              insecure_skip_verify: true
+              metric_groups:
+              - container
+              - pod
+              - node
+            rule: type == "k8s.node" && name contains "fargate" && name != "${env:K8S_NODE_NAME}"
+        watch_observers:
+        - k8s_observer
+    service:
+      extensions:
+      - health_check
+      - k8s_observer
+      pipelines:
+        logs:
+          exporters:
+          - debug
+          - coralogix
+          processors:
+          - memory_limiter
+          - resource/metadata
+          - resourcedetection/region
+          - resourcedetection/env
+          - k8sattributes
+          - batch
+          receivers:
+          - otlp
+        metrics:
+          exporters:
+          - debug
+          - coralogix
+          processors:
+          - memory_limiter
+          - resource/metadata
+          - resourcedetection/region
+          - resourcedetection/env
+          - k8sattributes
+          - transform/prometheus
+          - batch
+          receivers:
+          - prometheus
+          - otlp
+        metrics/colmon:
+          exporters:
+          - coralogix
+          processors:
+          - memory_limiter
+          - resource/metadata
+          - resourcedetection/region
+          - resourcedetection/env
+          - k8sattributes
+          receivers:
+          - receiver_creator
+        metrics/kubeletstats:
+          exporters:
+          - coralogix
+          processors:
+          - memory_limiter
+          - resource/metadata
+          - resourcedetection/region
+          - resourcedetection/env
+          - k8sattributes
+          receivers:
+          - receiver_creator
+        traces:
+          exporters:
+          - debug
+          - coralogix
+          processors:
+          - memory_limiter
+          - resource/metadata
+          - resourcedetection/region
+          - resourcedetection/env
+          - k8sattributes
+          - batch
+          receivers:
+          - otlp
+      telemetry:
+        logs:
+          encoding: json
+        metrics:
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: ${env:MY_POD_IP}
+                  port: 8888
+                  without_scope_info: false
+                  without_type_suffix: false
+                  without_units: false
+---
+# Source: otel-integration/charts/opentelemetry-agent-eks-fargate-monitoring/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: otel-agent-eks-fargate-monitoring
+  labels:
+    helm.sh/chart: opentelemetry-agent-eks-fargate-monitoring-0.132.0
+    app.kubernetes.io/name: opentelemetry-agent-eks-fargate-monitoring
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - nodes/proxy
+      - nodes/metrics
+      - nodes/stats
+      - services
+      - endpoints
+      - pods
+      - pods/proxy
+      - configmaps
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources:
+      - nodes
+    verbs: ["patch"]
+  - nonResourceURLs:
+    - "/metrics/cadvisor"
+    verbs: ["get", "list", "watch"]
+---
+# Source: otel-integration/charts/opentelemetry-agent-eks-fargate/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: otel-agent-eks-fargate
+  labels:
+    helm.sh/chart: opentelemetry-agent-eks-fargate-0.132.0
+    app.kubernetes.io/name: opentelemetry-agent-eks-fargate
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "namespaces"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - nodes/proxy
+      - nodes/metrics
+      - nodes/stats
+      - services
+      - endpoints
+      - pods
+      - pods/proxy
+      - configmaps
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources:
+      - nodes
+    verbs: ["patch"]
+  - nonResourceURLs:
+    - "/metrics/cadvisor"
+    verbs: ["get", "list", "watch"]
+---
+# Source: otel-integration/charts/opentelemetry-agent-eks-fargate-monitoring/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: otel-agent-eks-fargate-monitoring
+  labels:
+    helm.sh/chart: opentelemetry-agent-eks-fargate-monitoring-0.132.0
+    app.kubernetes.io/name: opentelemetry-agent-eks-fargate-monitoring
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: otel-agent-eks-fargate-monitoring
+subjects:
+- kind: ServiceAccount
+  name: otel-agent-eks-fargate-monitoring
+  namespace: default
+---
+# Source: otel-integration/charts/opentelemetry-agent-eks-fargate/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: otel-agent-eks-fargate
+  labels:
+    helm.sh/chart: opentelemetry-agent-eks-fargate-0.132.0
+    app.kubernetes.io/name: opentelemetry-agent-eks-fargate
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: otel-agent-eks-fargate
+subjects:
+- kind: ServiceAccount
+  name: otel-agent-eks-fargate
+  namespace: default
+---
+# Source: otel-integration/charts/opentelemetry-agent-eks-fargate-monitoring/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-agent-eks-fargate-monitoring
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-agent-eks-fargate-monitoring-0.132.0
+    app.kubernetes.io/name: opentelemetry-agent-eks-fargate-monitoring
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+    component: standalone-collector
+spec:
+  type: ClusterIP
+  ports:
+
+    - name: metrics
+      port: 8888
+      targetPort: 8888
+      protocol: TCP
+    - name: otlp
+      port: 4317
+      targetPort: 4317
+      protocol: TCP
+      appProtocol: grpc
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: opentelemetry-agent-eks-fargate-monitoring
+    app.kubernetes.io/instance: render-check
+    component: standalone-collector
+  internalTrafficPolicy: Cluster
+---
+# Source: otel-integration/charts/opentelemetry-agent-eks-fargate/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-agent-eks-fargate
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-agent-eks-fargate-0.132.0
+    app.kubernetes.io/name: opentelemetry-agent-eks-fargate
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+    component: statefulset-collector
+spec:
+  type: ClusterIP
+  ports:
+
+    - name: metrics
+      port: 8888
+      targetPort: 8888
+      protocol: TCP
+    - name: otlp
+      port: 4317
+      targetPort: 4317
+      protocol: TCP
+      appProtocol: grpc
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: opentelemetry-agent-eks-fargate
+    app.kubernetes.io/instance: render-check
+    component: statefulset-collector
+  internalTrafficPolicy: Cluster
+---
+# Source: otel-integration/charts/opentelemetry-agent-eks-fargate-monitoring/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-agent-eks-fargate-monitoring
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-agent-eks-fargate-monitoring-0.132.0
+    app.kubernetes.io/name: opentelemetry-agent-eks-fargate-monitoring
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opentelemetry-agent-eks-fargate-monitoring
+      app.kubernetes.io/instance: render-check
+      component: standalone-collector
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: dffe019c812d17b7e0c008f1047f85da06f2a1b2738f4c293b2b439081d3e935
+
+      labels:
+        app.kubernetes.io/name: opentelemetry-agent-eks-fargate-monitoring
+        app.kubernetes.io/instance: render-check
+        component: standalone-collector
+
+    spec:
+
+      serviceAccountName: otel-agent-eks-fargate-monitoring
+      securityContext:
+        fsGroup: 65534
+      containers:
+        - name: opentelemetry-agent-eks-fargate-monitoring
+          command:
+            - /otelcol-contrib
+            - --config=/conf/relay.yaml
+          securityContext:
+            {}
+          image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.152.1"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
+            - name: otlp
+              containerPort: 4317
+              protocol: TCP
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: GOMEMLIMIT
+              value: "1638MiB"
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "k8s.node.name=$(K8S_NODE_NAME),deployment.environment.name=golden-render,cloud.provider=aws,cloud.platform=aws_eks"
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: CORALOGIX_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: PRIVATE_KEY
+                  name: coralogix-keys
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          resources:
+            limits:
+              cpu: 1
+              memory: 2Gi
+            requests:
+              cpu: 1
+              memory: 2Gi
+          volumeMounts:
+            - mountPath: /conf
+              name: opentelemetry-agent-eks-fargate-monitoring-configmap
+      volumes:
+        - name: opentelemetry-agent-eks-fargate-monitoring-configmap
+          configMap:
+            name: otel-agent-eks-fargate-monitoring
+            items:
+              - key: relay
+                path: relay.yaml
+      nodeSelector:
+        eks.amazonaws.com/compute-type: fargate
+      hostNetwork: false
+---
+# Source: otel-integration/charts/opentelemetry-agent-eks-fargate/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: otel-agent-eks-fargate
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-agent-eks-fargate-0.132.0
+    app.kubernetes.io/name: opentelemetry-agent-eks-fargate
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+spec:
+  serviceName: otel-agent-eks-fargate
+  podManagementPolicy: Parallel
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opentelemetry-agent-eks-fargate
+      app.kubernetes.io/instance: render-check
+      component: statefulset-collector
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: 0eebc1a66cd0200239f1cee5bd29c123c6a1745ee66ba7e48acec62eeeb771b4
+
+      labels:
+        app.kubernetes.io/name: opentelemetry-agent-eks-fargate
+        app.kubernetes.io/instance: render-check
+        component: statefulset-collector
+
+    spec:
+
+      serviceAccountName: otel-agent-eks-fargate
+      securityContext:
+        fsGroup: 65534
+      initContainers:
+        - name: node-labeler
+          image: "public.ecr.aws/aws-cli/aws-cli:2.28.17"
+          command: ["/bin/sh", "-c", "/script/label_node.sh"]
+          env:
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: script-volume
+              mountPath: /script
+      containers:
+        - name: opentelemetry-agent-eks-fargate
+          command:
+            - /otelcol-contrib
+            - --config=/conf/relay.yaml
+          securityContext:
+            {}
+          image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.152.1"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
+            - name: otlp
+              containerPort: 4317
+              protocol: TCP
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: GOMEMLIMIT
+              value: "1638MiB"
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "k8s.node.name=$(K8S_NODE_NAME),deployment.environment.name=golden-render,cloud.provider=aws,cloud.platform=aws_eks"
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: CORALOGIX_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: PRIVATE_KEY
+                  name: coralogix-keys
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          resources:
+            limits:
+              cpu: 1
+              memory: 2Gi
+            requests:
+              cpu: 1
+              memory: 2Gi
+          volumeMounts:
+            - mountPath: /conf
+              name: opentelemetry-agent-eks-fargate-configmap
+      volumes:
+        - name: opentelemetry-agent-eks-fargate-configmap
+          configMap:
+            name: otel-agent-eks-fargate-statefulset
+            items:
+              - key: relay
+                path: relay.yaml
+        - name: script-volume
+          configMap:
+            name: otel-agent-eks-fargate-script
+            items:
+              - key: label-node-script
+                path: label_node.sh
+                mode: 0555
+      nodeSelector:
+        eks.amazonaws.com/compute-type: fargate
+      hostNetwork: false

--- a/otel-integration/k8s-helm/tests/golden/tail-sampling.yaml
+++ b/otel-integration/k8s-helm/tests/golden/tail-sampling.yaml
@@ -1,0 +1,2575 @@
+---
+# Source: otel-integration/charts/opentelemetry-agent/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: coralogix-opentelemetry
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-agent-0.132.0
+    app.kubernetes.io/name: opentelemetry-agent
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: otel-integration/charts/opentelemetry-cluster-collector/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: coralogix-opentelemetry-collector
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-cluster-collector-0.132.0
+    app.kubernetes.io/name: opentelemetry-cluster-collector
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: otel-integration/charts/opentelemetry-gateway/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: coralogix-opentelemetry-gateway
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-gateway-0.132.0
+    app.kubernetes.io/name: opentelemetry-gateway
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: otel-integration/charts/opentelemetry-agent/templates/configmap-agent.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coralogix-opentelemetry-agent
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-agent-0.132.0
+    app.kubernetes.io/name: opentelemetry-agent
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+data:
+  relay: |
+    connectors:
+      forward/compact: {}
+      forward/db: {}
+      forward/db_compact: {}
+      spanmetrics:
+        add_resource_attributes: true
+        aggregation_cardinality_limit: 100000
+        dimensions:
+        - name: http.method
+        - name: cgx.transaction
+        - name: cgx.transaction.root
+        - name: status_code
+        - name: db.namespace
+        - name: db.operation.name
+        - name: db.collection.name
+        - name: db.system
+        - name: http.response.status_code
+        - name: rpc.grpc.status_code
+        - name: service.version
+        exclude_dimensions:
+        - collector.instance.id
+        histogram:
+          explicit:
+            buckets:
+            - 1ms
+            - 4ms
+            - 10ms
+            - 20ms
+            - 50ms
+            - 100ms
+            - 200ms
+            - 500ms
+            - 1s
+            - 2s
+            - 5s
+          unit: ms
+        metrics_expiration: 5m
+        metrics_flush_interval: '30s'
+        namespace: ""
+      spanmetrics/compact:
+        add_resource_attributes: true
+        aggregation_cardinality_limit: 100000
+        exclude_dimensions:
+        - collector.instance.id
+        - span.name
+        histogram:
+          explicit:
+            buckets:
+            - 1ms
+            - 4ms
+            - 10ms
+            - 20ms
+            - 50ms
+            - 100ms
+            - 200ms
+            - 500ms
+            - 1s
+            - 2s
+            - 5s
+          unit: ms
+        metrics_expiration: 5m
+        metrics_flush_interval: '30s'
+        namespace: compact
+      spanmetrics/db:
+        add_resource_attributes: true
+        aggregation_cardinality_limit: 100000
+        dimensions:
+        - name: db.namespace
+        - name: db.operation.name
+        - name: db.collection.name
+        - name: db.system
+        - name: service.version
+        exclude_dimensions:
+        - collector.instance.id
+        histogram:
+          explicit:
+            buckets:
+            - 1ms
+            - 4ms
+            - 10ms
+            - 20ms
+            - 50ms
+            - 100ms
+            - 200ms
+            - 500ms
+            - 1s
+            - 2s
+            - 5s
+          unit: ms
+        metrics_expiration: 5m
+        metrics_flush_interval: '30s'
+        namespace: db
+      spanmetrics/db_compact:
+        add_resource_attributes: true
+        aggregation_cardinality_limit: 100000
+        dimensions:
+        - name: db.namespace
+        - name: db.system
+        exclude_dimensions:
+        - collector.instance.id
+        - span.name
+        - span.kind
+        histogram:
+          explicit:
+            buckets:
+            - 1ms
+            - 4ms
+            - 10ms
+            - 20ms
+            - 50ms
+            - 100ms
+            - 200ms
+            - 500ms
+            - 1s
+            - 2s
+            - 5s
+          unit: ms
+        metrics_expiration: 5m
+        metrics_flush_interval: '30s'
+        namespace: db_compact
+    exporters:
+      coralogix:
+        application_name: otel
+        application_name_attributes:
+        - k8s.namespace.name
+        - service.namespace
+        domain: eu2.coralogix.com
+        domain_settings:
+          keepalive:
+            enabled: true
+            permit_without_stream: false
+            time: 30s
+            timeout: 10s
+        logs:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+        metrics:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+        private_key: ${env:CORALOGIX_PRIVATE_KEY}
+        profiles:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+            x-coralogix-ingress: otlp/v1.10.0
+        sending_queue:
+          batch:
+            flush_timeout: 250ms
+            max_size: 2097152
+            min_size: 1048576
+            sizer: bytes
+          enabled: true
+          num_consumers: 20
+          queue_size: 209715200
+          sizer: bytes
+        subsystem_name: integration
+        subsystem_name_attributes:
+        - k8s.deployment.name
+        - k8s.statefulset.name
+        - k8s.daemonset.name
+        - k8s.cronjob.name
+        - service.name
+        timeout: 30s
+        traces:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+      coralogix/resource_catalog:
+        application_name: resource
+        domain: eu2.coralogix.com
+        logs:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+            x-coralogix-ingress: metadata-as-otlp-logs/v1
+        private_key: ${CORALOGIX_PRIVATE_KEY}
+        sending_queue:
+          batch:
+            flush_timeout: 250ms
+            max_size: 2097152
+            min_size: 1048576
+            sizer: bytes
+          enabled: true
+          num_consumers: 20
+          queue_size: 209715200
+          sizer: bytes
+        subsystem_name: catalog
+        timeout: 30s
+      debug: {}
+      loadbalancing:
+        protocol:
+          otlp:
+            tls:
+              insecure: true
+        resolver:
+          dns:
+            hostname: coralogix-opentelemetry-gateway
+        routing_key: traceID
+    extensions:
+      file_storage:
+        directory: /var/lib/otelcol
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
+      opamp:
+        agent_description:
+          include_resource_attributes: true
+          non_identifying_attributes:
+            cx.agent.type: agent
+            cx.cluster.name: 'golden-render'
+            helm.chart.opentelemetry-agent.version: 0.132.0
+        server:
+          http:
+            endpoint: https://ingress.eu2.coralogix.com/opamp/v1
+            headers:
+              Authorization: Bearer ${env:CORALOGIX_PRIVATE_KEY}
+            polling_interval: 2m
+      pprof:
+        endpoint: localhost:1777
+      zpages:
+        endpoint: localhost:55679
+    processors:
+      batch:
+        send_batch_max_size: 2048
+        send_batch_size: 1024
+        timeout: 1s
+      coralogix:
+        transactions:
+          enabled: true
+      filter/db_compact_spanmetrics:
+        traces:
+          span:
+          - span.kind != SPAN_KIND_CLIENT or span.attributes["db.namespace"] == nil or
+            span.attributes["db.system"] == nil
+      filter/db_spanmetrics:
+        traces:
+          span:
+          - span.attributes["db.system"] == nil
+      filter/k8s_extra_metrics:
+        metrics:
+          metric:
+          - resource.attributes["service.name"] == "kubernetes-cadvisor" and (metric.name
+            != "container_fs_writes_total" and metric.name != "container_fs_reads_total"
+            and metric.name != "container_fs_writes_bytes_total" and metric.name != "container_fs_reads_bytes_total"
+            and metric.name != "container_fs_usage_bytes" and metric.name != "container_cpu_cfs_throttled_periods_total"
+            and metric.name != "container_cpu_cfs_periods_total")
+      groupbytrace/transactions:
+        wait_duration: 30s
+      k8sattributes:
+        extract:
+          deployment_name_from_replicaset: true
+          metadata:
+          - k8s.namespace.name
+          - k8s.deployment.name
+          - k8s.statefulset.name
+          - k8s.daemonset.name
+          - k8s.cronjob.name
+          - k8s.job.name
+          - k8s.node.name
+          - k8s.pod.name
+        filter:
+          node_from_env_var: K8S_NODE_NAME
+        passthrough: false
+        pod_association:
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.ip
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.uid
+        - sources:
+          - from: connection
+        - sources:
+          - from: resource_attribute
+            name: k8s.job.name
+      k8sattributes/profiles:
+        extract:
+          annotations:
+          - from: pod
+            key: app.coralogix.com/service
+            tag_name: service.annotation
+          labels:
+          - from: pod
+            key: app.kubernetes.io/name
+            tag_name: k8s.label.name
+          - from: pod
+            key: app.kubernetes.io/instance
+            tag_name: k8s.label.instance
+          - from: pod
+            key: app.kubernetes.io/name
+            tag_name: service.label
+          metadata:
+          - k8s.namespace.name
+          - k8s.replicaset.name
+          - k8s.statefulset.name
+          - k8s.daemonset.name
+          - k8s.deployment.name
+          - k8s.cronjob.name
+          - k8s.job.name
+          - k8s.pod.name
+          - k8s.node.name
+          - container.id
+          - k8s.container.name
+          - service.version
+          otel_annotations: true
+        filter:
+          node_from_env_var: K8S_NODE_NAME
+        passthrough: false
+        pod_association:
+        - sources:
+          - from: resource_attribute
+            name: container.id
+        - sources:
+          - from: connection
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
+      redaction/spanname:
+        allow_all_keys: true
+        db_sanitizer:
+          es:
+            attributes:
+            - db.statement
+            - elasticsearch.body
+            enabled: true
+          memcached:
+            attributes:
+            - db.statement
+            - memcached.command
+            enabled: true
+          mongo:
+            attributes:
+            - db.statement
+            - mongodb.query
+            enabled: true
+          opensearch:
+            attributes:
+            - db.statement
+            - opensearch.body
+            enabled: true
+          redis:
+            attributes:
+            - db.statement
+            - redis.command
+            enabled: true
+          sql:
+            attributes:
+            - db.statement
+            - db.query
+            enabled: true
+        url_sanitizer:
+          enabled: true
+      resource/metadata:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: 'golden-render'
+        - action: upsert
+          key: cx.otel_integration.name
+          value: coralogix-integration-helm
+      resourcedetection/entity:
+        detectors:
+        - system
+        - env
+        override: false
+        system:
+          resource_attributes:
+            host.cpu.cache.l2.size:
+              enabled: true
+            host.cpu.family:
+              enabled: true
+            host.cpu.model.id:
+              enabled: true
+            host.cpu.model.name:
+              enabled: true
+            host.cpu.stepping:
+              enabled: true
+            host.cpu.vendor.id:
+              enabled: true
+            host.id:
+              enabled: true
+            host.ip:
+              enabled: true
+            host.mac:
+              enabled: true
+            os.description:
+              enabled: true
+        timeout: 2s
+      resourcedetection/env:
+        detectors:
+        - system
+        - env
+        override: false
+        system:
+          resource_attributes:
+            host.id:
+              enabled: true
+        timeout: 2s
+      resourcedetection/region:
+        detectors:
+        - gcp
+        - ec2
+        - azure
+        - eks
+        eks:
+          node_from_env_var: K8S_NODE_NAME
+        override: true
+        timeout: 2s
+      transform/compact:
+        trace_statements:
+        - context: resource
+          statements:
+          - keep_keys(resource.attributes, ["service.name", "k8s.cluster.name", "host.name",
+            "deployment.environment.name"])
+      transform/db_compact:
+        trace_statements:
+        - context: resource
+          statements:
+          - keep_keys(resource.attributes, ["service.name", "k8s.cluster.name", "host.name",
+            "deployment.environment.name"])
+        - context: span
+          statements:
+          - keep_keys(span.attributes, ["db.namespace", "db.system"])
+      transform/entity-event:
+        error_mode: silent
+        log_statements:
+        - context: log
+          statements:
+          - set(log.attributes["otel.entity.id"]["host.id"], resource.attributes["host.id"])
+          - merge_maps(log.attributes, resource.attributes, "insert")
+        - context: resource
+          statements:
+          - keep_keys(resource.attributes, [""])
+      transform/kubeletstatscpu:
+        error_mode: ignore
+        metric_statements:
+        - context: metric
+          statements:
+          - set(metric.unit, "1") where metric.name == "container.cpu.usage"
+          - set(metric.name, "container.cpu.utilization") where metric.name == "container.cpu.usage"
+          - set(metric.unit, "1") where metric.name == "k8s.pod.cpu.usage"
+          - set(metric.name, "k8s.pod.cpu.utilization") where metric.name == "k8s.pod.cpu.usage"
+          - set(metric.unit, "1") where metric.name == "k8s.node.cpu.usage"
+          - set(metric.name, "k8s.node.cpu.utilization") where metric.name == "k8s.node.cpu.usage"
+      transform/profiles:
+        profile_statements:
+        - set(resource.attributes["service.name"], resource.attributes["service.annotation"])
+          where resource.attributes["service.name"] == nil and resource.attributes["service.annotation"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["service.label"])
+          where resource.attributes["service.name"] == nil and resource.attributes["service.label"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["k8s.label.instance"])
+          where resource.attributes["service.name"] == nil and resource.attributes["k8s.label.instance"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["k8s.label.name"])
+          where resource.attributes["service.name"] == nil and resource.attributes["k8s.label.name"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["k8s.deployment.name"])
+          where resource.attributes["service.name"] == nil and resource.attributes["k8s.deployment.name"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["k8s.replicaset.name"])
+          where resource.attributes["service.name"] == nil and resource.attributes["k8s.replicaset.name"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["k8s.statefulset.name"])
+          where resource.attributes["service.name"] == nil and resource.attributes["k8s.statefulset.name"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["k8s.daemonset.name"])
+          where resource.attributes["service.name"] == nil and resource.attributes["k8s.daemonset.name"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["k8s.cronjob.name"])
+          where resource.attributes["service.name"] == nil and resource.attributes["k8s.cronjob.name"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["k8s.job.name"])
+          where resource.attributes["service.name"] == nil and resource.attributes["k8s.job.name"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["k8s.pod.name"])
+          where resource.attributes["service.name"] == nil and resource.attributes["k8s.pod.name"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["k8s.container.name"])
+          where resource.attributes["service.name"] == nil and resource.attributes["k8s.container.name"]
+          != nil
+      transform/prometheus:
+        error_mode: ignore
+        metric_statements:
+        - context: metric
+          statements:
+          - replace_pattern(metric.name, "_total$", "") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_cpu_seconds_seconds$", "otelcol_process_cpu_seconds")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_runtime_heap_alloc_bytes_bytes$",
+            "otelcol_process_runtime_heap_alloc_bytes") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_runtime_total_alloc_bytes_bytes$",
+            "otelcol_process_runtime_total_alloc_bytes") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_runtime_total_sys_memory_bytes_bytes$",
+            "otelcol_process_runtime_total_sys_memory_bytes") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_fileconsumer_open_files$", "otelcol_fileconsumer_open_files_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_fileconsumer_reading_files$", "otelcol_fileconsumer_reading_files_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_ip_lookup_miss$", "otelcol_otelsvc_k8s_ip_lookup_miss_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_pod_added$", "otelcol_otelsvc_k8s_pod_added_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_pod_updated$", "otelcol_otelsvc_k8s_pod_updated_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_pod_deleted$", "otelcol_otelsvc_k8s_pod_deleted_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_processor_filter_spans\\.filtered$",
+            "otelcol_processor_filter_spans.filtered_ratio") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+        - context: resource
+          statements:
+          - set(resource.attributes["k8s.pod.ip"], resource.attributes["net.host.name"])
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - delete_key(resource.attributes, "service_name") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+        - context: datapoint
+          statements:
+          - delete_key(datapoint.attributes, "service_name") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - delete_key(datapoint.attributes, "otel_scope_name") where datapoint.attributes["service.name"]
+            == "opentelemetry-collector"
+      transform/semconv:
+        error_mode: ignore
+        trace_statements:
+        - context: span
+          statements:
+          - set(span.attributes["http.method"], span.attributes["http.request.method"])
+            where span.attributes["http.request.method"] != nil
+      transform/spanmetrics:
+        error_mode: silent
+        metric_statements:
+        - context: datapoint
+          statements:
+          - set(datapoint.attributes["status.code"], "STATUS_CODE_ERROR") where datapoint.attributes["status.code"]
+            == nil and instrumentation_scope.name == "spanmetricsconnector" and datapoint.attributes["otel.status_code"]
+            == "ERROR"
+          - set(datapoint.attributes["status.code"], "STATUS_CODE_OK") where datapoint.attributes["status.code"]
+            == nil and instrumentation_scope.name == "spanmetricsconnector" and datapoint.attributes["otel.status_code"]
+            == "OK"
+          - set(datapoint.attributes["status.code"], "STATUS_CODE_UNSET") where datapoint.attributes["status.code"]
+            == nil and instrumentation_scope.name == "spanmetricsconnector" and (datapoint.attributes["otel.status_code"]
+            == "UNSET" or datapoint.attributes["otel.status_code"] == nil)
+    receivers:
+      filelog:
+        exclude: []
+        force_flush_period: 0
+        include:
+        - /var/log/pods/*/*/*.log
+        include_file_name: false
+        include_file_path: true
+        operators:
+        - id: get-format
+          routes:
+          - expr: body matches "^\\{"
+            output: parser-docker
+          - expr: body matches "^[^ Z]+ "
+            output: parser-crio
+          - expr: body matches "^[^ Z]+Z"
+            output: parser-containerd
+          type: router
+        - id: parser-crio
+          regex: ^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$
+          timestamp:
+            layout: 2006-01-02T15:04:05.999999999Z07:00
+            layout_type: gotime
+            parse_from: attributes.time
+          type: regex_parser
+        - combine_field: attributes.log
+          combine_with: ""
+          id: crio-recombine
+          is_last_entry: attributes.logtag == 'F'
+          max_batch_size: 1000
+          max_log_size: 1048576
+          output: handle_empty_log
+          source_identifier: attributes["log.file.path"]
+          type: recombine
+        - id: parser-containerd
+          regex: ^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$
+          timestamp:
+            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+            parse_from: attributes.time
+          type: regex_parser
+        - combine_field: attributes.log
+          combine_with: ""
+          id: containerd-recombine
+          is_last_entry: attributes.logtag == 'F'
+          max_batch_size: 1000
+          max_log_size: 1048576
+          output: handle_empty_log
+          source_identifier: attributes["log.file.path"]
+          type: recombine
+        - id: parser-docker
+          timestamp:
+            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+            parse_from: attributes.time
+          type: json_parser
+        - combine_field: attributes.log
+          combine_with: ""
+          id: docker-recombine
+          is_last_entry: attributes.log endsWith "\n"
+          max_batch_size: 1000
+          max_log_size: 1048576
+          output: handle_empty_log
+          source_identifier: attributes["log.file.path"]
+          type: recombine
+        - field: attributes.log
+          id: handle_empty_log
+          if: attributes.log == nil
+          type: add
+          value: ""
+        - parse_from: attributes["log.file.path"]
+          regex: ^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]+)\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$
+          type: regex_parser
+        - from: attributes.stream
+          to: attributes["log.iostream"]
+          type: move
+        - from: attributes.container_name
+          to: resource["k8s.container.name"]
+          type: move
+        - from: attributes.namespace
+          to: resource["k8s.namespace.name"]
+          type: move
+        - from: attributes.pod_name
+          to: resource["k8s.pod.name"]
+          type: move
+        - from: attributes.restart_count
+          to: resource["k8s.container.restart_count"]
+          type: move
+        - from: attributes.uid
+          to: resource["k8s.pod.uid"]
+          type: move
+        - from: attributes.log
+          id: clean-up-log-record
+          to: body
+          type: move
+        - default: skip-collector-logs-recombine
+          routes:
+          - expr: (attributes["log.file.path"] matches "/var/log/pods/default_coralogix-opentelemetry.*_.*/opentelemetry-agent/.*.log")
+            output: collector-logs-recombine
+          type: router
+        - combine_field: body
+          combine_with: |2+
+
+          id: collector-logs-recombine
+          is_first_entry: body matches "^\\{"
+          max_batch_size: 1000
+          max_log_size: 1048576
+          source_identifier: attributes["log.file.path"]
+          type: recombine
+        - id: skip-collector-logs-recombine
+          type: noop
+        - field: body
+          if: (attributes["log.file.path"] matches "/var/log/pods/default_coralogix-opentelemetry.*_.*/opentelemetry-agent/.*.log")
+          regex: (?s)("stacktrace":"[^"]*)"}\n(.*)$
+          replace_with: $${1}\\n$${2}"}
+          type: regex_replace
+        - drop_ratio: 1
+          expr: (attributes["log.file.path"] matches "/var/log/pods/default_coralogix-opentelemetry.*_.*/opentelemetry-agent/.*.log")
+            and ((body contains "logRecord") or (body contains "ResourceLog"))
+          type: filter
+        - default: logs-collection-continue
+          routes:
+          - expr: (body matches "\"resource\":{.*?},?") and not (body matches "\"logger\":\"supervisor\\.collector\"")
+            output: parse-body
+          type: router
+        - id: parse-body
+          if: (attributes["log.file.path"] matches "/var/log/pods/default_coralogix-opentelemetry.*_.*/.*/.*.log")
+            and not (body matches "\"logger\":\"supervisor\\.collector\"")
+          on_error: send_quiet
+          parse_to: attributes["parsed_body_tmp"]
+          type: json_parser
+        - field: body
+          if: (attributes["log.file.path"] matches "/var/log/pods/default_coralogix-opentelemetry.*_.*/.*/.*.log")
+            and not (body matches "\"logger\":\"supervisor\\.collector\"")
+          on_error: send_quiet
+          regex: \"resource\":{.*?},?
+          replace_with: ""
+          type: regex_replace
+        - from: attributes["parsed_body_tmp"]["resource"]
+          if: (attributes["log.file.path"] matches "/var/log/pods/default_coralogix-opentelemetry.*_.*/.*/.*.log")
+            and not (body matches "\"logger\":\"supervisor\\.collector\"")
+          on_error: send_quiet
+          to: resource["attributes_tmp"]
+          type: move
+        - field: attributes["parsed_body_tmp"]
+          if: (attributes["log.file.path"] matches "/var/log/pods/default_coralogix-opentelemetry.*_.*/.*/.*.log")
+            and not (body matches "\"logger\":\"supervisor\\.collector\"")
+          on_error: send_quiet
+          type: remove
+        - field: resource["attributes_tmp"]
+          id: flatten-resource
+          if: (attributes["log.file.path"] matches "/var/log/pods/default_coralogix-opentelemetry.*_.*/.*/.*.log")
+            and not (body matches "\"logger\":\"supervisor\\.collector\"")
+          on_error: send_quiet
+          type: flatten
+        - id: logs-collection-continue
+          type: noop
+        retry_on_failure:
+          enabled: true
+        start_at: beginning
+        storage: file_storage
+      hostmetrics:
+        collection_interval: '30s'
+        root_path: /hostfs
+        scrapers:
+          cpu:
+            metrics:
+              system.cpu.utilization:
+                enabled: true
+          disk: null
+          filesystem:
+            exclude_fs_types:
+              fs_types:
+              - autofs
+              - binfmt_misc
+              - bpf
+              - cgroup2
+              - configfs
+              - debugfs
+              - devpts
+              - devtmpfs
+              - fusectl
+              - hugetlbfs
+              - iso9660
+              - mqueue
+              - nsfs
+              - overlay
+              - proc
+              - procfs
+              - pstore
+              - rpc_pipefs
+              - securityfs
+              - selinuxfs
+              - squashfs
+              - sysfs
+              - tracefs
+              match_type: strict
+            exclude_mount_points:
+              match_type: regexp
+              mount_points:
+              - /dev/*
+              - /proc/*
+              - /sys/*
+              - /run/k3s/containerd/*
+              - /run/containerd/runc/*
+              - /var/lib/docker/*
+              - /var/lib/kubelet/*
+              - /snap/*
+          load: null
+          memory:
+            metrics:
+              system.memory.utilization:
+                enabled: true
+          network: null
+      jaeger:
+        protocols:
+          grpc:
+            endpoint: ${env:MY_POD_IP}:14250
+          thrift_binary:
+            endpoint: ${env:MY_POD_IP}:6832
+          thrift_compact:
+            endpoint: ${env:MY_POD_IP}:6831
+          thrift_http:
+            endpoint: ${env:MY_POD_IP}:14268
+      kubeletstats:
+        auth_type: serviceAccount
+        collect_all_network_interfaces:
+          node: true
+          pod: true
+        collection_interval: '30s'
+        endpoint: ${env:K8S_NODE_IP}:10250
+        insecure_skip_verify: true
+      otlp:
+        protocols:
+          grpc:
+            endpoint: ${env:MY_POD_IP}:4317
+            max_recv_msg_size_mib: 20
+          http:
+            endpoint: ${env:MY_POD_IP}:4318
+      prometheus:
+        config:
+          scrape_configs:
+          - job_name: opentelemetry-collector
+            scrape_interval: '30s'
+            static_configs:
+            - targets:
+              - ${env:MY_POD_IP}:8888
+      prometheus/k8s_extra_metrics:
+        config:
+          scrape_configs:
+          - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            honor_timestamps: true
+            job_name: kubernetes-cadvisor
+            metrics_path: /metrics/cadvisor
+            scheme: https
+            static_configs:
+            - targets:
+              - ${env:K8S_NODE_IP}:10250
+            tls_config:
+              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              insecure_skip_verify: true
+      statsd:
+        endpoint: ${env:MY_POD_IP}:8125
+      zipkin:
+        endpoint: ${env:MY_POD_IP}:9411
+    service:
+      extensions:
+      - health_check
+      - file_storage
+      - opamp
+      - zpages
+      - pprof
+      pipelines:
+        logs:
+          exporters:
+          - coralogix
+          processors:
+          - memory_limiter
+          - resourcedetection/region
+          - resourcedetection/env
+          - resource/metadata
+          - k8sattributes
+          - batch
+          receivers:
+          - filelog
+          - otlp
+        logs/resource_catalog:
+          exporters:
+          - coralogix/resource_catalog
+          processors:
+          - memory_limiter
+          - resource/metadata
+          - k8sattributes
+          - resourcedetection/entity
+          - resourcedetection/region
+          - transform/entity-event
+          receivers:
+          - hostmetrics
+        metrics:
+          exporters:
+          - coralogix
+          processors:
+          - memory_limiter
+          - resourcedetection/region
+          - resourcedetection/env
+          - resource/metadata
+          - k8sattributes
+          - transform/kubeletstatscpu
+          - filter/k8s_extra_metrics
+          - transform/spanmetrics
+          - transform/prometheus
+          - batch
+          receivers:
+          - hostmetrics
+          - kubeletstats
+          - prometheus/k8s_extra_metrics
+          - spanmetrics
+          - spanmetrics/db
+          - prometheus
+          - otlp
+          - statsd
+        metrics/compact:
+          exporters:
+          - coralogix
+          processors:
+          - memory_limiter
+          - transform/spanmetrics
+          - batch
+          receivers:
+          - spanmetrics/compact
+        metrics/db_compact:
+          exporters:
+          - coralogix
+          processors:
+          - memory_limiter
+          - transform/spanmetrics
+          - batch
+          receivers:
+          - spanmetrics/db_compact
+        traces:
+          exporters:
+          - loadbalancing
+          - spanmetrics
+          - forward/db
+          - forward/compact
+          - forward/db_compact
+          processors:
+          - memory_limiter
+          - resourcedetection/region
+          - resourcedetection/env
+          - resource/metadata
+          - k8sattributes
+          - transform/spanmetrics
+          - redaction/spanname
+          - transform/semconv
+          - groupbytrace/transactions
+          - coralogix
+          - batch
+          receivers:
+          - jaeger
+          - zipkin
+          - otlp
+        traces/compact:
+          exporters:
+          - spanmetrics/compact
+          processors:
+          - transform/compact
+          - batch
+          receivers:
+          - forward/compact
+        traces/db:
+          exporters:
+          - spanmetrics/db
+          processors:
+          - filter/db_spanmetrics
+          - batch
+          receivers:
+          - forward/db
+        traces/db_compact:
+          exporters:
+          - spanmetrics/db_compact
+          processors:
+          - filter/db_compact_spanmetrics
+          - transform/db_compact
+          - batch
+          receivers:
+          - forward/db_compact
+      telemetry:
+        logs:
+          encoding: json
+          level: 'warn'
+        metrics:
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: ${env:MY_POD_IP}
+                  port: 8888
+                  without_scope_info: false
+                  without_type_suffix: false
+                  without_units: false
+        resource:
+          cx.agent.type: agent
+          k8s.daemonset.name: coralogix-opentelemetry
+          k8s.namespace.name: default
+          k8s.node.name: ${env:KUBE_NODE_NAME}
+          k8s.pod.name: ${env:KUBE_POD_NAME}
+          service.name: opentelemetry-collector
+---
+# Source: otel-integration/charts/opentelemetry-cluster-collector/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coralogix-opentelemetry-collector
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-cluster-collector-0.132.0
+    app.kubernetes.io/name: opentelemetry-cluster-collector
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+data:
+  relay: |
+    exporters:
+      coralogix:
+        application_name: otel
+        application_name_attributes:
+        - k8s.namespace.name
+        - service.namespace
+        domain: eu2.coralogix.com
+        domain_settings:
+          keepalive:
+            enabled: true
+            permit_without_stream: false
+            time: 30s
+            timeout: 10s
+        logs:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+        metrics:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+        private_key: ${env:CORALOGIX_PRIVATE_KEY}
+        profiles:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+            x-coralogix-ingress: otlp/v1.10.0
+        sending_queue:
+          batch:
+            flush_timeout: 250ms
+            max_size: 2097152
+            min_size: 1048576
+            sizer: bytes
+          enabled: true
+          num_consumers: 20
+          queue_size: 209715200
+          sizer: bytes
+        subsystem_name: integration
+        subsystem_name_attributes:
+        - k8s.deployment.name
+        - k8s.statefulset.name
+        - k8s.daemonset.name
+        - k8s.cronjob.name
+        - service.name
+        timeout: 30s
+        traces:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+      coralogix/resource_catalog:
+        application_name: resource
+        domain: eu2.coralogix.com
+        logs:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+            x-coralogix-ingress: metadata-as-otlp-logs/v1
+        private_key: ${CORALOGIX_PRIVATE_KEY}
+        sending_queue:
+          batch:
+            flush_timeout: 250ms
+            max_size: 2097152
+            min_size: 1048576
+            sizer: bytes
+          enabled: true
+          num_consumers: 20
+          queue_size: 209715200
+          sizer: bytes
+        subsystem_name: catalog
+        timeout: 30s
+      debug: {}
+    extensions:
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
+      k8s_observer:
+        auth_type: serviceAccount
+        observe_pods: true
+      opamp:
+        agent_description:
+          include_resource_attributes: true
+          non_identifying_attributes:
+            cx.agent.type: cluster-collector
+            cx.cluster.name: 'golden-render'
+            helm.chart.opentelemetry-cluster-collector.version: 0.132.0
+        server:
+          http:
+            endpoint: https://ingress.eu2.coralogix.com/opamp/v1
+            headers:
+              Authorization: Bearer ${env:CORALOGIX_PRIVATE_KEY}
+            polling_interval: 2m
+      pprof:
+        endpoint: localhost:1777
+      zpages:
+        endpoint: localhost:55679
+    processors:
+      batch:
+        send_batch_max_size: 2048
+        send_batch_size: 1024
+        timeout: 1s
+      filter/k8s_apiserver_metrics:
+        metrics:
+          metric:
+          - resource.attributes["service.name"] == "kubernetes-apiserver" and metric.name
+            != "kubernetes_build_info"
+      filter/workflow:
+        error_mode: silent
+        logs:
+          log_record:
+          - log.body["object"]["kind"] == "Pod" and not IsMatch(String(log.body["object"]["metadata"]["ownerReferences"]),
+            ".*StatefulSet.*|.*ReplicaSet.*|.*Job.*|.*DaemonSet.*")
+          - log.body["kind"] == "Pod" and not IsMatch(String(log.body["metadata"]["ownerReferences"]),
+            ".*StatefulSet.*|.*ReplicaSet.*|.*Job.*|.*DaemonSet.*")
+      k8sattributes:
+        extract:
+          deployment_name_from_replicaset: true
+          metadata:
+          - k8s.namespace.name
+          - k8s.deployment.name
+          - k8s.statefulset.name
+          - k8s.daemonset.name
+          - k8s.cronjob.name
+          - k8s.job.name
+          - k8s.node.name
+          - k8s.pod.name
+        passthrough: false
+        pod_association:
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.ip
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.uid
+        - sources:
+          - from: connection
+        - sources:
+          - from: resource_attribute
+            name: k8s.job.name
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
+      metricstransform/k8s-dashboard:
+        transforms:
+        - action: insert
+          include: k8s.pod.phase
+          match_type: strict
+          new_name: kube_pod_status_qos_class
+        - action: insert
+          include: k8s.pod.status_reason
+          match_type: strict
+          new_name: kube_pod_status_reason
+        - action: insert
+          include: k8s.node.allocatable_cpu
+          match_type: strict
+          new_name: kube_node_info
+        - action: insert
+          include: k8s.container.ready
+          match_type: strict
+          new_name: k8s.container.status.last_terminated_reason
+      resource/kube-events:
+        attributes:
+        - action: upsert
+          key: service.name
+          value: kube-events
+        - action: upsert
+          key: k8s.cluster.name
+          value: golden-render
+      resource/metadata:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: 'golden-render'
+        - action: upsert
+          key: cx.otel_integration.name
+          value: coralogix-integration-helm
+      resourcedetection/env:
+        detectors:
+        - system
+        - env
+        override: false
+        system:
+          resource_attributes:
+            host.id:
+              enabled: true
+        timeout: 2s
+      resourcedetection/region:
+        detectors:
+        - gcp
+        - ec2
+        - azure
+        - eks
+        eks:
+          node_from_env_var: K8S_NODE_NAME
+        override: true
+        timeout: 2s
+      resourcedetection/resource_catalog:
+        azure:
+          resource_attributes:
+            azure.resourcegroup.name:
+              enabled: false
+            azure.vm.name:
+              enabled: false
+            azure.vm.scaleset.name:
+              enabled: false
+            azure.vm.size:
+              enabled: false
+            host.id:
+              enabled: false
+            host.name:
+              enabled: false
+        detectors:
+        - gcp
+        - ec2
+        - azure
+        - eks
+        ec2:
+          resource_attributes:
+            host.id:
+              enabled: false
+            host.image.id:
+              enabled: false
+            host.name:
+              enabled: false
+            host.type:
+              enabled: false
+        eks:
+          node_from_env_var: K8S_NODE_NAME
+        gcp:
+          resource_attributes:
+            host.id:
+              enabled: false
+            host.name:
+              enabled: false
+            host.type:
+              enabled: false
+            k8s.cluster.name:
+              enabled: false
+        override: true
+        timeout: 2s
+      transform/entity-event:
+        error_mode: silent
+        log_statements:
+        - context: log
+          statements:
+          - set(log.attributes["otel.entity.interval"], Milliseconds(Duration("1h")))
+      transform/k8s-dashboard:
+        error_mode: ignore
+        metric_statements:
+        - context: metric
+          statements:
+          - set(metric.unit, "1") where metric.name == "k8s.pod.phase"
+          - set(metric.unit, "") where metric.name == "kube_node_info"
+          - set(metric.unit, "") where metric.name == "k8s.container.status.last_terminated_reason"
+        - context: datapoint
+          statements:
+          - set(datapoint.value_int, 1) where metric.name == "kube_pod_status_qos_class"
+          - set(datapoint.attributes["qos_class"], resource.attributes["k8s.pod.qos_class"])
+            where metric.name == "kube_pod_status_qos_class"
+          - set(datapoint.attributes["pod"], resource.attributes["k8s.pod.name"]) where
+            metric.name == "kube_pod_status_reason"
+          - set(datapoint.attributes["reason"], "Evicted") where metric.name == "kube_pod_status_reason"
+            and datapoint.value_int == 1
+          - set(datapoint.attributes["reason"], "NodeAffinity") where metric.name == "kube_pod_status_reason"
+            and datapoint.value_int == 2
+          - set(datapoint.attributes["reason"], "NodeLost") where metric.name == "kube_pod_status_reason"
+            and datapoint.value_int == 3
+          - set(datapoint.attributes["reason"], "Shutdown") where metric.name == "kube_pod_status_reason"
+            and datapoint.value_int == 4
+          - set(datapoint.attributes["reason"], "UnexpectedAdmissionError") where metric.name
+            == "kube_pod_status_reason" and datapoint.value_int == 5
+          - set(datapoint.value_int, 0) where metric.name == "kube_pod_status_reason"
+            and datapoint.value_int == 6
+          - set(datapoint.value_int, 1) where metric.name == "kube_pod_status_reason"
+            and datapoint.value_int != 0
+          - set(datapoint.value_int, 1) where metric.name == "kube_node_info"
+          - set(datapoint.attributes["kubelet_version"], resource.attributes["k8s.kubelet.version"])
+            where metric.name == "kube_node_info"
+          - set(datapoint.value_int, 1) where metric.name == "k8s.container.status.last_terminated_reason"
+          - set(datapoint.attributes["reason"], "") where metric.name == "k8s.container.status.last_terminated_reason"
+          - set(datapoint.attributes["reason"], resource.attributes["k8s.container.status.last_terminated_reason"])
+            where metric.name == "k8s.container.status.last_terminated_reason"
+        - context: resource
+          statements:
+          - delete_key(resource.attributes, "k8s.container.status.last_terminated_reason")
+          - delete_key(resource.attributes, "k8s.pod.qos_class")
+          - delete_key(resource.attributes, "k8s.kubelet.version")
+      transform/kube-events:
+        log_statements:
+        - context: log
+          statements:
+          - keep_keys(log.body["object"], ["type", "eventTime", "reason", "regarding",
+            "note", "metadata", "deprecatedFirstTimestamp", "deprecatedLastTimestamp"])
+            where IsMap(log.body) and IsMap(log.body["object"])
+          - keep_keys(log.body["object"]["metadata"], ["creationTimestamp"]) where IsMap(log.body)
+            and IsMap(log.body["object"]) and IsMap(log.body["object"]["metadata"])
+          - keep_keys(log.body["object"]["regarding"], ["kind", "name", "namespace"])
+            where IsMap(log.body) and IsMap(log.body["object"]) and IsMap(log.body["object"]["regarding"])
+      transform/prometheus:
+        error_mode: ignore
+        metric_statements:
+        - context: metric
+          statements:
+          - replace_pattern(metric.name, "_total$", "") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_cpu_seconds_seconds$", "otelcol_process_cpu_seconds")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_runtime_heap_alloc_bytes_bytes$",
+            "otelcol_process_runtime_heap_alloc_bytes") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_runtime_total_alloc_bytes_bytes$",
+            "otelcol_process_runtime_total_alloc_bytes") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_runtime_total_sys_memory_bytes_bytes$",
+            "otelcol_process_runtime_total_sys_memory_bytes") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_fileconsumer_open_files$", "otelcol_fileconsumer_open_files_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_fileconsumer_reading_files$", "otelcol_fileconsumer_reading_files_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_ip_lookup_miss$", "otelcol_otelsvc_k8s_ip_lookup_miss_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_pod_added$", "otelcol_otelsvc_k8s_pod_added_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_pod_updated$", "otelcol_otelsvc_k8s_pod_updated_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_pod_deleted$", "otelcol_otelsvc_k8s_pod_deleted_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_processor_filter_spans\\.filtered$",
+            "otelcol_processor_filter_spans.filtered_ratio") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+        - context: resource
+          statements:
+          - set(resource.attributes["k8s.pod.ip"], resource.attributes["net.host.name"])
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - delete_key(resource.attributes, "service_name") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+        - context: datapoint
+          statements:
+          - delete_key(datapoint.attributes, "service_name") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - delete_key(datapoint.attributes, "otel_scope_name") where datapoint.attributes["service.name"]
+            == "opentelemetry-collector"
+    receivers:
+      k8s_cluster:
+        allocatable_types_to_report:
+        - cpu
+        - memory
+        collection_interval: '30s'
+        metrics:
+          k8s.pod.status_reason:
+            enabled: true
+        resource_attributes:
+          k8s.container.status.last_terminated_reason:
+            enabled: true
+          k8s.kubelet.version:
+            enabled: true
+          k8s.pod.qos_class:
+            enabled: true
+      k8sobjects:
+        objects:
+        - exclude_watch_type:
+          - DELETED
+          group: events.k8s.io
+          mode: watch
+          name: events
+      k8sobjects/resource_catalog:
+        objects:
+        - group: ""
+          mode: pull
+          name: namespaces
+        - group: ""
+          mode: pull
+          name: nodes
+        - group: ""
+          mode: pull
+          name: persistentvolumeclaims
+        - group: ""
+          mode: pull
+          name: persistentvolumes
+        - group: ""
+          mode: pull
+          name: pods
+        - group: ""
+          mode: pull
+          name: services
+        - group: apps
+          mode: pull
+          name: daemonsets
+        - group: apps
+          mode: pull
+          name: deployments
+        - group: apps
+          mode: pull
+          name: replicasets
+        - group: apps
+          mode: pull
+          name: statefulsets
+        - group: autoscaling
+          mode: pull
+          name: horizontalpodautoscalers
+        - group: batch
+          mode: pull
+          name: cronjobs
+        - group: batch
+          mode: pull
+          name: jobs
+        - group: extensions
+          mode: pull
+          name: ingresses
+        - group: networking.k8s.io
+          mode: pull
+          name: ingresses
+        - group: policy
+          mode: pull
+          name: poddisruptionbudgets
+        - group: rbac.authorization.k8s.io
+          mode: pull
+          name: clusterrolebindings
+        - group: rbac.authorization.k8s.io
+          mode: pull
+          name: clusterroles
+        - group: rbac.authorization.k8s.io
+          mode: pull
+          name: rolebindings
+        - group: rbac.authorization.k8s.io
+          mode: pull
+          name: roles
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: ""
+          mode: watch
+          name: namespaces
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: ""
+          mode: watch
+          name: nodes
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: ""
+          mode: watch
+          name: persistentvolumeclaims
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: ""
+          mode: watch
+          name: persistentvolumes
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: ""
+          mode: watch
+          name: pods
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: apps
+          mode: watch
+          name: daemonsets
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: apps
+          mode: watch
+          name: deployments
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: apps
+          mode: watch
+          name: replicasets
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: apps
+          mode: watch
+          name: statefulsets
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: autoscaling
+          mode: watch
+          name: horizontalpodautoscalers
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: batch
+          mode: watch
+          name: cronjobs
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: batch
+          mode: watch
+          name: jobs
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: extensions
+          mode: watch
+          name: ingresses
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: networking.k8s.io
+          mode: watch
+          name: ingresses
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: policy
+          mode: watch
+          name: poddisruptionbudgets
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: rbac.authorization.k8s.io
+          mode: watch
+          name: clusterrolebindings
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: rbac.authorization.k8s.io
+          mode: watch
+          name: clusterroles
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: rbac.authorization.k8s.io
+          mode: watch
+          name: rolebindings
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: rbac.authorization.k8s.io
+          mode: watch
+          name: roles
+      otlp:
+        protocols:
+          grpc:
+            endpoint: ${env:MY_POD_IP}:4317
+            max_recv_msg_size_mib: 20
+          http:
+            endpoint: ${env:MY_POD_IP}:4318
+      prometheus:
+        config:
+          scrape_configs:
+          - job_name: opentelemetry-collector
+            scrape_interval: '30s'
+            static_configs:
+            - targets:
+              - ${env:MY_POD_IP}:8888
+      prometheus/k8s_apiserver_metrics:
+        config:
+          scrape_configs:
+          - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            honor_timestamps: true
+            job_name: kubernetes-apiserver
+            kubernetes_sd_configs:
+            - role: endpoints
+            relabel_configs:
+            - action: keep
+              regex: default;kubernetes;https
+              source_labels:
+              - __meta_kubernetes_namespace
+              - __meta_kubernetes_service_name
+              - __meta_kubernetes_endpoint_port_name
+            scheme: https
+            tls_config:
+              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              insecure_skip_verify: true
+    service:
+      extensions:
+      - health_check
+      - k8s_observer
+      - opamp
+      - zpages
+      - pprof
+      pipelines:
+        logs:
+          exporters:
+          - coralogix
+          processors:
+          - memory_limiter
+          - resource/metadata
+          - resource/kube-events
+          - resourcedetection/region
+          - resourcedetection/env
+          - k8sattributes
+          - transform/kube-events
+          - batch
+          receivers:
+          - k8sobjects
+          - otlp
+        logs/resource_catalog:
+          exporters:
+          - coralogix/resource_catalog
+          processors:
+          - memory_limiter
+          - resourcedetection/resource_catalog
+          - transform/entity-event
+          - filter/workflow
+          - resource/metadata
+          - batch
+          receivers:
+          - k8sobjects/resource_catalog
+        metrics:
+          exporters:
+          - coralogix
+          processors:
+          - memory_limiter
+          - resource/metadata
+          - resourcedetection/region
+          - resourcedetection/env
+          - k8sattributes
+          - metricstransform/k8s-dashboard
+          - transform/k8s-dashboard
+          - filter/k8s_apiserver_metrics
+          - transform/prometheus
+          - batch
+          receivers:
+          - k8s_cluster
+          - prometheus/k8s_apiserver_metrics
+          - prometheus
+          - otlp
+        traces:
+          exporters:
+          - debug
+          - coralogix
+          processors:
+          - memory_limiter
+          - resource/metadata
+          - resourcedetection/region
+          - resourcedetection/env
+          - k8sattributes
+          - batch
+          receivers:
+          - otlp
+      telemetry:
+        logs:
+          encoding: json
+          level: 'warn'
+        metrics:
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: ${env:MY_POD_IP}
+                  port: 8888
+                  without_scope_info: false
+                  without_type_suffix: false
+                  without_units: false
+        resource:
+          cx.agent.type: cluster-collector
+          service.name: opentelemetry-collector
+---
+# Source: otel-integration/charts/opentelemetry-gateway/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coralogix-opentelemetry-gateway
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-gateway-0.132.0
+    app.kubernetes.io/name: opentelemetry-gateway
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+data:
+  relay: |
+    exporters:
+      coralogix:
+        application_name: otel
+        application_name_attributes:
+        - k8s.namespace.name
+        - service.namespace
+        domain: eu2.coralogix.com
+        domain_settings:
+          keepalive:
+            enabled: true
+            permit_without_stream: false
+            time: 30s
+            timeout: 10s
+        logs:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+        metrics:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+        private_key: ${env:CORALOGIX_PRIVATE_KEY}
+        profiles:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+            x-coralogix-ingress: otlp/v1.10.0
+        sending_queue:
+          batch:
+            flush_timeout: 250ms
+            max_size: 2097152
+            min_size: 1048576
+            sizer: bytes
+          enabled: true
+          num_consumers: 20
+          queue_size: 209715200
+          sizer: bytes
+        subsystem_name: integration
+        subsystem_name_attributes:
+        - k8s.deployment.name
+        - k8s.statefulset.name
+        - k8s.daemonset.name
+        - k8s.cronjob.name
+        - service.name
+        timeout: 30s
+        traces:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+      debug: {}
+    extensions:
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
+      opamp:
+        agent_description:
+          include_resource_attributes: true
+          non_identifying_attributes:
+            cx.agent.type: gateway
+            cx.cluster.name: 'golden-render'
+            helm.chart.opentelemetry-gateway.version: 0.132.0
+        server:
+          http:
+            endpoint: https://ingress.eu2.coralogix.com/opamp/v1
+            headers:
+              Authorization: Bearer ${env:CORALOGIX_PRIVATE_KEY}
+            polling_interval: 2m
+      pprof:
+        endpoint: localhost:1777
+      zpages:
+        endpoint: localhost:55679
+    processors:
+      batch:
+        send_batch_max_size: 2048
+        send_batch_size: 1024
+        timeout: 1s
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
+      resource/metadata:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: 'golden-render'
+        - action: upsert
+          key: cx.otel_integration.name
+          value: coralogix-integration-helm
+      resourcedetection/env:
+        detectors:
+        - system
+        - env
+        override: false
+        system:
+          resource_attributes:
+            host.id:
+              enabled: true
+        timeout: 2s
+      resourcedetection/region:
+        detectors:
+        - gcp
+        - ec2
+        - azure
+        - eks
+        eks:
+          node_from_env_var: K8S_NODE_NAME
+        override: true
+        timeout: 2s
+      tail_sampling:
+        policies:
+        - name: errors-policy
+          status_code:
+            status_codes:
+            - ERROR
+          type: status_code
+        - name: randomized-policy
+          probabilistic:
+            sampling_percentage: 10
+          type: probabilistic
+      transform/prometheus:
+        error_mode: ignore
+        metric_statements:
+        - context: metric
+          statements:
+          - replace_pattern(metric.name, "_total$", "") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_cpu_seconds_seconds$", "otelcol_process_cpu_seconds")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_runtime_heap_alloc_bytes_bytes$",
+            "otelcol_process_runtime_heap_alloc_bytes") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_runtime_total_alloc_bytes_bytes$",
+            "otelcol_process_runtime_total_alloc_bytes") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_runtime_total_sys_memory_bytes_bytes$",
+            "otelcol_process_runtime_total_sys_memory_bytes") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_fileconsumer_open_files$", "otelcol_fileconsumer_open_files_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_fileconsumer_reading_files$", "otelcol_fileconsumer_reading_files_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_ip_lookup_miss$", "otelcol_otelsvc_k8s_ip_lookup_miss_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_pod_added$", "otelcol_otelsvc_k8s_pod_added_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_pod_updated$", "otelcol_otelsvc_k8s_pod_updated_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_pod_deleted$", "otelcol_otelsvc_k8s_pod_deleted_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_processor_filter_spans\\.filtered$",
+            "otelcol_processor_filter_spans.filtered_ratio") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+        - context: resource
+          statements:
+          - set(resource.attributes["k8s.pod.ip"], resource.attributes["net.host.name"])
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - delete_key(resource.attributes, "service_name") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+        - context: datapoint
+          statements:
+          - delete_key(datapoint.attributes, "service_name") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - delete_key(datapoint.attributes, "otel_scope_name") where datapoint.attributes["service.name"]
+            == "opentelemetry-collector"
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: ${env:MY_POD_IP}:4317
+            max_recv_msg_size_mib: 20
+          http:
+            endpoint: ${env:MY_POD_IP}:4318
+      prometheus:
+        config:
+          scrape_configs:
+          - job_name: opentelemetry-collector
+            scrape_interval: '30s'
+            static_configs:
+            - targets:
+              - ${env:MY_POD_IP}:8888
+    service:
+      extensions:
+      - health_check
+      - opamp
+      - zpages
+      - pprof
+      pipelines:
+        logs:
+          exporters:
+          - debug
+          - coralogix
+          processors:
+          - memory_limiter
+          - resource/metadata
+          - batch
+          receivers:
+          - otlp
+        metrics:
+          exporters:
+          - coralogix
+          processors:
+          - memory_limiter
+          - resource/metadata
+          - resourcedetection/region
+          - resourcedetection/env
+          - transform/prometheus
+          - batch
+          receivers:
+          - prometheus
+          - otlp
+        traces:
+          exporters:
+          - coralogix
+          processors:
+          - memory_limiter
+          - resource/metadata
+          - tail_sampling
+          - batch
+          receivers:
+          - otlp
+      telemetry:
+        logs:
+          encoding: json
+          level: 'warn'
+        metrics:
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: ${env:MY_POD_IP}
+                  port: 8888
+                  without_scope_info: false
+                  without_type_suffix: false
+                  without_units: false
+        resource:
+          k8s.deployment.name: coralogix-opentelemetry-gateway
+          k8s.namespace.name: default
+          k8s.node.name: ${env:KUBE_NODE_NAME}
+          k8s.pod.name: ${env:KUBE_POD_NAME}
+          service.name: opentelemetry-collector
+---
+# Source: otel-integration/charts/opentelemetry-agent/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: coralogix-opentelemetry-agent
+  labels:
+    helm.sh/chart: opentelemetry-agent-0.132.0
+    app.kubernetes.io/name: opentelemetry-agent
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "namespaces"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes", "nodes/stats", "nodes/metrics"]
+    verbs: ["get", "watch", "list"]
+  - nonResourceURLs:
+    - "/metrics"
+    verbs: ["get"]
+---
+# Source: otel-integration/charts/opentelemetry-cluster-collector/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: coralogix-opentelemetry-collector
+  labels:
+    helm.sh/chart: opentelemetry-cluster-collector-0.132.0
+    app.kubernetes.io/name: opentelemetry-cluster-collector
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "namespaces"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events", "namespaces", "namespaces/status", "nodes", "nodes/spec", "pods", "pods/status", "replicationcontrollers", "replicationcontrollers/status", "resourcequotas", "services" ]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources: ["daemonsets", "deployments", "replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods", "endpoints", "nodes/stats", "nodes/metrics", "nodes", "services"]
+    verbs: ["get", "watch", "list"]
+  - nonResourceURLs:
+    - "/metrics"
+    verbs: ["get"]
+  - apiGroups: ["events.k8s.io"]
+    resources: ["events"]
+    verbs: ["watch", "list"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["aws-auth"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources:
+    - namespaces
+    - nodes
+    - persistentvolumeclaims
+    - persistentvolumes
+    - pods
+    - services
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources:
+    - daemonsets
+    - deployments
+    - replicasets
+    - statefulsets
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["autoscaling"]
+    resources:
+    - horizontalpodautoscalers
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources:
+    - cronjobs
+    - jobs
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources:
+    - ingresses
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+    - ingresses
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["policy"]
+    resources:
+    - poddisruptionbudgets
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources:
+    - clusterrolebindings
+    - clusterroles
+    - rolebindings
+    - roles
+    verbs: ["get", "list", "watch"]
+---
+# Source: otel-integration/charts/opentelemetry-agent/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: coralogix-opentelemetry-agent
+  labels:
+    helm.sh/chart: opentelemetry-agent-0.132.0
+    app.kubernetes.io/name: opentelemetry-agent
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: coralogix-opentelemetry-agent
+subjects:
+- kind: ServiceAccount
+  name: coralogix-opentelemetry
+  namespace: default
+---
+# Source: otel-integration/charts/opentelemetry-cluster-collector/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: coralogix-opentelemetry-collector
+  labels:
+    helm.sh/chart: opentelemetry-cluster-collector-0.132.0
+    app.kubernetes.io/name: opentelemetry-cluster-collector
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: coralogix-opentelemetry-collector
+subjects:
+- kind: ServiceAccount
+  name: coralogix-opentelemetry-collector
+  namespace: default
+---
+# Source: otel-integration/charts/opentelemetry-cluster-collector/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: coralogix-opentelemetry-collector
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-cluster-collector-0.132.0
+    app.kubernetes.io/name: opentelemetry-cluster-collector
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+    component: standalone-collector
+spec:
+  type: ClusterIP
+  ports:
+
+    - name: otlp
+      port: 4317
+      targetPort: 4317
+      protocol: TCP
+      appProtocol: grpc
+  selector:
+    app.kubernetes.io/name: opentelemetry-cluster-collector
+    app.kubernetes.io/instance: render-check
+    component: standalone-collector
+  internalTrafficPolicy: Cluster
+---
+# Source: otel-integration/charts/opentelemetry-gateway/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: coralogix-opentelemetry-gateway
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-gateway-0.132.0
+    app.kubernetes.io/name: opentelemetry-gateway
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+    component: standalone-collector
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+
+    - name: otlp
+      port: 4317
+      targetPort: 4317
+      protocol: TCP
+      appProtocol: grpc
+  selector:
+    app.kubernetes.io/name: opentelemetry-gateway
+    app.kubernetes.io/instance: render-check
+    component: standalone-collector
+  internalTrafficPolicy: Cluster
+---
+# Source: otel-integration/charts/opentelemetry-agent/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: coralogix-opentelemetry-agent
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-agent-0.132.0
+    app.kubernetes.io/name: opentelemetry-agent
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opentelemetry-agent
+      app.kubernetes.io/instance: render-check
+      component: agent-collector
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: 086ec7abfaedc6594f0c29b1910dcb88098a0b069ea991f734f38ce294ceb9d8
+
+      labels:
+        app.kubernetes.io/name: opentelemetry-agent
+        app.kubernetes.io/instance: render-check
+        component: agent-collector
+
+    spec:
+
+      serviceAccountName: coralogix-opentelemetry
+      securityContext:
+        {}
+      containers:
+        - name: opentelemetry-agent
+          command:
+            - /otelcol-contrib
+            - --config=/conf/relay.yaml
+            - --feature-gates=+service.profilesSupport
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+          image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.152.1"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: jaeger-binary
+              containerPort: 6832
+              protocol: TCP
+              hostPort: 6832
+            - name: jaeger-compact
+              containerPort: 6831
+              protocol: UDP
+              hostPort: 6831
+            - name: jaeger-grpc
+              containerPort: 14250
+              protocol: TCP
+              hostPort: 14250
+            - name: jaeger-thrift
+              containerPort: 14268
+              protocol: TCP
+              hostPort: 14268
+            - name: otlp
+              containerPort: 4317
+              protocol: TCP
+              hostPort: 4317
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+              hostPort: 4318
+            - name: statsd
+              containerPort: 8125
+              protocol: UDP
+              hostPort: 8125
+            - name: zipkin
+              containerPort: 9411
+              protocol: TCP
+              hostPort: 9411
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: KUBE_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+            - name: GOMEMLIMIT
+              value: "1525MiB"
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "k8s.node.name=$(K8S_NODE_NAME),deployment.environment.name=golden-render"
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: CORALOGIX_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: PRIVATE_KEY
+                  name: coralogix-keys
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          resources:
+            limits:
+              cpu: 1
+              memory: 2G
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          volumeMounts:
+            - mountPath: /conf
+              name: opentelemetry-agent-configmap
+            - name: varlogpods
+              mountPath: /var/log/pods
+              readOnly: true
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+            - name: varlibotelcol
+              mountPath: /var/lib/otelcol
+            - name: hostfs
+              mountPath: /hostfs
+              readOnly: true
+              mountPropagation: HostToContainer
+            - mountPath: /etc/machine-id
+              mountPropagation: HostToContainer
+              name: etcmachineid
+              readOnly: true
+            - mountPath: /var/lib/dbus/machine-id
+              mountPropagation: HostToContainer
+              name: varlibdbusmachineid
+              readOnly: true
+      volumes:
+        - name: opentelemetry-agent-configmap
+          configMap:
+            name: coralogix-opentelemetry-agent
+            items:
+              - key: relay
+                path: relay.yaml
+        - name: varlogpods
+          hostPath:
+            path: /var/log/pods
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+        - name: varlibotelcol
+          hostPath:
+            path: /var/lib/otelcol
+            type: DirectoryOrCreate
+        - name: hostfs
+          hostPath:
+            path: /
+        - name: etcmachineid
+          hostPath:
+            path: /etc/machine-id
+        - name: varlibdbusmachineid
+          hostPath:
+            path: /var/lib/dbus/machine-id
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - operator: Exists
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+---
+# Source: otel-integration/charts/opentelemetry-cluster-collector/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coralogix-opentelemetry-collector
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-cluster-collector-0.132.0
+    app.kubernetes.io/name: opentelemetry-cluster-collector
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opentelemetry-cluster-collector
+      app.kubernetes.io/instance: render-check
+      component: standalone-collector
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: f40e8af2bd36b2ae59a97c43ca3e468cf2e274a67711e09bc9442d102c56eb47
+
+      labels:
+        app.kubernetes.io/name: opentelemetry-cluster-collector
+        app.kubernetes.io/instance: render-check
+        component: standalone-collector
+
+    spec:
+
+      serviceAccountName: coralogix-opentelemetry-collector
+      securityContext:
+        {}
+      containers:
+        - name: opentelemetry-cluster-collector
+          command:
+            - /otelcol-contrib
+            - --config=/conf/relay.yaml
+          securityContext:
+            {}
+          image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.152.1"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: otlp
+              containerPort: 4317
+              protocol: TCP
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: GOMEMLIMIT
+              value: "1525MiB"
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "deployment.environment.name=golden-render"
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: CORALOGIX_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: PRIVATE_KEY
+                  name: coralogix-keys
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          startupProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            failureThreshold: 4
+            httpGet:
+              port: 13133
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          resources:
+            limits:
+              cpu: 1
+              memory: 2G
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          volumeMounts:
+            - mountPath: /conf
+              name: opentelemetry-cluster-collector-configmap
+            - mountPath: /etc/machine-id
+              mountPropagation: HostToContainer
+              name: etcmachineid
+              readOnly: true
+            - mountPath: /var/lib/dbus/machine-id
+              mountPropagation: HostToContainer
+              name: varlibdbusmachineid
+              readOnly: true
+      volumes:
+        - name: opentelemetry-cluster-collector-configmap
+          configMap:
+            name: coralogix-opentelemetry-collector
+            items:
+              - key: relay
+                path: relay.yaml
+        - name: etcmachineid
+          hostPath:
+            path: /etc/machine-id
+        - name: varlibdbusmachineid
+          hostPath:
+            path: /var/lib/dbus/machine-id
+      nodeSelector:
+        kubernetes.io/os: linux
+      hostNetwork: false
+---
+# Source: otel-integration/charts/opentelemetry-gateway/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coralogix-opentelemetry-gateway
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-gateway-0.132.0
+    app.kubernetes.io/name: opentelemetry-gateway
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+spec:
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opentelemetry-gateway
+      app.kubernetes.io/instance: render-check
+      component: standalone-collector
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: c72601c1f46e7a2233aa40dfa4a5798ce3e889be6bcd1c90743d669b63c1d9a7
+
+      labels:
+        app.kubernetes.io/name: opentelemetry-gateway
+        app.kubernetes.io/instance: render-check
+        component: standalone-collector
+
+    spec:
+
+      serviceAccountName: coralogix-opentelemetry-gateway
+      securityContext:
+        {}
+      containers:
+        - name: opentelemetry-gateway
+          command:
+            - /otelcol-contrib
+            - --config=/conf/relay.yaml
+          securityContext:
+            {}
+          image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.152.1"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: otlp
+              containerPort: 4317
+              protocol: TCP
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: KUBE_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "k8s.node.name=$(K8S_NODE_NAME),deployment.environment.name=golden-render"
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: CORALOGIX_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: PRIVATE_KEY
+                  name: coralogix-keys
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          volumeMounts:
+            - mountPath: /conf
+              name: opentelemetry-gateway-configmap
+            - mountPath: /etc/machine-id
+              mountPropagation: HostToContainer
+              name: etcmachineid
+              readOnly: true
+            - mountPath: /var/lib/dbus/machine-id
+              mountPropagation: HostToContainer
+              name: varlibdbusmachineid
+              readOnly: true
+      volumes:
+        - name: opentelemetry-gateway-configmap
+          configMap:
+            name: coralogix-opentelemetry-gateway
+            items:
+              - key: relay
+                path: relay.yaml
+        - name: etcmachineid
+          hostPath:
+            path: /etc/machine-id
+        - name: varlibdbusmachineid
+          hostPath:
+            path: /var/lib/dbus/machine-id
+      nodeSelector:
+        kubernetes.io/os: linux
+      hostNetwork: false

--- a/otel-integration/k8s-helm/tests/golden/windows.yaml
+++ b/otel-integration/k8s-helm/tests/golden/windows.yaml
@@ -1,0 +1,2842 @@
+---
+# Source: otel-integration/charts/opentelemetry-agent-windows/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: coralogix-opentelemetry-windows
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-agent-windows-0.132.0
+    app.kubernetes.io/name: opentelemetry-agent-windows
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: otel-integration/charts/opentelemetry-agent/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: coralogix-opentelemetry
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-agent-0.132.0
+    app.kubernetes.io/name: opentelemetry-agent
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: otel-integration/charts/opentelemetry-cluster-collector/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: coralogix-opentelemetry-collector
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-cluster-collector-0.132.0
+    app.kubernetes.io/name: opentelemetry-cluster-collector
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: otel-integration/charts/opentelemetry-agent-windows/templates/configmap-agent.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coralogix-opentelemetry-windows-agent
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-agent-windows-0.132.0
+    app.kubernetes.io/name: opentelemetry-agent-windows
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+data:
+  relay: |
+    exporters:
+      coralogix:
+        application_name: otel
+        application_name_attributes:
+        - k8s.namespace.name
+        - service.namespace
+        domain: eu2.coralogix.com
+        domain_settings:
+          keepalive:
+            enabled: true
+            permit_without_stream: false
+            time: 30s
+            timeout: 10s
+        logs:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+        metrics:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+        private_key: ${env:CORALOGIX_PRIVATE_KEY}
+        profiles:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+            x-coralogix-ingress: otlp/v1.10.0
+        sending_queue:
+          batch:
+            flush_timeout: 250ms
+            max_size: 2097152
+            min_size: 1048576
+            sizer: bytes
+          enabled: true
+          num_consumers: 20
+          queue_size: 209715200
+          sizer: bytes
+        subsystem_name: integration
+        subsystem_name_attributes:
+        - k8s.deployment.name
+        - k8s.statefulset.name
+        - k8s.daemonset.name
+        - k8s.cronjob.name
+        - service.name
+        timeout: 30s
+        traces:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+      debug: {}
+    extensions:
+      file_storage:
+        directory: /var/lib/otelcol
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
+      opamp:
+        agent_description:
+          include_resource_attributes: true
+          non_identifying_attributes:
+            cx.agent.type: agent
+            cx.cluster.name: 'golden-render'
+            helm.chart.opentelemetry-agent-windows.version: 0.132.0
+        server:
+          http:
+            endpoint: https://ingress.eu2.coralogix.com/opamp/v1
+            headers:
+              Authorization: Bearer ${env:CORALOGIX_PRIVATE_KEY}
+            polling_interval: 2m
+      pprof:
+        endpoint: localhost:1777
+      zpages:
+        endpoint: localhost:55679
+    processors:
+      batch:
+        send_batch_max_size: 2048
+        send_batch_size: 1024
+        timeout: 1s
+      k8sattributes:
+        extract:
+          deployment_name_from_replicaset: true
+          metadata:
+          - k8s.namespace.name
+          - k8s.deployment.name
+          - k8s.statefulset.name
+          - k8s.daemonset.name
+          - k8s.cronjob.name
+          - k8s.job.name
+          - k8s.node.name
+          - k8s.pod.name
+        filter:
+          node_from_env_var: K8S_NODE_NAME
+        passthrough: false
+        pod_association:
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.ip
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.uid
+        - sources:
+          - from: connection
+        - sources:
+          - from: resource_attribute
+            name: k8s.job.name
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
+      resource/metadata:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: 'golden-render'
+        - action: upsert
+          key: cx.otel_integration.name
+          value: coralogix-integration-helm
+      resourcedetection/env:
+        detectors:
+        - system
+        - env
+        override: false
+        system:
+          resource_attributes:
+            host.id:
+              enabled: true
+        timeout: 2s
+      resourcedetection/region:
+        detectors:
+        - gcp
+        - ec2
+        - azure
+        - eks
+        eks:
+          node_from_env_var: K8S_NODE_NAME
+        override: true
+        timeout: 2s
+      transform/kubeletstatscpu:
+        error_mode: ignore
+        metric_statements:
+        - context: metric
+          statements:
+          - set(metric.unit, "1") where metric.name == "container.cpu.usage"
+          - set(metric.name, "container.cpu.utilization") where metric.name == "container.cpu.usage"
+          - set(metric.unit, "1") where metric.name == "k8s.pod.cpu.usage"
+          - set(metric.name, "k8s.pod.cpu.utilization") where metric.name == "k8s.pod.cpu.usage"
+          - set(metric.unit, "1") where metric.name == "k8s.node.cpu.usage"
+          - set(metric.name, "k8s.node.cpu.utilization") where metric.name == "k8s.node.cpu.usage"
+      transform/prometheus:
+        error_mode: ignore
+        metric_statements:
+        - context: metric
+          statements:
+          - replace_pattern(metric.name, "_total$", "") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_cpu_seconds_seconds$", "otelcol_process_cpu_seconds")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_runtime_heap_alloc_bytes_bytes$",
+            "otelcol_process_runtime_heap_alloc_bytes") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_runtime_total_alloc_bytes_bytes$",
+            "otelcol_process_runtime_total_alloc_bytes") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_runtime_total_sys_memory_bytes_bytes$",
+            "otelcol_process_runtime_total_sys_memory_bytes") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_fileconsumer_open_files$", "otelcol_fileconsumer_open_files_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_fileconsumer_reading_files$", "otelcol_fileconsumer_reading_files_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_ip_lookup_miss$", "otelcol_otelsvc_k8s_ip_lookup_miss_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_pod_added$", "otelcol_otelsvc_k8s_pod_added_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_pod_updated$", "otelcol_otelsvc_k8s_pod_updated_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_pod_deleted$", "otelcol_otelsvc_k8s_pod_deleted_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_processor_filter_spans\\.filtered$",
+            "otelcol_processor_filter_spans.filtered_ratio") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+        - context: resource
+          statements:
+          - set(resource.attributes["k8s.pod.ip"], resource.attributes["net.host.name"])
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - delete_key(resource.attributes, "service_name") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+        - context: datapoint
+          statements:
+          - delete_key(datapoint.attributes, "service_name") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - delete_key(datapoint.attributes, "otel_scope_name") where datapoint.attributes["service.name"]
+            == "opentelemetry-collector"
+    receivers:
+      filelog:
+        exclude:
+        - C:\var\log\pods\default_coralogix-opentelemetry-windows*_*\opentelemetry-agent-windows\*.log
+        force_flush_period: 0
+        include:
+        - C:\var\log\pods\*\*\*.log
+        include_file_name: false
+        include_file_path: true
+        operators:
+        - id: get-format
+          routes:
+          - expr: body matches "^\\{"
+            output: parser-docker
+          - expr: body matches "^[^ Z]+ "
+            output: parser-crio
+          - expr: body matches "^[^ Z]+Z"
+            output: parser-containerd
+          type: router
+        - id: parser-crio
+          regex: ^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$
+          timestamp:
+            layout: 2006-01-02T15:04:05.999999999Z07:00
+            layout_type: gotime
+            parse_from: attributes.time
+          type: regex_parser
+        - combine_field: attributes.log
+          combine_with: ""
+          id: crio-recombine
+          is_last_entry: attributes.logtag == 'F'
+          max_batch_size: 1000
+          max_log_size: 1048576
+          output: handle_empty_log
+          source_identifier: attributes["log.file.path"]
+          type: recombine
+        - id: parser-containerd
+          regex: ^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$
+          timestamp:
+            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+            parse_from: attributes.time
+          type: regex_parser
+        - combine_field: attributes.log
+          combine_with: ""
+          id: containerd-recombine
+          is_last_entry: attributes.logtag == 'F'
+          max_batch_size: 1000
+          max_log_size: 1048576
+          output: handle_empty_log
+          source_identifier: attributes["log.file.path"]
+          type: recombine
+        - id: parser-docker
+          timestamp:
+            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+            parse_from: attributes.time
+          type: json_parser
+        - combine_field: attributes.log
+          combine_with: ""
+          id: docker-recombine
+          is_last_entry: attributes.log endsWith "\n"
+          max_batch_size: 1000
+          max_log_size: 1048576
+          output: handle_empty_log
+          source_identifier: attributes["log.file.path"]
+          type: recombine
+        - field: attributes.log
+          id: handle_empty_log
+          if: attributes.log == nil
+          type: add
+          value: ""
+        - parse_from: attributes["log.file.path"]
+          regex: ^C:\\var\\log\\pods\\(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[^\/]+)\\(?P<container_name>[^\._]+)\\(?P<restart_count>\d+)\.log$
+          type: regex_parser
+        - from: attributes.stream
+          to: attributes["log.iostream"]
+          type: move
+        - from: attributes.container_name
+          to: resource["k8s.container.name"]
+          type: move
+        - from: attributes.namespace
+          to: resource["k8s.namespace.name"]
+          type: move
+        - from: attributes.pod_name
+          to: resource["k8s.pod.name"]
+          type: move
+        - from: attributes.restart_count
+          to: resource["k8s.container.restart_count"]
+          type: move
+        - from: attributes.uid
+          to: resource["k8s.pod.uid"]
+          type: move
+        - from: attributes.log
+          id: clean-up-log-record
+          to: body
+          type: move
+        - id: logs-collection-continue
+          type: noop
+        retry_on_failure:
+          enabled: true
+        start_at: beginning
+        storage: file_storage
+      hostmetrics:
+        collection_interval: '30s'
+        scrapers:
+          cpu:
+            metrics:
+              system.cpu.utilization:
+                enabled: true
+          disk: null
+          filesystem:
+            exclude_mount_points:
+              match_type: strict
+              mount_points:
+              - ""
+          memory:
+            metrics:
+              system.memory.utilization:
+                enabled: true
+          network: null
+          paging: null
+      jaeger:
+        protocols:
+          grpc:
+            endpoint: ${env:MY_POD_IP}:14250
+          thrift_binary:
+            endpoint: ${env:MY_POD_IP}:6832
+          thrift_compact:
+            endpoint: ${env:MY_POD_IP}:6831
+          thrift_http:
+            endpoint: ${env:MY_POD_IP}:14268
+      kubeletstats:
+        auth_type: serviceAccount
+        collect_all_network_interfaces:
+          node: true
+          pod: true
+        collection_interval: '30s'
+        endpoint: ${env:K8S_NODE_IP}:10250
+        insecure_skip_verify: true
+      otlp:
+        protocols:
+          grpc:
+            endpoint: ${env:MY_POD_IP}:4317
+            max_recv_msg_size_mib: 20
+          http:
+            endpoint: ${env:MY_POD_IP}:4318
+      prometheus:
+        config:
+          scrape_configs:
+          - job_name: opentelemetry-collector
+            scrape_interval: '30s'
+            static_configs:
+            - targets:
+              - ${env:MY_POD_IP}:8888
+      statsd:
+        endpoint: ${env:MY_POD_IP}:8125
+      zipkin:
+        endpoint: ${env:MY_POD_IP}:9411
+    service:
+      extensions:
+      - health_check
+      - file_storage
+      - opamp
+      - zpages
+      - pprof
+      pipelines:
+        logs:
+          exporters:
+          - debug
+          - coralogix
+          processors:
+          - memory_limiter
+          - resourcedetection/region
+          - resourcedetection/env
+          - resource/metadata
+          - k8sattributes
+          - batch
+          receivers:
+          - filelog
+          - otlp
+        metrics:
+          exporters:
+          - debug
+          - coralogix
+          processors:
+          - memory_limiter
+          - resourcedetection/region
+          - resourcedetection/env
+          - resource/metadata
+          - k8sattributes
+          - transform/kubeletstatscpu
+          - transform/prometheus
+          - batch
+          receivers:
+          - hostmetrics
+          - kubeletstats
+          - prometheus
+          - otlp
+          - statsd
+        traces:
+          exporters:
+          - debug
+          - coralogix
+          processors:
+          - memory_limiter
+          - resourcedetection/region
+          - resourcedetection/env
+          - resource/metadata
+          - k8sattributes
+          - batch
+          receivers:
+          - jaeger
+          - zipkin
+          - otlp
+      telemetry:
+        logs:
+          encoding: json
+          level: 'warn'
+        metrics:
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: ${env:MY_POD_IP}
+                  port: 8888
+                  without_scope_info: false
+                  without_type_suffix: false
+                  without_units: false
+        resource:
+          cx.agent.type: agent
+          service.name: opentelemetry-collector
+---
+# Source: otel-integration/charts/opentelemetry-agent/templates/configmap-agent.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coralogix-opentelemetry-agent
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-agent-0.132.0
+    app.kubernetes.io/name: opentelemetry-agent
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+data:
+  relay: |
+    connectors:
+      forward/compact: {}
+      forward/db: {}
+      forward/db_compact: {}
+      spanmetrics:
+        add_resource_attributes: true
+        aggregation_cardinality_limit: 100000
+        dimensions:
+        - name: http.method
+        - name: cgx.transaction
+        - name: cgx.transaction.root
+        - name: status_code
+        - name: db.namespace
+        - name: db.operation.name
+        - name: db.collection.name
+        - name: db.system
+        - name: http.response.status_code
+        - name: rpc.grpc.status_code
+        - name: service.version
+        exclude_dimensions:
+        - collector.instance.id
+        histogram:
+          explicit:
+            buckets:
+            - 1ms
+            - 4ms
+            - 10ms
+            - 20ms
+            - 50ms
+            - 100ms
+            - 200ms
+            - 500ms
+            - 1s
+            - 2s
+            - 5s
+          unit: ms
+        metrics_expiration: 5m
+        metrics_flush_interval: '30s'
+        namespace: ""
+      spanmetrics/compact:
+        add_resource_attributes: true
+        aggregation_cardinality_limit: 100000
+        exclude_dimensions:
+        - collector.instance.id
+        - span.name
+        histogram:
+          explicit:
+            buckets:
+            - 1ms
+            - 4ms
+            - 10ms
+            - 20ms
+            - 50ms
+            - 100ms
+            - 200ms
+            - 500ms
+            - 1s
+            - 2s
+            - 5s
+          unit: ms
+        metrics_expiration: 5m
+        metrics_flush_interval: '30s'
+        namespace: compact
+      spanmetrics/db:
+        add_resource_attributes: true
+        aggregation_cardinality_limit: 100000
+        dimensions:
+        - name: db.namespace
+        - name: db.operation.name
+        - name: db.collection.name
+        - name: db.system
+        - name: service.version
+        exclude_dimensions:
+        - collector.instance.id
+        histogram:
+          explicit:
+            buckets:
+            - 1ms
+            - 4ms
+            - 10ms
+            - 20ms
+            - 50ms
+            - 100ms
+            - 200ms
+            - 500ms
+            - 1s
+            - 2s
+            - 5s
+          unit: ms
+        metrics_expiration: 5m
+        metrics_flush_interval: '30s'
+        namespace: db
+      spanmetrics/db_compact:
+        add_resource_attributes: true
+        aggregation_cardinality_limit: 100000
+        dimensions:
+        - name: db.namespace
+        - name: db.system
+        exclude_dimensions:
+        - collector.instance.id
+        - span.name
+        - span.kind
+        histogram:
+          explicit:
+            buckets:
+            - 1ms
+            - 4ms
+            - 10ms
+            - 20ms
+            - 50ms
+            - 100ms
+            - 200ms
+            - 500ms
+            - 1s
+            - 2s
+            - 5s
+          unit: ms
+        metrics_expiration: 5m
+        metrics_flush_interval: '30s'
+        namespace: db_compact
+    exporters:
+      coralogix:
+        application_name: otel
+        application_name_attributes:
+        - k8s.namespace.name
+        - service.namespace
+        domain: eu2.coralogix.com
+        domain_settings:
+          keepalive:
+            enabled: true
+            permit_without_stream: false
+            time: 30s
+            timeout: 10s
+        logs:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+        metrics:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+        private_key: ${env:CORALOGIX_PRIVATE_KEY}
+        profiles:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+            x-coralogix-ingress: otlp/v1.10.0
+        sending_queue:
+          batch:
+            flush_timeout: 250ms
+            max_size: 2097152
+            min_size: 1048576
+            sizer: bytes
+          enabled: true
+          num_consumers: 20
+          queue_size: 209715200
+          sizer: bytes
+        subsystem_name: integration
+        subsystem_name_attributes:
+        - k8s.deployment.name
+        - k8s.statefulset.name
+        - k8s.daemonset.name
+        - k8s.cronjob.name
+        - service.name
+        timeout: 30s
+        traces:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+      coralogix/resource_catalog:
+        application_name: resource
+        domain: eu2.coralogix.com
+        logs:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+            x-coralogix-ingress: metadata-as-otlp-logs/v1
+        private_key: ${CORALOGIX_PRIVATE_KEY}
+        sending_queue:
+          batch:
+            flush_timeout: 250ms
+            max_size: 2097152
+            min_size: 1048576
+            sizer: bytes
+          enabled: true
+          num_consumers: 20
+          queue_size: 209715200
+          sizer: bytes
+        subsystem_name: catalog
+        timeout: 30s
+      debug: {}
+    extensions:
+      file_storage:
+        directory: /var/lib/otelcol
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
+      opamp:
+        agent_description:
+          include_resource_attributes: true
+          non_identifying_attributes:
+            cx.agent.type: agent
+            cx.cluster.name: 'golden-render'
+            helm.chart.opentelemetry-agent.version: 0.132.0
+        server:
+          http:
+            endpoint: https://ingress.eu2.coralogix.com/opamp/v1
+            headers:
+              Authorization: Bearer ${env:CORALOGIX_PRIVATE_KEY}
+            polling_interval: 2m
+      pprof:
+        endpoint: localhost:1777
+      zpages:
+        endpoint: localhost:55679
+    processors:
+      batch:
+        send_batch_max_size: 2048
+        send_batch_size: 1024
+        timeout: 1s
+      coralogix:
+        transactions:
+          enabled: true
+      filter/db_compact_spanmetrics:
+        traces:
+          span:
+          - span.kind != SPAN_KIND_CLIENT or span.attributes["db.namespace"] == nil or
+            span.attributes["db.system"] == nil
+      filter/db_spanmetrics:
+        traces:
+          span:
+          - span.attributes["db.system"] == nil
+      filter/k8s_extra_metrics:
+        metrics:
+          metric:
+          - resource.attributes["service.name"] == "kubernetes-cadvisor" and (metric.name
+            != "container_fs_writes_total" and metric.name != "container_fs_reads_total"
+            and metric.name != "container_fs_writes_bytes_total" and metric.name != "container_fs_reads_bytes_total"
+            and metric.name != "container_fs_usage_bytes" and metric.name != "container_cpu_cfs_throttled_periods_total"
+            and metric.name != "container_cpu_cfs_periods_total")
+      groupbytrace/transactions:
+        wait_duration: 30s
+      k8sattributes:
+        extract:
+          deployment_name_from_replicaset: true
+          metadata:
+          - k8s.namespace.name
+          - k8s.deployment.name
+          - k8s.statefulset.name
+          - k8s.daemonset.name
+          - k8s.cronjob.name
+          - k8s.job.name
+          - k8s.node.name
+          - k8s.pod.name
+        filter:
+          node_from_env_var: K8S_NODE_NAME
+        passthrough: false
+        pod_association:
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.ip
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.uid
+        - sources:
+          - from: connection
+        - sources:
+          - from: resource_attribute
+            name: k8s.job.name
+      k8sattributes/profiles:
+        extract:
+          annotations:
+          - from: pod
+            key: app.coralogix.com/service
+            tag_name: service.annotation
+          labels:
+          - from: pod
+            key: app.kubernetes.io/name
+            tag_name: k8s.label.name
+          - from: pod
+            key: app.kubernetes.io/instance
+            tag_name: k8s.label.instance
+          - from: pod
+            key: app.kubernetes.io/name
+            tag_name: service.label
+          metadata:
+          - k8s.namespace.name
+          - k8s.replicaset.name
+          - k8s.statefulset.name
+          - k8s.daemonset.name
+          - k8s.deployment.name
+          - k8s.cronjob.name
+          - k8s.job.name
+          - k8s.pod.name
+          - k8s.node.name
+          - container.id
+          - k8s.container.name
+          - service.version
+          otel_annotations: true
+        filter:
+          node_from_env_var: K8S_NODE_NAME
+        passthrough: false
+        pod_association:
+        - sources:
+          - from: resource_attribute
+            name: container.id
+        - sources:
+          - from: connection
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
+      redaction/spanname:
+        allow_all_keys: true
+        db_sanitizer:
+          es:
+            attributes:
+            - db.statement
+            - elasticsearch.body
+            enabled: true
+          memcached:
+            attributes:
+            - db.statement
+            - memcached.command
+            enabled: true
+          mongo:
+            attributes:
+            - db.statement
+            - mongodb.query
+            enabled: true
+          opensearch:
+            attributes:
+            - db.statement
+            - opensearch.body
+            enabled: true
+          redis:
+            attributes:
+            - db.statement
+            - redis.command
+            enabled: true
+          sql:
+            attributes:
+            - db.statement
+            - db.query
+            enabled: true
+        url_sanitizer:
+          enabled: true
+      resource/metadata:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: 'golden-render'
+        - action: upsert
+          key: cx.otel_integration.name
+          value: coralogix-integration-helm
+      resourcedetection/entity:
+        detectors:
+        - system
+        - env
+        override: false
+        system:
+          resource_attributes:
+            host.cpu.cache.l2.size:
+              enabled: true
+            host.cpu.family:
+              enabled: true
+            host.cpu.model.id:
+              enabled: true
+            host.cpu.model.name:
+              enabled: true
+            host.cpu.stepping:
+              enabled: true
+            host.cpu.vendor.id:
+              enabled: true
+            host.id:
+              enabled: true
+            host.ip:
+              enabled: true
+            host.mac:
+              enabled: true
+            os.description:
+              enabled: true
+        timeout: 2s
+      resourcedetection/env:
+        detectors:
+        - system
+        - env
+        override: false
+        system:
+          resource_attributes:
+            host.id:
+              enabled: true
+        timeout: 2s
+      resourcedetection/region:
+        detectors:
+        - gcp
+        - ec2
+        - azure
+        - eks
+        eks:
+          node_from_env_var: K8S_NODE_NAME
+        override: true
+        timeout: 2s
+      transform/compact:
+        trace_statements:
+        - context: resource
+          statements:
+          - keep_keys(resource.attributes, ["service.name", "k8s.cluster.name", "host.name",
+            "deployment.environment.name"])
+      transform/db_compact:
+        trace_statements:
+        - context: resource
+          statements:
+          - keep_keys(resource.attributes, ["service.name", "k8s.cluster.name", "host.name",
+            "deployment.environment.name"])
+        - context: span
+          statements:
+          - keep_keys(span.attributes, ["db.namespace", "db.system"])
+      transform/entity-event:
+        error_mode: silent
+        log_statements:
+        - context: log
+          statements:
+          - set(log.attributes["otel.entity.id"]["host.id"], resource.attributes["host.id"])
+          - merge_maps(log.attributes, resource.attributes, "insert")
+        - context: resource
+          statements:
+          - keep_keys(resource.attributes, [""])
+      transform/kubeletstatscpu:
+        error_mode: ignore
+        metric_statements:
+        - context: metric
+          statements:
+          - set(metric.unit, "1") where metric.name == "container.cpu.usage"
+          - set(metric.name, "container.cpu.utilization") where metric.name == "container.cpu.usage"
+          - set(metric.unit, "1") where metric.name == "k8s.pod.cpu.usage"
+          - set(metric.name, "k8s.pod.cpu.utilization") where metric.name == "k8s.pod.cpu.usage"
+          - set(metric.unit, "1") where metric.name == "k8s.node.cpu.usage"
+          - set(metric.name, "k8s.node.cpu.utilization") where metric.name == "k8s.node.cpu.usage"
+      transform/profiles:
+        profile_statements:
+        - set(resource.attributes["service.name"], resource.attributes["service.annotation"])
+          where resource.attributes["service.name"] == nil and resource.attributes["service.annotation"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["service.label"])
+          where resource.attributes["service.name"] == nil and resource.attributes["service.label"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["k8s.label.instance"])
+          where resource.attributes["service.name"] == nil and resource.attributes["k8s.label.instance"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["k8s.label.name"])
+          where resource.attributes["service.name"] == nil and resource.attributes["k8s.label.name"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["k8s.deployment.name"])
+          where resource.attributes["service.name"] == nil and resource.attributes["k8s.deployment.name"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["k8s.replicaset.name"])
+          where resource.attributes["service.name"] == nil and resource.attributes["k8s.replicaset.name"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["k8s.statefulset.name"])
+          where resource.attributes["service.name"] == nil and resource.attributes["k8s.statefulset.name"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["k8s.daemonset.name"])
+          where resource.attributes["service.name"] == nil and resource.attributes["k8s.daemonset.name"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["k8s.cronjob.name"])
+          where resource.attributes["service.name"] == nil and resource.attributes["k8s.cronjob.name"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["k8s.job.name"])
+          where resource.attributes["service.name"] == nil and resource.attributes["k8s.job.name"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["k8s.pod.name"])
+          where resource.attributes["service.name"] == nil and resource.attributes["k8s.pod.name"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["k8s.container.name"])
+          where resource.attributes["service.name"] == nil and resource.attributes["k8s.container.name"]
+          != nil
+      transform/prometheus:
+        error_mode: ignore
+        metric_statements:
+        - context: metric
+          statements:
+          - replace_pattern(metric.name, "_total$", "") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_cpu_seconds_seconds$", "otelcol_process_cpu_seconds")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_runtime_heap_alloc_bytes_bytes$",
+            "otelcol_process_runtime_heap_alloc_bytes") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_runtime_total_alloc_bytes_bytes$",
+            "otelcol_process_runtime_total_alloc_bytes") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_runtime_total_sys_memory_bytes_bytes$",
+            "otelcol_process_runtime_total_sys_memory_bytes") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_fileconsumer_open_files$", "otelcol_fileconsumer_open_files_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_fileconsumer_reading_files$", "otelcol_fileconsumer_reading_files_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_ip_lookup_miss$", "otelcol_otelsvc_k8s_ip_lookup_miss_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_pod_added$", "otelcol_otelsvc_k8s_pod_added_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_pod_updated$", "otelcol_otelsvc_k8s_pod_updated_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_pod_deleted$", "otelcol_otelsvc_k8s_pod_deleted_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_processor_filter_spans\\.filtered$",
+            "otelcol_processor_filter_spans.filtered_ratio") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+        - context: resource
+          statements:
+          - set(resource.attributes["k8s.pod.ip"], resource.attributes["net.host.name"])
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - delete_key(resource.attributes, "service_name") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+        - context: datapoint
+          statements:
+          - delete_key(datapoint.attributes, "service_name") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - delete_key(datapoint.attributes, "otel_scope_name") where datapoint.attributes["service.name"]
+            == "opentelemetry-collector"
+      transform/semconv:
+        error_mode: ignore
+        trace_statements:
+        - context: span
+          statements:
+          - set(span.attributes["http.method"], span.attributes["http.request.method"])
+            where span.attributes["http.request.method"] != nil
+      transform/spanmetrics:
+        error_mode: silent
+        metric_statements:
+        - context: datapoint
+          statements:
+          - set(datapoint.attributes["status.code"], "STATUS_CODE_ERROR") where datapoint.attributes["status.code"]
+            == nil and instrumentation_scope.name == "spanmetricsconnector" and datapoint.attributes["otel.status_code"]
+            == "ERROR"
+          - set(datapoint.attributes["status.code"], "STATUS_CODE_OK") where datapoint.attributes["status.code"]
+            == nil and instrumentation_scope.name == "spanmetricsconnector" and datapoint.attributes["otel.status_code"]
+            == "OK"
+          - set(datapoint.attributes["status.code"], "STATUS_CODE_UNSET") where datapoint.attributes["status.code"]
+            == nil and instrumentation_scope.name == "spanmetricsconnector" and (datapoint.attributes["otel.status_code"]
+            == "UNSET" or datapoint.attributes["otel.status_code"] == nil)
+    receivers:
+      filelog:
+        exclude: []
+        force_flush_period: 0
+        include:
+        - /var/log/pods/*/*/*.log
+        include_file_name: false
+        include_file_path: true
+        operators:
+        - id: get-format
+          routes:
+          - expr: body matches "^\\{"
+            output: parser-docker
+          - expr: body matches "^[^ Z]+ "
+            output: parser-crio
+          - expr: body matches "^[^ Z]+Z"
+            output: parser-containerd
+          type: router
+        - id: parser-crio
+          regex: ^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$
+          timestamp:
+            layout: 2006-01-02T15:04:05.999999999Z07:00
+            layout_type: gotime
+            parse_from: attributes.time
+          type: regex_parser
+        - combine_field: attributes.log
+          combine_with: ""
+          id: crio-recombine
+          is_last_entry: attributes.logtag == 'F'
+          max_batch_size: 1000
+          max_log_size: 1048576
+          output: handle_empty_log
+          source_identifier: attributes["log.file.path"]
+          type: recombine
+        - id: parser-containerd
+          regex: ^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$
+          timestamp:
+            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+            parse_from: attributes.time
+          type: regex_parser
+        - combine_field: attributes.log
+          combine_with: ""
+          id: containerd-recombine
+          is_last_entry: attributes.logtag == 'F'
+          max_batch_size: 1000
+          max_log_size: 1048576
+          output: handle_empty_log
+          source_identifier: attributes["log.file.path"]
+          type: recombine
+        - id: parser-docker
+          timestamp:
+            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+            parse_from: attributes.time
+          type: json_parser
+        - combine_field: attributes.log
+          combine_with: ""
+          id: docker-recombine
+          is_last_entry: attributes.log endsWith "\n"
+          max_batch_size: 1000
+          max_log_size: 1048576
+          output: handle_empty_log
+          source_identifier: attributes["log.file.path"]
+          type: recombine
+        - field: attributes.log
+          id: handle_empty_log
+          if: attributes.log == nil
+          type: add
+          value: ""
+        - parse_from: attributes["log.file.path"]
+          regex: ^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]+)\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$
+          type: regex_parser
+        - from: attributes.stream
+          to: attributes["log.iostream"]
+          type: move
+        - from: attributes.container_name
+          to: resource["k8s.container.name"]
+          type: move
+        - from: attributes.namespace
+          to: resource["k8s.namespace.name"]
+          type: move
+        - from: attributes.pod_name
+          to: resource["k8s.pod.name"]
+          type: move
+        - from: attributes.restart_count
+          to: resource["k8s.container.restart_count"]
+          type: move
+        - from: attributes.uid
+          to: resource["k8s.pod.uid"]
+          type: move
+        - from: attributes.log
+          id: clean-up-log-record
+          to: body
+          type: move
+        - default: skip-collector-logs-recombine
+          routes:
+          - expr: (attributes["log.file.path"] matches "/var/log/pods/default_coralogix-opentelemetry.*_.*/opentelemetry-agent/.*.log")
+            output: collector-logs-recombine
+          type: router
+        - combine_field: body
+          combine_with: |2+
+
+          id: collector-logs-recombine
+          is_first_entry: body matches "^\\{"
+          max_batch_size: 1000
+          max_log_size: 1048576
+          source_identifier: attributes["log.file.path"]
+          type: recombine
+        - id: skip-collector-logs-recombine
+          type: noop
+        - field: body
+          if: (attributes["log.file.path"] matches "/var/log/pods/default_coralogix-opentelemetry.*_.*/opentelemetry-agent/.*.log")
+          regex: (?s)("stacktrace":"[^"]*)"}\n(.*)$
+          replace_with: $${1}\\n$${2}"}
+          type: regex_replace
+        - drop_ratio: 1
+          expr: (attributes["log.file.path"] matches "/var/log/pods/default_coralogix-opentelemetry.*_.*/opentelemetry-agent/.*.log")
+            and ((body contains "logRecord") or (body contains "ResourceLog"))
+          type: filter
+        - default: logs-collection-continue
+          routes:
+          - expr: (body matches "\"resource\":{.*?},?") and not (body matches "\"logger\":\"supervisor\\.collector\"")
+            output: parse-body
+          type: router
+        - id: parse-body
+          if: (attributes["log.file.path"] matches "/var/log/pods/default_coralogix-opentelemetry.*_.*/.*/.*.log")
+            and not (body matches "\"logger\":\"supervisor\\.collector\"")
+          on_error: send_quiet
+          parse_to: attributes["parsed_body_tmp"]
+          type: json_parser
+        - field: body
+          if: (attributes["log.file.path"] matches "/var/log/pods/default_coralogix-opentelemetry.*_.*/.*/.*.log")
+            and not (body matches "\"logger\":\"supervisor\\.collector\"")
+          on_error: send_quiet
+          regex: \"resource\":{.*?},?
+          replace_with: ""
+          type: regex_replace
+        - from: attributes["parsed_body_tmp"]["resource"]
+          if: (attributes["log.file.path"] matches "/var/log/pods/default_coralogix-opentelemetry.*_.*/.*/.*.log")
+            and not (body matches "\"logger\":\"supervisor\\.collector\"")
+          on_error: send_quiet
+          to: resource["attributes_tmp"]
+          type: move
+        - field: attributes["parsed_body_tmp"]
+          if: (attributes["log.file.path"] matches "/var/log/pods/default_coralogix-opentelemetry.*_.*/.*/.*.log")
+            and not (body matches "\"logger\":\"supervisor\\.collector\"")
+          on_error: send_quiet
+          type: remove
+        - field: resource["attributes_tmp"]
+          id: flatten-resource
+          if: (attributes["log.file.path"] matches "/var/log/pods/default_coralogix-opentelemetry.*_.*/.*/.*.log")
+            and not (body matches "\"logger\":\"supervisor\\.collector\"")
+          on_error: send_quiet
+          type: flatten
+        - id: logs-collection-continue
+          type: noop
+        retry_on_failure:
+          enabled: true
+        start_at: beginning
+        storage: file_storage
+      hostmetrics:
+        collection_interval: '30s'
+        root_path: /hostfs
+        scrapers:
+          cpu:
+            metrics:
+              system.cpu.utilization:
+                enabled: true
+          disk: null
+          filesystem:
+            exclude_fs_types:
+              fs_types:
+              - autofs
+              - binfmt_misc
+              - bpf
+              - cgroup2
+              - configfs
+              - debugfs
+              - devpts
+              - devtmpfs
+              - fusectl
+              - hugetlbfs
+              - iso9660
+              - mqueue
+              - nsfs
+              - overlay
+              - proc
+              - procfs
+              - pstore
+              - rpc_pipefs
+              - securityfs
+              - selinuxfs
+              - squashfs
+              - sysfs
+              - tracefs
+              match_type: strict
+            exclude_mount_points:
+              match_type: regexp
+              mount_points:
+              - /dev/*
+              - /proc/*
+              - /sys/*
+              - /run/k3s/containerd/*
+              - /run/containerd/runc/*
+              - /var/lib/docker/*
+              - /var/lib/kubelet/*
+              - /snap/*
+          load: null
+          memory:
+            metrics:
+              system.memory.utilization:
+                enabled: true
+          network: null
+      jaeger:
+        protocols:
+          grpc:
+            endpoint: ${env:MY_POD_IP}:14250
+          thrift_binary:
+            endpoint: ${env:MY_POD_IP}:6832
+          thrift_compact:
+            endpoint: ${env:MY_POD_IP}:6831
+          thrift_http:
+            endpoint: ${env:MY_POD_IP}:14268
+      kubeletstats:
+        auth_type: serviceAccount
+        collect_all_network_interfaces:
+          node: true
+          pod: true
+        collection_interval: '30s'
+        endpoint: ${env:K8S_NODE_IP}:10250
+        insecure_skip_verify: true
+      otlp:
+        protocols:
+          grpc:
+            endpoint: ${env:MY_POD_IP}:4317
+            max_recv_msg_size_mib: 20
+          http:
+            endpoint: ${env:MY_POD_IP}:4318
+      prometheus:
+        config:
+          scrape_configs:
+          - job_name: opentelemetry-collector
+            scrape_interval: '30s'
+            static_configs:
+            - targets:
+              - ${env:MY_POD_IP}:8888
+      prometheus/k8s_extra_metrics:
+        config:
+          scrape_configs:
+          - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            honor_timestamps: true
+            job_name: kubernetes-cadvisor
+            metrics_path: /metrics/cadvisor
+            scheme: https
+            static_configs:
+            - targets:
+              - ${env:K8S_NODE_IP}:10250
+            tls_config:
+              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              insecure_skip_verify: true
+      statsd:
+        endpoint: ${env:MY_POD_IP}:8125
+      zipkin:
+        endpoint: ${env:MY_POD_IP}:9411
+    service:
+      extensions:
+      - health_check
+      - file_storage
+      - opamp
+      - zpages
+      - pprof
+      pipelines:
+        logs:
+          exporters:
+          - coralogix
+          processors:
+          - memory_limiter
+          - resourcedetection/region
+          - resourcedetection/env
+          - resource/metadata
+          - k8sattributes
+          - batch
+          receivers:
+          - filelog
+          - otlp
+        logs/resource_catalog:
+          exporters:
+          - coralogix/resource_catalog
+          processors:
+          - memory_limiter
+          - resource/metadata
+          - k8sattributes
+          - resourcedetection/entity
+          - resourcedetection/region
+          - transform/entity-event
+          receivers:
+          - hostmetrics
+        metrics:
+          exporters:
+          - coralogix
+          processors:
+          - memory_limiter
+          - resourcedetection/region
+          - resourcedetection/env
+          - resource/metadata
+          - k8sattributes
+          - transform/kubeletstatscpu
+          - filter/k8s_extra_metrics
+          - transform/spanmetrics
+          - transform/prometheus
+          - batch
+          receivers:
+          - hostmetrics
+          - kubeletstats
+          - prometheus/k8s_extra_metrics
+          - spanmetrics
+          - spanmetrics/db
+          - prometheus
+          - otlp
+          - statsd
+        metrics/compact:
+          exporters:
+          - coralogix
+          processors:
+          - memory_limiter
+          - transform/spanmetrics
+          - batch
+          receivers:
+          - spanmetrics/compact
+        metrics/db_compact:
+          exporters:
+          - coralogix
+          processors:
+          - memory_limiter
+          - transform/spanmetrics
+          - batch
+          receivers:
+          - spanmetrics/db_compact
+        profiles:
+          exporters:
+          - coralogix
+          processors:
+          - memory_limiter
+          - resourcedetection/region
+          - resourcedetection/env
+          - k8sattributes/profiles
+          - resource/metadata
+          - transform/profiles
+          receivers:
+          - otlp
+        traces:
+          exporters:
+          - spanmetrics
+          - forward/db
+          - forward/compact
+          - forward/db_compact
+          - coralogix
+          processors:
+          - memory_limiter
+          - resourcedetection/region
+          - resourcedetection/env
+          - resource/metadata
+          - k8sattributes
+          - transform/spanmetrics
+          - redaction/spanname
+          - transform/semconv
+          - groupbytrace/transactions
+          - coralogix
+          - batch
+          receivers:
+          - jaeger
+          - zipkin
+          - otlp
+        traces/compact:
+          exporters:
+          - spanmetrics/compact
+          processors:
+          - transform/compact
+          - batch
+          receivers:
+          - forward/compact
+        traces/db:
+          exporters:
+          - spanmetrics/db
+          processors:
+          - filter/db_spanmetrics
+          - batch
+          receivers:
+          - forward/db
+        traces/db_compact:
+          exporters:
+          - spanmetrics/db_compact
+          processors:
+          - filter/db_compact_spanmetrics
+          - transform/db_compact
+          - batch
+          receivers:
+          - forward/db_compact
+      telemetry:
+        logs:
+          encoding: json
+          level: 'warn'
+        metrics:
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: ${env:MY_POD_IP}
+                  port: 8888
+                  without_scope_info: false
+                  without_type_suffix: false
+                  without_units: false
+        resource:
+          cx.agent.type: agent
+          k8s.daemonset.name: coralogix-opentelemetry
+          k8s.namespace.name: default
+          k8s.node.name: ${env:KUBE_NODE_NAME}
+          k8s.pod.name: ${env:KUBE_POD_NAME}
+          service.name: opentelemetry-collector
+---
+# Source: otel-integration/charts/opentelemetry-cluster-collector/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coralogix-opentelemetry-collector
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-cluster-collector-0.132.0
+    app.kubernetes.io/name: opentelemetry-cluster-collector
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+data:
+  relay: |
+    exporters:
+      coralogix:
+        application_name: otel
+        application_name_attributes:
+        - k8s.namespace.name
+        - service.namespace
+        domain: eu2.coralogix.com
+        domain_settings:
+          keepalive:
+            enabled: true
+            permit_without_stream: false
+            time: 30s
+            timeout: 10s
+        logs:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+        metrics:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+        private_key: ${env:CORALOGIX_PRIVATE_KEY}
+        profiles:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+            x-coralogix-ingress: otlp/v1.10.0
+        sending_queue:
+          batch:
+            flush_timeout: 250ms
+            max_size: 2097152
+            min_size: 1048576
+            sizer: bytes
+          enabled: true
+          num_consumers: 20
+          queue_size: 209715200
+          sizer: bytes
+        subsystem_name: integration
+        subsystem_name_attributes:
+        - k8s.deployment.name
+        - k8s.statefulset.name
+        - k8s.daemonset.name
+        - k8s.cronjob.name
+        - service.name
+        timeout: 30s
+        traces:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+      coralogix/resource_catalog:
+        application_name: resource
+        domain: eu2.coralogix.com
+        logs:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.317
+            x-coralogix-ingress: metadata-as-otlp-logs/v1
+        private_key: ${CORALOGIX_PRIVATE_KEY}
+        sending_queue:
+          batch:
+            flush_timeout: 250ms
+            max_size: 2097152
+            min_size: 1048576
+            sizer: bytes
+          enabled: true
+          num_consumers: 20
+          queue_size: 209715200
+          sizer: bytes
+        subsystem_name: catalog
+        timeout: 30s
+      debug: {}
+    extensions:
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
+      k8s_observer:
+        auth_type: serviceAccount
+        observe_pods: true
+      opamp:
+        agent_description:
+          include_resource_attributes: true
+          non_identifying_attributes:
+            cx.agent.type: cluster-collector
+            cx.cluster.name: 'golden-render'
+            helm.chart.opentelemetry-cluster-collector.version: 0.132.0
+        server:
+          http:
+            endpoint: https://ingress.eu2.coralogix.com/opamp/v1
+            headers:
+              Authorization: Bearer ${env:CORALOGIX_PRIVATE_KEY}
+            polling_interval: 2m
+      pprof:
+        endpoint: localhost:1777
+      zpages:
+        endpoint: localhost:55679
+    processors:
+      batch:
+        send_batch_max_size: 2048
+        send_batch_size: 1024
+        timeout: 1s
+      filter/k8s_apiserver_metrics:
+        metrics:
+          metric:
+          - resource.attributes["service.name"] == "kubernetes-apiserver" and metric.name
+            != "kubernetes_build_info"
+      filter/workflow:
+        error_mode: silent
+        logs:
+          log_record:
+          - log.body["object"]["kind"] == "Pod" and not IsMatch(String(log.body["object"]["metadata"]["ownerReferences"]),
+            ".*StatefulSet.*|.*ReplicaSet.*|.*Job.*|.*DaemonSet.*")
+          - log.body["kind"] == "Pod" and not IsMatch(String(log.body["metadata"]["ownerReferences"]),
+            ".*StatefulSet.*|.*ReplicaSet.*|.*Job.*|.*DaemonSet.*")
+      k8sattributes:
+        extract:
+          deployment_name_from_replicaset: true
+          metadata:
+          - k8s.namespace.name
+          - k8s.deployment.name
+          - k8s.statefulset.name
+          - k8s.daemonset.name
+          - k8s.cronjob.name
+          - k8s.job.name
+          - k8s.node.name
+          - k8s.pod.name
+        passthrough: false
+        pod_association:
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.ip
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.uid
+        - sources:
+          - from: connection
+        - sources:
+          - from: resource_attribute
+            name: k8s.job.name
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
+      metricstransform/k8s-dashboard:
+        transforms:
+        - action: insert
+          include: k8s.pod.phase
+          match_type: strict
+          new_name: kube_pod_status_qos_class
+        - action: insert
+          include: k8s.pod.status_reason
+          match_type: strict
+          new_name: kube_pod_status_reason
+        - action: insert
+          include: k8s.node.allocatable_cpu
+          match_type: strict
+          new_name: kube_node_info
+        - action: insert
+          include: k8s.container.ready
+          match_type: strict
+          new_name: k8s.container.status.last_terminated_reason
+      resource/kube-events:
+        attributes:
+        - action: upsert
+          key: service.name
+          value: kube-events
+        - action: upsert
+          key: k8s.cluster.name
+          value: golden-render
+      resource/metadata:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: 'golden-render'
+        - action: upsert
+          key: cx.otel_integration.name
+          value: coralogix-integration-helm
+      resourcedetection/env:
+        detectors:
+        - system
+        - env
+        override: false
+        system:
+          resource_attributes:
+            host.id:
+              enabled: true
+        timeout: 2s
+      resourcedetection/region:
+        detectors:
+        - gcp
+        - ec2
+        - azure
+        - eks
+        eks:
+          node_from_env_var: K8S_NODE_NAME
+        override: true
+        timeout: 2s
+      resourcedetection/resource_catalog:
+        azure:
+          resource_attributes:
+            azure.resourcegroup.name:
+              enabled: false
+            azure.vm.name:
+              enabled: false
+            azure.vm.scaleset.name:
+              enabled: false
+            azure.vm.size:
+              enabled: false
+            host.id:
+              enabled: false
+            host.name:
+              enabled: false
+        detectors:
+        - gcp
+        - ec2
+        - azure
+        - eks
+        ec2:
+          resource_attributes:
+            host.id:
+              enabled: false
+            host.image.id:
+              enabled: false
+            host.name:
+              enabled: false
+            host.type:
+              enabled: false
+        eks:
+          node_from_env_var: K8S_NODE_NAME
+        gcp:
+          resource_attributes:
+            host.id:
+              enabled: false
+            host.name:
+              enabled: false
+            host.type:
+              enabled: false
+            k8s.cluster.name:
+              enabled: false
+        override: true
+        timeout: 2s
+      transform/entity-event:
+        error_mode: silent
+        log_statements:
+        - context: log
+          statements:
+          - set(log.attributes["otel.entity.interval"], Milliseconds(Duration("1h")))
+      transform/k8s-dashboard:
+        error_mode: ignore
+        metric_statements:
+        - context: metric
+          statements:
+          - set(metric.unit, "1") where metric.name == "k8s.pod.phase"
+          - set(metric.unit, "") where metric.name == "kube_node_info"
+          - set(metric.unit, "") where metric.name == "k8s.container.status.last_terminated_reason"
+        - context: datapoint
+          statements:
+          - set(datapoint.value_int, 1) where metric.name == "kube_pod_status_qos_class"
+          - set(datapoint.attributes["qos_class"], resource.attributes["k8s.pod.qos_class"])
+            where metric.name == "kube_pod_status_qos_class"
+          - set(datapoint.attributes["pod"], resource.attributes["k8s.pod.name"]) where
+            metric.name == "kube_pod_status_reason"
+          - set(datapoint.attributes["reason"], "Evicted") where metric.name == "kube_pod_status_reason"
+            and datapoint.value_int == 1
+          - set(datapoint.attributes["reason"], "NodeAffinity") where metric.name == "kube_pod_status_reason"
+            and datapoint.value_int == 2
+          - set(datapoint.attributes["reason"], "NodeLost") where metric.name == "kube_pod_status_reason"
+            and datapoint.value_int == 3
+          - set(datapoint.attributes["reason"], "Shutdown") where metric.name == "kube_pod_status_reason"
+            and datapoint.value_int == 4
+          - set(datapoint.attributes["reason"], "UnexpectedAdmissionError") where metric.name
+            == "kube_pod_status_reason" and datapoint.value_int == 5
+          - set(datapoint.value_int, 0) where metric.name == "kube_pod_status_reason"
+            and datapoint.value_int == 6
+          - set(datapoint.value_int, 1) where metric.name == "kube_pod_status_reason"
+            and datapoint.value_int != 0
+          - set(datapoint.value_int, 1) where metric.name == "kube_node_info"
+          - set(datapoint.attributes["kubelet_version"], resource.attributes["k8s.kubelet.version"])
+            where metric.name == "kube_node_info"
+          - set(datapoint.value_int, 1) where metric.name == "k8s.container.status.last_terminated_reason"
+          - set(datapoint.attributes["reason"], "") where metric.name == "k8s.container.status.last_terminated_reason"
+          - set(datapoint.attributes["reason"], resource.attributes["k8s.container.status.last_terminated_reason"])
+            where metric.name == "k8s.container.status.last_terminated_reason"
+        - context: resource
+          statements:
+          - delete_key(resource.attributes, "k8s.container.status.last_terminated_reason")
+          - delete_key(resource.attributes, "k8s.pod.qos_class")
+          - delete_key(resource.attributes, "k8s.kubelet.version")
+      transform/kube-events:
+        log_statements:
+        - context: log
+          statements:
+          - keep_keys(log.body["object"], ["type", "eventTime", "reason", "regarding",
+            "note", "metadata", "deprecatedFirstTimestamp", "deprecatedLastTimestamp"])
+            where IsMap(log.body) and IsMap(log.body["object"])
+          - keep_keys(log.body["object"]["metadata"], ["creationTimestamp"]) where IsMap(log.body)
+            and IsMap(log.body["object"]) and IsMap(log.body["object"]["metadata"])
+          - keep_keys(log.body["object"]["regarding"], ["kind", "name", "namespace"])
+            where IsMap(log.body) and IsMap(log.body["object"]) and IsMap(log.body["object"]["regarding"])
+      transform/prometheus:
+        error_mode: ignore
+        metric_statements:
+        - context: metric
+          statements:
+          - replace_pattern(metric.name, "_total$", "") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_cpu_seconds_seconds$", "otelcol_process_cpu_seconds")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_runtime_heap_alloc_bytes_bytes$",
+            "otelcol_process_runtime_heap_alloc_bytes") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_runtime_total_alloc_bytes_bytes$",
+            "otelcol_process_runtime_total_alloc_bytes") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_runtime_total_sys_memory_bytes_bytes$",
+            "otelcol_process_runtime_total_sys_memory_bytes") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_fileconsumer_open_files$", "otelcol_fileconsumer_open_files_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_fileconsumer_reading_files$", "otelcol_fileconsumer_reading_files_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_ip_lookup_miss$", "otelcol_otelsvc_k8s_ip_lookup_miss_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_pod_added$", "otelcol_otelsvc_k8s_pod_added_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_pod_updated$", "otelcol_otelsvc_k8s_pod_updated_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_pod_deleted$", "otelcol_otelsvc_k8s_pod_deleted_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_processor_filter_spans\\.filtered$",
+            "otelcol_processor_filter_spans.filtered_ratio") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+        - context: resource
+          statements:
+          - set(resource.attributes["k8s.pod.ip"], resource.attributes["net.host.name"])
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - delete_key(resource.attributes, "service_name") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+        - context: datapoint
+          statements:
+          - delete_key(datapoint.attributes, "service_name") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - delete_key(datapoint.attributes, "otel_scope_name") where datapoint.attributes["service.name"]
+            == "opentelemetry-collector"
+    receivers:
+      k8s_cluster:
+        allocatable_types_to_report:
+        - cpu
+        - memory
+        collection_interval: '30s'
+        metrics:
+          k8s.pod.status_reason:
+            enabled: true
+        resource_attributes:
+          k8s.container.status.last_terminated_reason:
+            enabled: true
+          k8s.kubelet.version:
+            enabled: true
+          k8s.pod.qos_class:
+            enabled: true
+      k8sobjects:
+        objects:
+        - exclude_watch_type:
+          - DELETED
+          group: events.k8s.io
+          mode: watch
+          name: events
+      k8sobjects/resource_catalog:
+        objects:
+        - group: ""
+          mode: pull
+          name: namespaces
+        - group: ""
+          mode: pull
+          name: nodes
+        - group: ""
+          mode: pull
+          name: persistentvolumeclaims
+        - group: ""
+          mode: pull
+          name: persistentvolumes
+        - group: ""
+          mode: pull
+          name: pods
+        - group: ""
+          mode: pull
+          name: services
+        - group: apps
+          mode: pull
+          name: daemonsets
+        - group: apps
+          mode: pull
+          name: deployments
+        - group: apps
+          mode: pull
+          name: replicasets
+        - group: apps
+          mode: pull
+          name: statefulsets
+        - group: autoscaling
+          mode: pull
+          name: horizontalpodautoscalers
+        - group: batch
+          mode: pull
+          name: cronjobs
+        - group: batch
+          mode: pull
+          name: jobs
+        - group: extensions
+          mode: pull
+          name: ingresses
+        - group: networking.k8s.io
+          mode: pull
+          name: ingresses
+        - group: policy
+          mode: pull
+          name: poddisruptionbudgets
+        - group: rbac.authorization.k8s.io
+          mode: pull
+          name: clusterrolebindings
+        - group: rbac.authorization.k8s.io
+          mode: pull
+          name: clusterroles
+        - group: rbac.authorization.k8s.io
+          mode: pull
+          name: rolebindings
+        - group: rbac.authorization.k8s.io
+          mode: pull
+          name: roles
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: ""
+          mode: watch
+          name: namespaces
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: ""
+          mode: watch
+          name: nodes
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: ""
+          mode: watch
+          name: persistentvolumeclaims
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: ""
+          mode: watch
+          name: persistentvolumes
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: ""
+          mode: watch
+          name: pods
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: apps
+          mode: watch
+          name: daemonsets
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: apps
+          mode: watch
+          name: deployments
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: apps
+          mode: watch
+          name: replicasets
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: apps
+          mode: watch
+          name: statefulsets
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: autoscaling
+          mode: watch
+          name: horizontalpodautoscalers
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: batch
+          mode: watch
+          name: cronjobs
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: batch
+          mode: watch
+          name: jobs
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: extensions
+          mode: watch
+          name: ingresses
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: networking.k8s.io
+          mode: watch
+          name: ingresses
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: policy
+          mode: watch
+          name: poddisruptionbudgets
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: rbac.authorization.k8s.io
+          mode: watch
+          name: clusterrolebindings
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: rbac.authorization.k8s.io
+          mode: watch
+          name: clusterroles
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: rbac.authorization.k8s.io
+          mode: watch
+          name: rolebindings
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: rbac.authorization.k8s.io
+          mode: watch
+          name: roles
+      otlp:
+        protocols:
+          grpc:
+            endpoint: ${env:MY_POD_IP}:4317
+            max_recv_msg_size_mib: 20
+          http:
+            endpoint: ${env:MY_POD_IP}:4318
+      prometheus:
+        config:
+          scrape_configs:
+          - job_name: opentelemetry-collector
+            scrape_interval: '30s'
+            static_configs:
+            - targets:
+              - ${env:MY_POD_IP}:8888
+      prometheus/k8s_apiserver_metrics:
+        config:
+          scrape_configs:
+          - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            honor_timestamps: true
+            job_name: kubernetes-apiserver
+            kubernetes_sd_configs:
+            - role: endpoints
+            relabel_configs:
+            - action: keep
+              regex: default;kubernetes;https
+              source_labels:
+              - __meta_kubernetes_namespace
+              - __meta_kubernetes_service_name
+              - __meta_kubernetes_endpoint_port_name
+            scheme: https
+            tls_config:
+              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              insecure_skip_verify: true
+    service:
+      extensions:
+      - health_check
+      - k8s_observer
+      - opamp
+      - zpages
+      - pprof
+      pipelines:
+        logs:
+          exporters:
+          - coralogix
+          processors:
+          - memory_limiter
+          - resource/metadata
+          - resource/kube-events
+          - resourcedetection/region
+          - resourcedetection/env
+          - k8sattributes
+          - transform/kube-events
+          - batch
+          receivers:
+          - k8sobjects
+          - otlp
+        logs/resource_catalog:
+          exporters:
+          - coralogix/resource_catalog
+          processors:
+          - memory_limiter
+          - resourcedetection/resource_catalog
+          - transform/entity-event
+          - filter/workflow
+          - resource/metadata
+          - batch
+          receivers:
+          - k8sobjects/resource_catalog
+        metrics:
+          exporters:
+          - coralogix
+          processors:
+          - memory_limiter
+          - resource/metadata
+          - resourcedetection/region
+          - resourcedetection/env
+          - k8sattributes
+          - metricstransform/k8s-dashboard
+          - transform/k8s-dashboard
+          - filter/k8s_apiserver_metrics
+          - transform/prometheus
+          - batch
+          receivers:
+          - k8s_cluster
+          - prometheus/k8s_apiserver_metrics
+          - prometheus
+          - otlp
+        traces:
+          exporters:
+          - debug
+          - coralogix
+          processors:
+          - memory_limiter
+          - resource/metadata
+          - resourcedetection/region
+          - resourcedetection/env
+          - k8sattributes
+          - batch
+          receivers:
+          - otlp
+      telemetry:
+        logs:
+          encoding: json
+          level: 'warn'
+        metrics:
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: ${env:MY_POD_IP}
+                  port: 8888
+                  without_scope_info: false
+                  without_type_suffix: false
+                  without_units: false
+        resource:
+          cx.agent.type: cluster-collector
+          service.name: opentelemetry-collector
+---
+# Source: otel-integration/charts/opentelemetry-agent-windows/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: coralogix-opentelemetry-agent-windows
+  labels:
+    helm.sh/chart: opentelemetry-agent-windows-0.132.0
+    app.kubernetes.io/name: opentelemetry-agent-windows
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "namespaces"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods", "endpoints", "nodes/stats", "nodes/metrics", "nodes", "services"]
+    verbs: ["get", "watch", "list"]
+  - nonResourceURLs:
+    - "/metrics"
+    verbs: ["get"]
+---
+# Source: otel-integration/charts/opentelemetry-agent/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: coralogix-opentelemetry-agent
+  labels:
+    helm.sh/chart: opentelemetry-agent-0.132.0
+    app.kubernetes.io/name: opentelemetry-agent
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "namespaces"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes", "nodes/stats", "nodes/metrics"]
+    verbs: ["get", "watch", "list"]
+  - nonResourceURLs:
+    - "/metrics"
+    verbs: ["get"]
+---
+# Source: otel-integration/charts/opentelemetry-cluster-collector/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: coralogix-opentelemetry-collector
+  labels:
+    helm.sh/chart: opentelemetry-cluster-collector-0.132.0
+    app.kubernetes.io/name: opentelemetry-cluster-collector
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "namespaces"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events", "namespaces", "namespaces/status", "nodes", "nodes/spec", "pods", "pods/status", "replicationcontrollers", "replicationcontrollers/status", "resourcequotas", "services" ]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources: ["daemonsets", "deployments", "replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods", "endpoints", "nodes/stats", "nodes/metrics", "nodes", "services"]
+    verbs: ["get", "watch", "list"]
+  - nonResourceURLs:
+    - "/metrics"
+    verbs: ["get"]
+  - apiGroups: ["events.k8s.io"]
+    resources: ["events"]
+    verbs: ["watch", "list"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["aws-auth"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources:
+    - namespaces
+    - nodes
+    - persistentvolumeclaims
+    - persistentvolumes
+    - pods
+    - services
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources:
+    - daemonsets
+    - deployments
+    - replicasets
+    - statefulsets
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["autoscaling"]
+    resources:
+    - horizontalpodautoscalers
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources:
+    - cronjobs
+    - jobs
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources:
+    - ingresses
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+    - ingresses
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["policy"]
+    resources:
+    - poddisruptionbudgets
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources:
+    - clusterrolebindings
+    - clusterroles
+    - rolebindings
+    - roles
+    verbs: ["get", "list", "watch"]
+---
+# Source: otel-integration/charts/opentelemetry-agent-windows/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: coralogix-opentelemetry-agent-windows
+  labels:
+    helm.sh/chart: opentelemetry-agent-windows-0.132.0
+    app.kubernetes.io/name: opentelemetry-agent-windows
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: coralogix-opentelemetry-agent-windows
+subjects:
+- kind: ServiceAccount
+  name: coralogix-opentelemetry-windows
+  namespace: default
+---
+# Source: otel-integration/charts/opentelemetry-agent/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: coralogix-opentelemetry-agent
+  labels:
+    helm.sh/chart: opentelemetry-agent-0.132.0
+    app.kubernetes.io/name: opentelemetry-agent
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: coralogix-opentelemetry-agent
+subjects:
+- kind: ServiceAccount
+  name: coralogix-opentelemetry
+  namespace: default
+---
+# Source: otel-integration/charts/opentelemetry-cluster-collector/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: coralogix-opentelemetry-collector
+  labels:
+    helm.sh/chart: opentelemetry-cluster-collector-0.132.0
+    app.kubernetes.io/name: opentelemetry-cluster-collector
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: coralogix-opentelemetry-collector
+subjects:
+- kind: ServiceAccount
+  name: coralogix-opentelemetry-collector
+  namespace: default
+---
+# Source: otel-integration/charts/opentelemetry-cluster-collector/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: coralogix-opentelemetry-collector
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-cluster-collector-0.132.0
+    app.kubernetes.io/name: opentelemetry-cluster-collector
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+    component: standalone-collector
+spec:
+  type: ClusterIP
+  ports:
+
+    - name: otlp
+      port: 4317
+      targetPort: 4317
+      protocol: TCP
+      appProtocol: grpc
+  selector:
+    app.kubernetes.io/name: opentelemetry-cluster-collector
+    app.kubernetes.io/instance: render-check
+    component: standalone-collector
+  internalTrafficPolicy: Cluster
+---
+# Source: otel-integration/charts/opentelemetry-agent-windows/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: coralogix-opentelemetry-windows-agent
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-agent-windows-0.132.0
+    app.kubernetes.io/name: opentelemetry-agent-windows
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opentelemetry-agent-windows
+      app.kubernetes.io/instance: render-check
+      component: agent-collector
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: 826953bc5d16342c76b72a02d57be6dc6be09a7c752c51d70be6432b090c65ac
+
+      labels:
+        app.kubernetes.io/name: opentelemetry-agent-windows
+        app.kubernetes.io/instance: render-check
+        component: agent-collector
+
+    spec:
+
+      serviceAccountName: coralogix-opentelemetry-windows
+      securityContext:
+        {}
+      containers:
+        - name: opentelemetry-agent-windows
+          command:
+            - "C:\\otelcol-contrib.exe"
+            - --config=C:\\conf\relay.yaml
+          securityContext:
+            {}
+          image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.152.1-windows-2019-amd64"
+          imagePullPolicy: Always
+          ports:
+            - name: jaeger-binary
+              containerPort: 6832
+              protocol: TCP
+              hostPort: 6832
+            - name: jaeger-compact
+              containerPort: 6831
+              protocol: UDP
+              hostPort: 6831
+            - name: jaeger-grpc
+              containerPort: 14250
+              protocol: TCP
+              hostPort: 14250
+            - name: jaeger-thrift
+              containerPort: 14268
+              protocol: TCP
+              hostPort: 14268
+            - name: otlp
+              containerPort: 4317
+              protocol: TCP
+              hostPort: 4317
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+              hostPort: 4318
+            - name: statsd
+              containerPort: 8125
+              protocol: UDP
+              hostPort: 8125
+            - name: zipkin
+              containerPort: 9411
+              protocol: TCP
+              hostPort: 9411
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+            - name: GOMEMLIMIT
+              value: "1525MiB"
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "k8s.node.name=$(K8S_NODE_NAME),k8s.node.name=$(K8S_NODE_NAME),deployment.environment.name=golden-render"
+            - name: CORALOGIX_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: PRIVATE_KEY
+                  name: coralogix-keys
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          resources:
+            limits:
+              cpu: 1
+              memory: 2G
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          volumeMounts:
+            - mountPath: C:\conf
+              name: opentelemetry-agent-windows-configmap
+            - name: varlogpods
+              mountPath: C:\var\log\pods
+              readOnly: true
+            - name: varlibotelcol
+              mountPath: /var/lib/otelcol
+            - mountPath: "C:\\hostfs"
+              name: hostfs
+              readOnly: true
+            - mountPath: /etc/machine-id
+              mountPropagation: HostToContainer
+              name: etcmachineid
+              readOnly: true
+            - mountPath: /var/lib/dbus/machine-id
+              mountPropagation: HostToContainer
+              name: varlibdbusmachineid
+              readOnly: true
+      volumes:
+        - name: opentelemetry-agent-windows-configmap
+          configMap:
+            name: coralogix-opentelemetry-windows-agent
+            items:
+              - key: relay
+                path: relay.yaml
+        - name: varlogpods
+          hostPath:
+            path: C:\var\log\pods
+        - name: programdata
+          hostPath:
+            path: C:\ProgramData
+        - name: varlibotelcol
+          hostPath:
+            path: /var/lib/otelcol
+            type: DirectoryOrCreate
+        - name: hostfs
+          hostPath:
+            path: "C:\\"
+        - hostPath:
+            path: /etc/machine-id
+          name: etcmachineid
+        - hostPath:
+            path: /var/lib/dbus/machine-id
+          name: varlibdbusmachineid
+      nodeSelector:
+
+        kubernetes.io/os: windows
+      tolerations:
+        - operator: Exists
+      dnsPolicy: ClusterFirstWithHostNet
+---
+# Source: otel-integration/charts/opentelemetry-agent/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: coralogix-opentelemetry-agent
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-agent-0.132.0
+    app.kubernetes.io/name: opentelemetry-agent
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opentelemetry-agent
+      app.kubernetes.io/instance: render-check
+      component: agent-collector
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: db363f35618487c8f7861e22b708b4ca86d181b66884dbcb670df30beff396c9
+
+      labels:
+        app.kubernetes.io/name: opentelemetry-agent
+        app.kubernetes.io/instance: render-check
+        component: agent-collector
+
+    spec:
+
+      serviceAccountName: coralogix-opentelemetry
+      securityContext:
+        {}
+      containers:
+        - name: opentelemetry-agent
+          command:
+            - /otelcol-contrib
+            - --config=/conf/relay.yaml
+            - --feature-gates=+service.profilesSupport
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+          image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.152.1"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: jaeger-binary
+              containerPort: 6832
+              protocol: TCP
+              hostPort: 6832
+            - name: jaeger-compact
+              containerPort: 6831
+              protocol: UDP
+              hostPort: 6831
+            - name: jaeger-grpc
+              containerPort: 14250
+              protocol: TCP
+              hostPort: 14250
+            - name: jaeger-thrift
+              containerPort: 14268
+              protocol: TCP
+              hostPort: 14268
+            - name: otlp
+              containerPort: 4317
+              protocol: TCP
+              hostPort: 4317
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+              hostPort: 4318
+            - name: statsd
+              containerPort: 8125
+              protocol: UDP
+              hostPort: 8125
+            - name: zipkin
+              containerPort: 9411
+              protocol: TCP
+              hostPort: 9411
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: KUBE_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+            - name: GOMEMLIMIT
+              value: "1525MiB"
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "k8s.node.name=$(K8S_NODE_NAME),deployment.environment.name=golden-render"
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: CORALOGIX_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: PRIVATE_KEY
+                  name: coralogix-keys
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          resources:
+            limits:
+              cpu: 1
+              memory: 2G
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          volumeMounts:
+            - mountPath: /conf
+              name: opentelemetry-agent-configmap
+            - name: varlogpods
+              mountPath: /var/log/pods
+              readOnly: true
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+            - name: varlibotelcol
+              mountPath: /var/lib/otelcol
+            - name: hostfs
+              mountPath: /hostfs
+              readOnly: true
+              mountPropagation: HostToContainer
+            - mountPath: /etc/machine-id
+              mountPropagation: HostToContainer
+              name: etcmachineid
+              readOnly: true
+            - mountPath: /var/lib/dbus/machine-id
+              mountPropagation: HostToContainer
+              name: varlibdbusmachineid
+              readOnly: true
+      volumes:
+        - name: opentelemetry-agent-configmap
+          configMap:
+            name: coralogix-opentelemetry-agent
+            items:
+              - key: relay
+                path: relay.yaml
+        - name: varlogpods
+          hostPath:
+            path: /var/log/pods
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+        - name: varlibotelcol
+          hostPath:
+            path: /var/lib/otelcol
+            type: DirectoryOrCreate
+        - name: hostfs
+          hostPath:
+            path: /
+        - name: etcmachineid
+          hostPath:
+            path: /etc/machine-id
+        - name: varlibdbusmachineid
+          hostPath:
+            path: /var/lib/dbus/machine-id
+      nodeSelector:
+
+        kubernetes.io/os: linux
+      tolerations:
+        - operator: Exists
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+---
+# Source: otel-integration/charts/opentelemetry-cluster-collector/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coralogix-opentelemetry-collector
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-cluster-collector-0.132.0
+    app.kubernetes.io/name: opentelemetry-cluster-collector
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.152.1"
+    app.kubernetes.io/managed-by: Helm
+
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opentelemetry-cluster-collector
+      app.kubernetes.io/instance: render-check
+      component: standalone-collector
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: f40e8af2bd36b2ae59a97c43ca3e468cf2e274a67711e09bc9442d102c56eb47
+
+      labels:
+        app.kubernetes.io/name: opentelemetry-cluster-collector
+        app.kubernetes.io/instance: render-check
+        component: standalone-collector
+
+    spec:
+
+      serviceAccountName: coralogix-opentelemetry-collector
+      securityContext:
+        {}
+      containers:
+        - name: opentelemetry-cluster-collector
+          command:
+            - /otelcol-contrib
+            - --config=/conf/relay.yaml
+          securityContext:
+            {}
+          image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.152.1"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: otlp
+              containerPort: 4317
+              protocol: TCP
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: GOMEMLIMIT
+              value: "1525MiB"
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "deployment.environment.name=golden-render"
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: CORALOGIX_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: PRIVATE_KEY
+                  name: coralogix-keys
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          startupProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            failureThreshold: 4
+            httpGet:
+              port: 13133
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          resources:
+            limits:
+              cpu: 1
+              memory: 2G
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          volumeMounts:
+            - mountPath: /conf
+              name: opentelemetry-cluster-collector-configmap
+            - mountPath: /etc/machine-id
+              mountPropagation: HostToContainer
+              name: etcmachineid
+              readOnly: true
+            - mountPath: /var/lib/dbus/machine-id
+              mountPropagation: HostToContainer
+              name: varlibdbusmachineid
+              readOnly: true
+      volumes:
+        - name: opentelemetry-cluster-collector-configmap
+          configMap:
+            name: coralogix-opentelemetry-collector
+            items:
+              - key: relay
+                path: relay.yaml
+        - name: etcmachineid
+          hostPath:
+            path: /etc/machine-id
+        - name: varlibdbusmachineid
+          hostPath:
+            path: /var/lib/dbus/machine-id
+      nodeSelector:
+
+        kubernetes.io/os: linux
+      hostNetwork: false

--- a/otel-supervised-cdot/Dockerfile
+++ b/otel-supervised-cdot/Dockerfile
@@ -3,11 +3,15 @@ ARG COLLECTOR_VERSION=v0.5.7
 ARG SUPERVISOR_VERSION=0.142.0
 
 FROM alpine:3.22 AS certs
-RUN apk --update add ca-certificates
-RUN mkdir -p /etc/otelcol-contrib/supervisor-data
+RUN apk add --no-cache ca-certificates=20260413-r0 \
+    && mkdir -p /etc/otelcol-contrib/supervisor-data
 
+# DL3006: Always tag the version of an image explicitly.
+# hadolint ignore=DL3006
 FROM cgx.jfrog.io/coralogix-docker-images/cx-opampsupervisor:${SUPERVISOR_VERSION} AS supervisor
 
+# DL3006: Always tag the version of an image explicitly.
+# hadolint ignore=DL3006
 FROM coralogixrepo/coralogix-otel-collector:${COLLECTOR_VERSION}
 
 USER 10001:10001

--- a/otel-supervised-cdot/examples/supervisor.yaml
+++ b/otel-supervised-cdot/examples/supervisor.yaml
@@ -3,7 +3,7 @@ server:
   endpoint: "http://host.docker.internal:4320/v1/opamp"
   headers:
     # This is a mocked token for testing purposes.
-    X-Coralogix-Auth: "EgY0MjQyNDIiUApOCiRmZjhjODJmNi1iNzk2LTRhMWUtODkzMi0yMjBlMTc3MDBjMmUQBhokMzg2ZjA1ZjYtMWUyNS00ZmM0LWJhZjItNDgwZWQ5Yzk5NDJmQgkaBzEuMi4zLjQ="
+    X-Coralogix-Auth: "mock-coralogix-auth-token"
   tls:
     insecure_skip_verify: true
 

--- a/otel-supervised-collector/Dockerfile
+++ b/otel-supervised-collector/Dockerfile
@@ -3,11 +3,15 @@ ARG COLLECTOR_VERSION
 ARG SUPERVISOR_VERSION
 
 FROM alpine:3.22 AS certs
-RUN apk --update add ca-certificates
-RUN mkdir -p /etc/otelcol-contrib/supervisor-data
+RUN apk add --no-cache ca-certificates=20260413-r0 \
+    && mkdir -p /etc/otelcol-contrib/supervisor-data
 
+# DL3006: Always tag the version of an image explicitly.
+# hadolint ignore=DL3006
 FROM cgx.jfrog.io/coralogix-docker-images/cx-opampsupervisor:${SUPERVISOR_VERSION} AS supervisor
 
+# DL3006: Always tag the version of an image explicitly.
+# hadolint ignore=DL3006
 FROM ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:${COLLECTOR_VERSION} AS collector
 
 # Uncomment the line below to generate a more helpful debug container

--- a/otel-supervised-collector/examples/supervisor.yaml
+++ b/otel-supervised-collector/examples/supervisor.yaml
@@ -3,7 +3,7 @@ server:
   endpoint: "http://host.docker.internal:4320/v1/opamp"
   headers:
     # This is a mocked token for testing purposes.
-    X-Coralogix-Auth: "EgY0MjQyNDIiUApOCiRmZjhjODJmNi1iNzk2LTRhMWUtODkzMi0yMjBlMTc3MDBjMmUQBhokMzg2ZjA1ZjYtMWUyNS00ZmM0LWJhZjItNDgwZWQ5Yzk5NDJmQgkaBzEuMi4zLjQ="
+    X-Coralogix-Auth: "mock-coralogix-auth-token"
   tls:
     insecure_skip_verify: true
 

--- a/otel-supervised-collector/uninstall.sh
+++ b/otel-supervised-collector/uninstall.sh
@@ -34,6 +34,7 @@ ensure_sudo() {
 
 detect_pkg_type() {
   if [ -r /etc/os-release ]; then
+    # shellcheck disable=SC1091 # Runtime OS metadata file; guarded by readability check.
     . /etc/os-release
     base="${ID_LIKE:-$ID}"
     case "$base" in

--- a/otel-supervised-ebpf-profiler/Dockerfile
+++ b/otel-supervised-ebpf-profiler/Dockerfile
@@ -3,11 +3,15 @@ ARG COLLECTOR_VERSION=0.147.0
 ARG SUPERVISOR_VERSION=0.147.0
 
 FROM alpine:3.22 AS certs
-RUN apk --update add ca-certificates
-RUN mkdir -p /etc/otelcol-contrib/supervisor-data
+RUN apk add --no-cache ca-certificates=20260413-r0 \
+    && mkdir -p /etc/otelcol-contrib/supervisor-data
 
+# DL3006: Always tag the version of an image explicitly.
+# hadolint ignore=DL3006
 FROM cgx.jfrog.io/coralogix-docker-images/cx-opampsupervisor:${SUPERVISOR_VERSION} AS supervisor
 
+# DL3006: Always tag the version of an image explicitly.
+# hadolint ignore=DL3006
 FROM ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-ebpf-profiler:${COLLECTOR_VERSION}
 
 USER 10001:10001

--- a/scripts/bump-otel-collector-version.sh
+++ b/scripts/bump-otel-collector-version.sh
@@ -272,7 +272,7 @@ update_changelog() {
     temp_file=$(mktemp)
     head -n $((first_version_line - 1)) "$changelog_path" > "$temp_file"
     cat "$entry_file" >> "$temp_file"
-    tail -n +$first_version_line "$changelog_path" >> "$temp_file"
+    tail -n +"$first_version_line" "$changelog_path" >> "$temp_file"
     mv "$temp_file" "$changelog_path"
   else
     # No version headers found, append to end

--- a/scripts/changelog_check.sh
+++ b/scripts/changelog_check.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # Simply check if diff in changelog exists.
-git diff --exit-code --quiet origin/master... ./$1/CHANGELOG.md
+git diff --exit-code --quiet origin/master... -- "./$1/CHANGELOG.md"
 if [ $? -ne 1 ]; then
   echo "Following files have been changed:"
-  echo $(git diff --name-only origin/master... ./$1)
+  git diff --name-only origin/master... -- "./$1"
   echo ""
   echo "Please add a changelog entry in $1/CHANGELOG.md or add 'skip changelog' label to your PR if this change does not require an entry".
   exit 1

--- a/scripts/version_bump_check.sh
+++ b/scripts/version_bump_check.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
 
 # Simply check if diff in 'version' exists in the chart file.
-git diff origin/master... ./$1/Chart.yaml | grep -q "+version";
-if [ $? -ne 0 ]; then
+if ! git diff origin/master... -- "./$1/Chart.yaml" | grep -q "+version"; then
   echo "Following files have been changed:"
-  echo $(git diff --name-only origin/master... ./$1)
+  git diff --name-only origin/master... -- "./$1"
   echo ""
   echo "Chart version in $1/Chart.yaml needs to be updated."
   exit 1

--- a/telemetrygen-windows-image/Dockerfile
+++ b/telemetrygen-windows-image/Dockerfile
@@ -5,16 +5,20 @@ ARG TELEMETRYGEN_VERSION=v0.147.0
 ARG WIN_BASE_IMAGE=mcr.microsoft.com/windows/servercore:ltsc2019
 
 # Build stage: cross-compile telemetrygen for Windows
+# DL3029: Do not use --platform= with FROM.
+# hadolint ignore=DL3029
 FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS build
-RUN apk add --no-cache git
+RUN apk add --no-cache git=2.54.0-r0
 ARG TELEMETRYGEN_VERSION
 WORKDIR /src
-RUN git clone --depth 1 --branch ${TELEMETRYGEN_VERSION} https://github.com/open-telemetry/opentelemetry-collector-contrib.git .
+RUN git clone --depth 1 --branch "${TELEMETRYGEN_VERSION}" https://github.com/open-telemetry/opentelemetry-collector-contrib.git .
 # telemetrygen is a separate Go module; build from its directory
 WORKDIR /src/cmd/telemetrygen
 RUN CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o telemetrygen.exe .
 
 ##
+# DL3006: Always tag the version of an image explicitly.
+# hadolint ignore=DL3006
 FROM ${WIN_BASE_IMAGE}
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]


### PR DESCRIPTION
# Description

**Most of the added lines (around 97%) are Helm golden render snapshots.**

Add CI coverage for security and hygiene checks:

- gitleaks current-tree secret scanning
- shellcheck for checked-in shell scripts
- hadolint for Dockerfiles
- Helm golden render checks for high-risk presets

Some `shellcheck`/`hadolint` ignores were added where changing the code would be riskier than documenting the existing baseline. Examples include preserving existing Docker label keys that may be externally consumed, keeping established package-install commands unchanged, and avoiding behavior changes in installer/runtime scripts where lint-only rewrites could affect execution.

# How Has This Been Tested?

1. Deliberately added or changed files to force each new CI job to fail:
   - fake private key for `gitleaks`
   - unquoted shell variable for `shellcheck`
   - bad Dockerfile fixture for `hadolint`
   - golden render mismatch for Helm

2. Confirmed the jobs failed for the expected reasons, then reverted the failure fixtures.

3. Re-ran the checks and verified the scripts/jobs passed again.

4. Built the changed Linux Dockerfiles with Docker where possible; the buildable images passed. Windows Dockerfiles were not built locally because macOS Docker Desktop cannot build Windows container images.

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [x] This change does not affect any particular component (e.g. it's CI or docs change)
