### PR TITLE
CX-47627: Fix Windows integration agent log collection permissions

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemetry-Integration
 
+### v0.0.322 / 2026-06-30
+
+- [Fix] Run the Windows integration agent container as `NT AUTHORITY\SYSTEM` so the default Windows log collection preset can read pod log files.
+
 ### v0.0.321 / 2026-06-30
 
 - [Chore] Bump chart dependency to opentelemetry-collector 0.134.2

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.321
+version: 0.0.322
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/e2e-test/testdata/values-e2e-windows-test.yaml
+++ b/otel-integration/k8s-helm/e2e-test/testdata/values-e2e-windows-test.yaml
@@ -4,12 +4,6 @@ global:
   hostedEndpoint: "host.docker.internal"
 
 opentelemetry-agent-windows:
-  podSecurityContext:
-    windowsOptions:
-      runAsUserName: "NT AUTHORITY\\SYSTEM"
-  securityContext:
-    windowsOptions:
-      runAsUserName: "NT AUTHORITY\\SYSTEM"
   presets:
     coralogixExporter:
       enabled: false

--- a/otel-integration/k8s-helm/tests/golden/ebpf-profiler.yaml
+++ b/otel-integration/k8s-helm/tests/golden/ebpf-profiler.yaml
@@ -184,14 +184,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -213,13 +213,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:
@@ -1034,14 +1034,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -1063,13 +1063,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:
@@ -2011,7 +2011,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 98bbeb5021f9c873cd5054eaff03fd56249404067b12eb19ed4f50d2a35b19c5
+        checksum/config: 302617afedf9fa30610d2dec4b6a57f568838445840e3375c301f2808fb5d093
 
       labels:
         app.kubernetes.io/name: opentelemetry-agent
@@ -2198,7 +2198,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: fe89e85f601cf3663a39bde39357b04380f9a5b7a758cced1c8e2b451b251ea7
+        checksum/config: 18e43fa21539c674b94050afd53f358661d0c4d98600daac27e9d229420ed34e
 
       labels:
         app.kubernetes.io/name: opentelemetry-cluster-collector

--- a/otel-integration/k8s-helm/tests/golden/eks-fargate.yaml
+++ b/otel-integration/k8s-helm/tests/golden/eks-fargate.yaml
@@ -55,14 +55,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -87,7 +87,7 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
       debug: {}
     extensions:
       health_check:
@@ -332,14 +332,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -364,7 +364,7 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
       debug: {}
     extensions:
       health_check:
@@ -809,7 +809,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 1ca59a07a262b8c0a7a2989604ba721e2e0bed4cb7dae74ae576e2cab4ec0950
+        checksum/config: 14a0f11ee6a8e7a57be5802909685a29e3c06b16c044f34cc5fa6fded2eff5fd
 
       labels:
         app.kubernetes.io/name: opentelemetry-agent-eks-fargate-monitoring
@@ -924,7 +924,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 10e7723a39ad5aa89aed6bc84e7947ba530d73bb176195282de1326b9f4e5eee
+        checksum/config: 4511fac4a6f866a68e022483db603108ed60fd2679979426c36324a75bc49104
 
       labels:
         app.kubernetes.io/name: opentelemetry-agent-eks-fargate

--- a/otel-integration/k8s-helm/tests/golden/tail-sampling.yaml
+++ b/otel-integration/k8s-helm/tests/golden/tail-sampling.yaml
@@ -188,14 +188,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -217,13 +217,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:
@@ -1035,14 +1035,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -1064,13 +1064,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:
@@ -1725,14 +1725,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -1754,7 +1754,7 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
       debug: {}
     extensions:
       health_check:
@@ -2195,7 +2195,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: afb26105a3edd54038d0c37907fb8cf9be0a773b4d1471acdfda1ae0f04417a9
+        checksum/config: c4614f7bc6a3aac953483bde2a0a60fb2c32e4eb66d32b75a2d41b72c86f702b
 
       labels:
         app.kubernetes.io/name: opentelemetry-agent
@@ -2382,7 +2382,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 70c6468f986a79b2af07942046d5096fa73ace7694cac56fe98d20731f69d5c0
+        checksum/config: ba203d32f9ed7dc7bc66cd80df2156e23c63a326225e580e7ff07a7295d588e5
 
       labels:
         app.kubernetes.io/name: opentelemetry-cluster-collector
@@ -2506,7 +2506,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 662f41f0bd56b31a4856a06def35b2a5154cc554c7fb142c7624556541909c53
+        checksum/config: 0f09b8e06323ebdeb19fc341e00f5472233aa2a2e85aff9399d8d2316d8ae792
 
       labels:
         app.kubernetes.io/name: opentelemetry-gateway

--- a/otel-integration/k8s-helm/tests/golden/windows.yaml
+++ b/otel-integration/k8s-helm/tests/golden/windows.yaml
@@ -68,14 +68,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -97,7 +97,7 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
       debug: {}
     extensions:
       file_storage:
@@ -621,14 +621,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -650,13 +650,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:
@@ -1471,14 +1471,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -1500,13 +1500,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.321
+            X-Coralogix-Distribution: helm-otel-integration/0.0.322
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:
@@ -2400,7 +2400,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 09c934aee5afee64fb3d6caae2205ea6583d12adf0e9a3f8a47ca8515b29e2e8
+        checksum/config: b1e29121650fa96abfaa4f61ad4bb3385436979b217c7f55e612b023e869de5f
 
       labels:
         app.kubernetes.io/name: opentelemetry-agent-windows
@@ -2418,7 +2418,8 @@ spec:
             - "C:\\otelcol-contrib.exe"
             - --config=C:\\conf\relay.yaml
           securityContext:
-            {}
+            windowsOptions:
+              runAsUserName: NT AUTHORITY\SYSTEM
           image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.154.0-windows-2019-amd64"
           imagePullPolicy: Always
           ports:
@@ -2574,7 +2575,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a7c76f12081db149f9672c8438b541f9e5722de7762e0ac61a01eb24c82e3338
+        checksum/config: 8924065c1032701e5a29098978faa7303b4c50dbc291372a3ffa45725a3a3129
 
       labels:
         app.kubernetes.io/name: opentelemetry-agent
@@ -2762,7 +2763,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 70c6468f986a79b2af07942046d5096fa73ace7694cac56fe98d20731f69d5c0
+        checksum/config: ba203d32f9ed7dc7bc66cd80df2156e23c63a326225e580e7ff07a7295d588e5
 
       labels:
         app.kubernetes.io/name: opentelemetry-cluster-collector

--- a/otel-integration/k8s-helm/values-windows-tailsampling.yaml
+++ b/otel-integration/k8s-helm/values-windows-tailsampling.yaml
@@ -79,6 +79,9 @@ opentelemetry-agent-windows:
     priorityValue: 1000000000
   hostNetwork: true
   dnsPolicy: "ClusterFirstWithHostNet"
+  securityContext:
+    windowsOptions:
+      runAsUserName: "NT AUTHORITY\\SYSTEM"
 
   presets:
     metadata:

--- a/otel-integration/k8s-helm/values-windows.yaml
+++ b/otel-integration/k8s-helm/values-windows.yaml
@@ -80,6 +80,9 @@ opentelemetry-agent-windows:
     priorityValue: 1000000000
   hostNetwork: true
   dnsPolicy: "ClusterFirstWithHostNet"
+  securityContext:
+    windowsOptions:
+      runAsUserName: "NT AUTHORITY\\SYSTEM"
 
   presets:
     metadata:

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "info"
   collectionInterval: "30s"
-  version: "0.0.321"
+  version: "0.0.322"
   deploymentEnvironmentName: ""
 
   extensions:


### PR DESCRIPTION
# Description
CX-47627

Fix Windows integration agent log collection permissions

# How Has This Been Tested?
Run the E2E test suite in EKS.

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
