### PR TITLE
Fix definitions sync: don't block merge on skipped checks

### DIFF
--- a/.github/workflows/Sync-k8s-integration-definition.yaml
+++ b/.github/workflows/Sync-k8s-integration-definition.yaml
@@ -144,7 +144,7 @@ jobs:
         if: "${{env.new_version_exist == 'false' || github.event_name == 'workflow_dispatch'}}"
         run: |
           check_status() {
-            gh pr checks ${{ env.branch_name }} --json state --jq 'all(.[]; .state == "SUCCESS")'
+            gh pr checks ${{ env.branch_name }} --json state --jq 'all(.[]; .state == "SUCCESS" or .state == "NEUTRAL" or .state == "SKIPPED")'
           }
 
           # Initialize the timeout variables


### PR DESCRIPTION
# Description

The `Sync k8s with integration-definitions` workflow has been failing since ~June 30: the merge-wait loop requires every check on the sync PR to be `SUCCESS`, but the `Validate Configs - integration-definitions` check now reports `NEUTRAL` (skipped) on these PRs, so the loop never succeeds and times out after 10 minutes — leaving green sync PRs unmerged (see the pending `sync-telemetry-branch-*` PRs in integration-definitions).

This treats `NEUTRAL`/`SKIPPED` check states as passing, matching how GitHub's own required-checks logic handles skipped checks.