### PR TITLE
security: harden sync-otel-collector "Get version" against script injection (CX-49059)

### DIFF
--- a/.github/workflows/sync-otel-collector.yml
+++ b/.github/workflows/sync-otel-collector.yml
@@ -40,13 +40,19 @@ jobs:
 
       - name: Get version
         id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+          PAYLOAD_VERSION: ${{ github.event.client_payload.version }}
+          PAYLOAD_PR_URL: ${{ github.event.client_payload.pr_url }}
+          PAYLOAD_CHANGELOG_B64: ${{ github.event.client_payload.changelog_b64 }}
         run: |
-          if [[ "${{ github.event_name }}" == "repository_dispatch" ]]; then
-            VERSION="${{ github.event.client_payload.version }}"
-            SOURCE_PR="${{ github.event.client_payload.pr_url }}"
-            CHANGELOG_B64="${{ github.event.client_payload.changelog_b64 }}"
+          if [[ "$EVENT_NAME" == "repository_dispatch" ]]; then
+            VERSION="$PAYLOAD_VERSION"
+            SOURCE_PR="$PAYLOAD_PR_URL"
+            CHANGELOG_B64="$PAYLOAD_CHANGELOG_B64"
           else
-            VERSION="${{ inputs.version }}"
+            VERSION="$INPUT_VERSION"
             SOURCE_PR=""
             CHANGELOG_B64=""
           fi

--- a/.github/workflows/sync-otel-collector.yml
+++ b/.github/workflows/sync-otel-collector.yml
@@ -56,6 +56,13 @@ jobs:
             SOURCE_PR=""
             CHANGELOG_B64=""
           fi
+          # Validate the version at the source so a tainted value can never reach
+          # downstream steps that still inline steps.version.outputs.value into run scripts.
+          SEMVER_RE='^[0-9]+\.[0-9]+\.[0-9]+$'
+          if [[ ! "$VERSION" =~ $SEMVER_RE ]]; then
+            echo "::error::Invalid version '$VERSION' - expected semver like 1.2.3"
+            exit 1
+          fi
           echo "value=$VERSION" >> $GITHUB_OUTPUT
           echo "source_pr=$SOURCE_PR" >> $GITHUB_OUTPUT
           echo "changelog_b64=$CHANGELOG_B64" >> $GITHUB_OUTPUT

--- a/.github/workflows/sync-otel-collector.yml
+++ b/.github/workflows/sync-otel-collector.yml
@@ -45,27 +45,30 @@ jobs:
           INPUT_VERSION: ${{ inputs.version }}
           PAYLOAD_VERSION: ${{ github.event.client_payload.version }}
           PAYLOAD_PR_URL: ${{ github.event.client_payload.pr_url }}
-          PAYLOAD_CHANGELOG_B64: ${{ github.event.client_payload.changelog_b64 }}
         run: |
           if [[ "$EVENT_NAME" == "repository_dispatch" ]]; then
             VERSION="$PAYLOAD_VERSION"
             SOURCE_PR="$PAYLOAD_PR_URL"
-            CHANGELOG_B64="$PAYLOAD_CHANGELOG_B64"
           else
             VERSION="$INPUT_VERSION"
             SOURCE_PR=""
-            CHANGELOG_B64=""
           fi
-          # Validate the version at the source so a tainted value can never reach
-          # downstream steps that still inline steps.version.outputs.value into run scripts.
+          # Validate untrusted fields at this single trust boundary. The strict
+          # patterns also forbid newlines, so a payload cannot forge extra
+          # $GITHUB_OUTPUT lines nor inject into the downstream run: steps that
+          # inline steps.version.outputs.*.
           SEMVER_RE='^[0-9]+\.[0-9]+\.[0-9]+$'
+          PR_URL_RE='^https://github\.com/[A-Za-z0-9._/-]+$'
           if [[ ! "$VERSION" =~ $SEMVER_RE ]]; then
             echo "::error::Invalid version '$VERSION' - expected semver like 1.2.3"
             exit 1
           fi
+          if [[ -n "$SOURCE_PR" && ! "$SOURCE_PR" =~ $PR_URL_RE ]]; then
+            echo "::error::Invalid source PR URL '$SOURCE_PR'"
+            exit 1
+          fi
           echo "value=$VERSION" >> $GITHUB_OUTPUT
           echo "source_pr=$SOURCE_PR" >> $GITHUB_OUTPUT
-          echo "changelog_b64=$CHANGELOG_B64" >> $GITHUB_OUTPUT
 
       - name: Extract full changelog
         id: changelog


### PR DESCRIPTION
## Summary

Hardens the **"Get version"** step in `.github/workflows/sync-otel-collector.yml` against GitHub Actions **script injection**, as flagged in HackerOne report **#3729825** / **CX-49059**.

The step previously inlined `VERSION="${{ inputs.version }}"` (and the `github.event.client_payload.*` fields) directly into a `run:` block. Because `${{ }}` expressions are expanded *before* bash runs, a value like `test" | id; cat /etc/passwd;#` would break out of the quotes and execute on the runner.

## What changed

1. **Pass untrusted values via `env:`, not inline `${{ }}`.** `inputs.version` and the `client_payload.*` fields now enter through an `env:` block and are referenced as shell variables (`"$VERSION"`, `"$SOURCE_PR"`). GitHub no longer substitutes them into the command *text*; bash reads them as inert data. Matches the convention already used in `notify-docs-helm-version.yml` and `sync-fleet-manager.yml`.

2. **Validate untrusted fields at a single trust boundary.** Before anything is written to `$GITHUB_OUTPUT`:
   - `version` must match `^[0-9]+\.[0-9]+\.[0-9]+$`
   - `source_pr` must be empty or match `^https://github\.com/[A-Za-z0-9._/-]+$`

   Both patterns also forbid newlines, so a payload can't forge extra `$GITHUB_OUTPUT` lines (e.g. a smuggled `value=`) or reach the downstream `run:` steps that inline `steps.version.outputs.*`.

3. **Dropped the dead `changelog_b64` output.** It was written to `$GITHUB_OUTPUT` but never consumed — the changelog is re-fetched from the API in the "Extract full changelog" step. Removing it eliminates an unused injection vector rather than guarding it.

Net effect: every untrusted field is either **validated at the source** or **removed**, so the injection class is fully closed — not just at the named sink but across every downstream step that re-uses these values.

> Note: HackerOne closed the report as **Informative** — the workflow only triggers on `workflow_dispatch` / `repository_dispatch`, so the input can only come from someone who already has write access (self-RCE, no privilege boundary crossed). This PR is the recommended good-practice hardening.

## Verification

- `python3 -c "import yaml; yaml.safe_load(...)"` → valid YAML
- No `${{ }}` interpolation remains inside the "Get version" `run:` block
- Regex checks (in a real script): accept `0.155.0` and a real GitHub PR URL; reject `0.155`, `1.2.3.4`, shell-metacharacter payloads, and newline-forging payloads
- All changes are contained in the "Get version" step

🤖 Generated with [Claude Code](https://claude.com/claude-code)