### PR TITLE
fix: report standalone agent type for standalone charts

### DIFF
--- a/otel-linux-standalone/CHANGELOG.md
+++ b/otel-linux-standalone/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## otel-linux-standalone
 
+### v0.0.46 / 2026-07-17
+
+- [Breaking] Change the default `presets.fleetManagement.agentType` from `agent` to `standalone`. Existing Fleet Manager selectors targeting `cx.agent.type: agent` must be updated to `standalone` for newly installed or upgraded hosts.
+
 ### v0.0.45 / 2026-07-15
 
 - [Chore] Bump chart dependency to opentelemetry-collector 0.135.1
@@ -157,7 +161,6 @@
 
 #### Changes from opentelemetry-collector 0.130.15:
 - [Fix] Use `syslog_parser` for macOS system log parsing logic.
-
 ### v0.0.25 / 2026-04-22
 
 - [Chore] Bump chart dependency to opentelemetry-collector 0.130.14

--- a/otel-linux-standalone/Chart.yaml
+++ b/otel-linux-standalone/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: linux-standalone
 description: Standalone Linux OpenTelemetry Collector configuration
-version: 0.0.45
+version: 0.0.46
 keywords:
   - OpenTelemetry Collector
   - Coralogix

--- a/otel-linux-standalone/build/otel-config.yaml
+++ b/otel-linux-standalone/build/otel-config.yaml
@@ -133,14 +133,14 @@ exporters:
         timeout: 10s
     logs:
       headers:
-        X-Coralogix-Distribution: helm-otel-standalone/0.0.45
+        X-Coralogix-Distribution: helm-otel-standalone/0.0.46
     metrics:
       headers:
-        X-Coralogix-Distribution: helm-otel-standalone/0.0.45
+        X-Coralogix-Distribution: helm-otel-standalone/0.0.46
     private_key: ${env:CORALOGIX_PRIVATE_KEY}
     profiles:
       headers:
-        X-Coralogix-Distribution: helm-otel-standalone/0.0.45
+        X-Coralogix-Distribution: helm-otel-standalone/0.0.46
         x-coralogix-ingress: otlp/v1.10.0
     sending_queue:
       batch:
@@ -159,13 +159,13 @@ exporters:
     timeout: 30s
     traces:
       headers:
-        X-Coralogix-Distribution: helm-otel-standalone/0.0.45
+        X-Coralogix-Distribution: helm-otel-standalone/0.0.46
   coralogix/resource_catalog:
     application_name: resource
     domain: coralogix.com
     logs:
       headers:
-        X-Coralogix-Distribution: helm-otel-standalone/0.0.45
+        X-Coralogix-Distribution: helm-otel-standalone/0.0.46
         x-coralogix-ingress: metadata-as-otlp-logs/v1
     private_key: ${CORALOGIX_PRIVATE_KEY}
     sending_queue:
@@ -188,7 +188,7 @@ extensions:
     agent_description:
       include_resource_attributes: true
       non_identifying_attributes:
-        cx.agent.type: agent
+        cx.agent.type: standalone
         helm.chart.opentelemetry-agent.version: 0.135.1
     server:
       http:
@@ -775,4 +775,3 @@ service:
               without_scope_info: false
               without_type_suffix: false
               without_units: false
-

--- a/otel-linux-standalone/values.yaml
+++ b/otel-linux-standalone/values.yaml
@@ -4,7 +4,7 @@ global:
   defaultSubsystemName: "linux"
   logLevel: "info"
   collectionInterval: "30s"
-  version: "0.0.45"
+  version: "0.0.46"
   # deploymentEnvironmentName: "development"
 
 opentelemetry-agent:
@@ -18,7 +18,7 @@ opentelemetry-agent:
       enabled: true
     fleetManagement:
       enabled: true
-      agentType: "agent"
+      agentType: "standalone"
     hostMetrics:
       enabled: true
       # Enables process metrics scraping.

--- a/otel-macos-standalone/CHANGELOG.md
+++ b/otel-macos-standalone/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## otel-macos-standalone
 
+### v0.0.46 / 2026-07-17
+
+- [Breaking] Change the default `presets.fleetManagement.agentType` from `agent` to `standalone`. Existing Fleet Manager selectors targeting `cx.agent.type: agent` must be updated to `standalone` for newly installed or upgraded hosts.
+
 ### v0.0.45 / 2026-07-15
 
 - [Chore] Bump chart dependency to opentelemetry-collector 0.135.1
@@ -157,7 +161,6 @@
 
 #### Changes from opentelemetry-collector 0.130.15:
 - [Fix] Use `syslog_parser` for macOS system log parsing logic.
-
 ### v0.0.25 / 2026-04-22
 
 - [Chore] Bump chart dependency to opentelemetry-collector 0.130.14

--- a/otel-macos-standalone/Chart.yaml
+++ b/otel-macos-standalone/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: macos-standalone
 description: Standalone macOS OpenTelemetry Collector configuration
-version: 0.0.45
+version: 0.0.46
 keywords:
   - OpenTelemetry Collector
   - Coralogix

--- a/otel-macos-standalone/build/otel-config.yaml
+++ b/otel-macos-standalone/build/otel-config.yaml
@@ -133,14 +133,14 @@ exporters:
         timeout: 10s
     logs:
       headers:
-        X-Coralogix-Distribution: helm-otel-macos/0.0.45
+        X-Coralogix-Distribution: helm-otel-macos/0.0.46
     metrics:
       headers:
-        X-Coralogix-Distribution: helm-otel-macos/0.0.45
+        X-Coralogix-Distribution: helm-otel-macos/0.0.46
     private_key: ${env:CORALOGIX_PRIVATE_KEY}
     profiles:
       headers:
-        X-Coralogix-Distribution: helm-otel-macos/0.0.45
+        X-Coralogix-Distribution: helm-otel-macos/0.0.46
         x-coralogix-ingress: otlp/v1.10.0
     sending_queue:
       batch:
@@ -159,13 +159,13 @@ exporters:
     timeout: 30s
     traces:
       headers:
-        X-Coralogix-Distribution: helm-otel-macos/0.0.45
+        X-Coralogix-Distribution: helm-otel-macos/0.0.46
   coralogix/resource_catalog:
     application_name: resource
     domain: coralogix.com
     logs:
       headers:
-        X-Coralogix-Distribution: helm-otel-macos/0.0.45
+        X-Coralogix-Distribution: helm-otel-macos/0.0.46
         x-coralogix-ingress: metadata-as-otlp-logs/v1
     private_key: ${CORALOGIX_PRIVATE_KEY}
     sending_queue:
@@ -188,7 +188,7 @@ extensions:
     agent_description:
       include_resource_attributes: true
       non_identifying_attributes:
-        cx.agent.type: agent
+        cx.agent.type: standalone
         helm.chart.opentelemetry-agent.version: 0.135.1
     server:
       http:
@@ -684,4 +684,3 @@ service:
               without_scope_info: false
               without_type_suffix: false
               without_units: false
-

--- a/otel-macos-standalone/values.yaml
+++ b/otel-macos-standalone/values.yaml
@@ -4,7 +4,7 @@ global:
   defaultSubsystemName: "macos"
   logLevel: "info"
   collectionInterval: "30s"
-  version: "0.0.45"
+  version: "0.0.46"
 
 opentelemetry-agent:
   enabled: true
@@ -17,7 +17,7 @@ opentelemetry-agent:
       enabled: true
     fleetManagement:
       enabled: true
-      agentType: "agent"
+      agentType: "standalone"
       customAttributes: {}
     
     hostMetrics:

--- a/otel-windows-standalone/CHANGELOG.md
+++ b/otel-windows-standalone/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## otel-windows-standalone
 
+### v0.0.46 / 2026-07-17
+
+- [Breaking] Change the default `presets.fleetManagement.agentType` from `agent` to `standalone`. Existing Fleet Manager selectors targeting `cx.agent.type: agent` must be updated to `standalone` for newly installed or upgraded hosts.
+
 ### v0.0.45 / 2026-07-15
 
 - [Chore] Bump chart dependency to opentelemetry-collector 0.135.1
@@ -157,7 +161,6 @@
 
 #### Changes from opentelemetry-collector 0.130.15:
 - [Fix] Use `syslog_parser` for macOS system log parsing logic.
-
 ### v0.0.25 / 2026-04-22
 
 - [Chore] Bump chart dependency to opentelemetry-collector 0.130.14

--- a/otel-windows-standalone/Chart.yaml
+++ b/otel-windows-standalone/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: windows-standalone
 description: Standalone Windows OpenTelemetry Collector configuration
-version: 0.0.45
+version: 0.0.46
 keywords:
   - OpenTelemetry Collector
   - Coralogix

--- a/otel-windows-standalone/build/otel-config.yaml
+++ b/otel-windows-standalone/build/otel-config.yaml
@@ -13,14 +13,14 @@ exporters:
         timeout: 10s
     logs:
       headers:
-        X-Coralogix-Distribution: helm-otel-standalone/0.0.45
+        X-Coralogix-Distribution: helm-otel-standalone/0.0.46
     metrics:
       headers:
-        X-Coralogix-Distribution: helm-otel-standalone/0.0.45
+        X-Coralogix-Distribution: helm-otel-standalone/0.0.46
     private_key: ${env:CORALOGIX_PRIVATE_KEY}
     profiles:
       headers:
-        X-Coralogix-Distribution: helm-otel-standalone/0.0.45
+        X-Coralogix-Distribution: helm-otel-standalone/0.0.46
         x-coralogix-ingress: otlp/v1.10.0
     sending_queue:
       batch:
@@ -39,13 +39,13 @@ exporters:
     timeout: 30s
     traces:
       headers:
-        X-Coralogix-Distribution: helm-otel-standalone/0.0.45
+        X-Coralogix-Distribution: helm-otel-standalone/0.0.46
   coralogix/resource_catalog:
     application_name: resource
     domain: eu2.coralogix.com
     logs:
       headers:
-        X-Coralogix-Distribution: helm-otel-standalone/0.0.45
+        X-Coralogix-Distribution: helm-otel-standalone/0.0.46
         x-coralogix-ingress: metadata-as-otlp-logs/v1
     private_key: ${CORALOGIX_PRIVATE_KEY}
     sending_queue:
@@ -71,7 +71,7 @@ extensions:
     agent_description:
       include_resource_attributes: true
       non_identifying_attributes:
-        cx.agent.type: agent
+        cx.agent.type: standalone
         helm.chart.opentelemetry-agent.version: 0.135.1
     server:
       http:
@@ -400,4 +400,3 @@ service:
               without_scope_info: false
               without_type_suffix: false
               without_units: false
-

--- a/otel-windows-standalone/values.yaml
+++ b/otel-windows-standalone/values.yaml
@@ -4,7 +4,7 @@ global:
   defaultSubsystemName: "windows"
   logLevel: "info"
   collectionInterval: "30s"
-  version: "0.0.45"
+  version: "0.0.46"
 
 opentelemetry-agent:
   enabled: true
@@ -19,7 +19,7 @@ opentelemetry-agent:
       enabled: true
     fleetManagement:
       enabled: true
-      agentType: "agent"
+      agentType: "standalone"
     hostMetrics:
       enabled: true
       process:


### PR DESCRIPTION
## Related Jira issue

- [CX-50122](https://coralogix.atlassian.net/browse/CX-50122)

## What changed

- Change the default `presets.fleetManagement.agentType` from `agent` to `standalone` in the Linux, Windows, and macOS standalone charts.
- Bump all three chart versions to `0.0.46`.
- Regenerate the checked-in default collector configurations.
- Document the selector identity change as a breaking change in each chart changelog.

## Why

The standalone Host installer hardcodes the agent type as `standalone`. Fleet Manager uses this chart to generate the `agentSelector`, but the chart default was `agent`, creating a mismatch between the deployed agent type (`standalone`) and the selector type (`agent`). As a result, no agents match the deployment and it remains Pending until the selector is updated manually.

## User impact

This is a breaking selector change. Existing Fleet Manager selectors targeting `cx.agent.type: agent` must be updated to `standalone` for newly installed or upgraded standalone hosts.


[CX-50122]: https://coralogix.atlassian.net/browse/CX-50122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ