### PR TITLE
fix: update supervised image ca-certificates pin

### DIFF
--- a/otel-supervised-cdot/Dockerfile
+++ b/otel-supervised-cdot/Dockerfile
@@ -3,7 +3,7 @@ ARG COLLECTOR_VERSION=v0.5.7
 ARG SUPERVISOR_VERSION=0.142.0
 
 FROM alpine:3.22 AS certs
-RUN apk add --no-cache ca-certificates=20260413-r0 \
+RUN apk add --no-cache ca-certificates=20260611-r0 \
     && mkdir -p /etc/otelcol-contrib/supervisor-data
 
 # DL3006: Always tag the version of an image explicitly.

--- a/otel-supervised-collector/Dockerfile
+++ b/otel-supervised-collector/Dockerfile
@@ -3,7 +3,7 @@ ARG COLLECTOR_VERSION
 ARG SUPERVISOR_VERSION
 
 FROM alpine:3.22 AS certs
-RUN apk add --no-cache ca-certificates=20260413-r0 \
+RUN apk add --no-cache ca-certificates=20260611-r0 \
     && mkdir -p /etc/otelcol-contrib/supervisor-data
 
 # DL3006: Always tag the version of an image explicitly.

--- a/otel-supervised-ebpf-profiler/Dockerfile
+++ b/otel-supervised-ebpf-profiler/Dockerfile
@@ -3,7 +3,7 @@ ARG COLLECTOR_VERSION=0.147.0
 ARG SUPERVISOR_VERSION=0.147.0
 
 FROM alpine:3.22 AS certs
-RUN apk add --no-cache ca-certificates=20260413-r0 \
+RUN apk add --no-cache ca-certificates=20260611-r0 \
     && mkdir -p /etc/otelcol-contrib/supervisor-data
 
 # DL3006: Always tag the version of an image explicitly.


### PR DESCRIPTION
Summary
- Update supervised image Alpine ca-certificates pins to 20260611-r0.
- Fix release workflows for supervised collector, CDOT, and eBPF profiler images.

Why
- Alpine 3.22 now serves ca-certificates 20260611-r0. The old 20260413-r0 pin fails in fresh CI builds.

Validation
- Built supervised collector locally with docker build --pull --no-cache.
- Built supervised CDOT locally with docker build --pull --no-cache.
- Built supervised eBPF profiler locally with docker build --pull --no-cache.