### PR TITLE
fix(eks-fargate): accept secret keys  PRIVATE_KEY and CORALOGIX_PRIVATE_KEY

### DIFF
--- a/otel-eks-fargate/CHANGELOG.md
+++ b/otel-eks-fargate/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## OpenTelemetry EKS-Fargate
 
+### v0.0.6 / 2026-06-16
+
+* [BREAKING] Rename Kubernetes secret key from `PRIVATE_KEY` to `CORALOGIX_PRIVATE_KEY` to match the container environment variable name. Before applying updated manifests, recreate the secret:
+  ```bash
+  kubectl delete secret coralogix-keys -n $NAMESPACE
+  kubectl create secret generic coralogix-keys -n $NAMESPACE --from-literal=CORALOGIX_PRIVATE_KEY=<your-api-key>
+  ```
+
 ### v0.0.5 / 2025-05-14
 * [FIX] Remove overwrite of k8s.node.name attribute
 

--- a/otel-eks-fargate/CHANGELOG.md
+++ b/otel-eks-fargate/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemetry EKS-Fargate
 
+### v0.0.6 / 2026-06-16
+
+* [FEAT] Accept both `PRIVATE_KEY` and `CORALOGIX_PRIVATE_KEY` as secret key names in the `coralogix-keys` secret
+
 ### v0.0.5 / 2025-05-14
 * [FIX] Remove overwrite of k8s.node.name attribute
 

--- a/otel-eks-fargate/CHANGELOG.md
+++ b/otel-eks-fargate/CHANGELOG.md
@@ -2,14 +2,6 @@
 
 ## OpenTelemetry EKS-Fargate
 
-### v0.0.6 / 2026-06-16
-
-* [BREAKING] Rename Kubernetes secret key from `PRIVATE_KEY` to `CORALOGIX_PRIVATE_KEY` to match the container environment variable name. Before applying updated manifests, recreate the secret:
-  ```bash
-  kubectl delete secret coralogix-keys -n $NAMESPACE
-  kubectl create secret generic coralogix-keys -n $NAMESPACE --from-literal=CORALOGIX_PRIVATE_KEY=<your-api-key>
-  ```
-
 ### v0.0.5 / 2025-05-14
 * [FIX] Remove overwrite of k8s.node.name attribute
 

--- a/otel-eks-fargate/README.md
+++ b/otel-eks-fargate/README.md
@@ -15,11 +15,11 @@ The Coralogix EKS Fargate integration for Metrics and Traces leverages OpenTelem
 ## Creating Secret
 
 1. Export your API key to a local variable:
-   1. `export CORALOGIX_PRIVATE_KEY=<Send-Your-Data API key>`
+   1. `export PRIVATE_KEY=<Send-Your-Data API key>`
 2. Set your namespace variable:
    1. `export NAMESPACE=cx-eks-fargate-otel`
 3. Create the secret using kubectl:
-   1. `kubectl create secret generic coralogix-keys -n $NAMESPACE --from-literal=CORALOGIX_PRIVATE_KEY=$CORALOGIX_PRIVATE_KEY`
+   1. `kubectl create secret generic coralogix-keys -n $NAMESPACE --from-literal=PRIVATE_KEY=$PRIVATE_KEY`
 4. Confirm it’s been set
    1. `kubectl get secret coralogix-keys -o yaml -n $NAMESPACE`
 

--- a/otel-eks-fargate/README.md
+++ b/otel-eks-fargate/README.md
@@ -15,11 +15,11 @@ The Coralogix EKS Fargate integration for Metrics and Traces leverages OpenTelem
 ## Creating Secret
 
 1. Export your API key to a local variable:
-   1. `export CORALOGIX_PRIVATE_KEY=<Send-Your-Data API key>`
+   1. `export PRIVATE_KEY=<Send-Your-Data API key>`
 2. Set your namespace variable:
    1. `export NAMESPACE=cx-eks-fargate-otel`
 3. Create the secret using kubectl:
-   1. `kubectl create secret generic coralogix-keys -n $NAMESPACE --from-literal=PRIVATE_KEY=$CORALOGIX_PRIVATE_KEY`
+   1. `kubectl create secret generic coralogix-keys -n $NAMESPACE --from-literal=PRIVATE_KEY=$PRIVATE_KEY`
 4. Confirm it’s been set
    1. `kubectl get secret coralogix-keys -o yaml -n $NAMESPACE`
 

--- a/otel-eks-fargate/README.md
+++ b/otel-eks-fargate/README.md
@@ -15,11 +15,11 @@ The Coralogix EKS Fargate integration for Metrics and Traces leverages OpenTelem
 ## Creating Secret
 
 1. Export your API key to a local variable:
-   1. `export PRIVATE_KEY=<Send-Your-Data API key>`
+   1. `export CORALOGIX_PRIVATE_KEY=<Send-Your-Data API key>`
 2. Set your namespace variable:
    1. `export NAMESPACE=cx-eks-fargate-otel`
 3. Create the secret using kubectl:
-   1. `kubectl create secret generic coralogix-keys -n $NAMESPACE --from-literal=PRIVATE_KEY=$PRIVATE_KEY`
+   1. `kubectl create secret generic coralogix-keys -n $NAMESPACE --from-literal=CORALOGIX_PRIVATE_KEY=$CORALOGIX_PRIVATE_KEY`
 4. Confirm it’s been set
    1. `kubectl get secret coralogix-keys -o yaml -n $NAMESPACE`
 

--- a/otel-eks-fargate/README.md
+++ b/otel-eks-fargate/README.md
@@ -15,11 +15,11 @@ The Coralogix EKS Fargate integration for Metrics and Traces leverages OpenTelem
 ## Creating Secret
 
 1. Export your API key to a local variable:
-   1. `export PRIVATE_KEY=<Send-Your-Data API key>`
+   1. `export CORALOGIX_PRIVATE_KEY=<Send-Your-Data API key>`
 2. Set your namespace variable:
    1. `export NAMESPACE=cx-eks-fargate-otel`
 3. Create the secret using kubectl:
-   1. `kubectl create secret generic coralogix-keys -n $NAMESPACE --from-literal=PRIVATE_KEY=$PRIVATE_KEY`
+   1. `kubectl create secret generic coralogix-keys -n $NAMESPACE --from-literal=PRIVATE_KEY=$CORALOGIX_PRIVATE_KEY`
 4. Confirm it’s been set
    1. `kubectl get secret coralogix-keys -o yaml -n $NAMESPACE`
 

--- a/otel-eks-fargate/cx-eks-fargate-otel-self-monitoring.yaml
+++ b/otel-eks-fargate/cx-eks-fargate-otel-self-monitoring.yaml
@@ -155,7 +155,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: coralogix-keys
-                  key: CORALOGIX_PRIVATE_KEY
+                  key: PRIVATE_KEY
           resources:
             limits:
               cpu: 1

--- a/otel-eks-fargate/cx-eks-fargate-otel-self-monitoring.yaml
+++ b/otel-eks-fargate/cx-eks-fargate-otel-self-monitoring.yaml
@@ -155,7 +155,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: coralogix-keys
-                  key: PRIVATE_KEY
+                  key: CORALOGIX_PRIVATE_KEY
           resources:
             limits:
               cpu: 1

--- a/otel-eks-fargate/cx-eks-fargate-otel-self-monitoring.yaml
+++ b/otel-eks-fargate/cx-eks-fargate-otel-self-monitoring.yaml
@@ -156,6 +156,13 @@ spec:
                 secretKeyRef:
                   name: coralogix-keys
                   key: PRIVATE_KEY
+                  optional: true
+            - name: CORALOGIX_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: coralogix-keys
+                  key: CORALOGIX_PRIVATE_KEY
+                  optional: true
           resources:
             limits:
               cpu: 1

--- a/otel-eks-fargate/cx-eks-fargate-otel.yaml
+++ b/otel-eks-fargate/cx-eks-fargate-otel.yaml
@@ -306,7 +306,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: coralogix-keys
-                  key: PRIVATE_KEY
+                  key: CORALOGIX_PRIVATE_KEY
           resources:
             limits:
               cpu: 1

--- a/otel-eks-fargate/cx-eks-fargate-otel.yaml
+++ b/otel-eks-fargate/cx-eks-fargate-otel.yaml
@@ -307,6 +307,13 @@ spec:
                 secretKeyRef:
                   name: coralogix-keys
                   key: PRIVATE_KEY
+                  optional: true
+            - name: CORALOGIX_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: coralogix-keys
+                  key: CORALOGIX_PRIVATE_KEY
+                  optional: true
           resources:
             limits:
               cpu: 1

--- a/otel-eks-fargate/cx-eks-fargate-otel.yaml
+++ b/otel-eks-fargate/cx-eks-fargate-otel.yaml
@@ -306,7 +306,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: coralogix-keys
-                  key: CORALOGIX_PRIVATE_KEY
+                  key: PRIVATE_KEY
           resources:
             limits:
               cpu: 1


### PR DESCRIPTION
Aligns the Kubernetes secret key name with the container env var name (CORALOGIX_PRIVATE_KEY), removing the confusing mismatch where the env var and secret key used different names.

This avoid the need for this ambiguous documentation change - https://github.com/coralogix/documentation/pull/2435

BREAKING CHANGE: existing deployments must recreate the coralogix-keys secret with the new key name before applying updated manifests.

# Description

<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the relevant Helm chart(s) version(s)
- [ ] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
