### PR TITLE
fix(ci): treat NEUTRAL/SKIPPED checks as pass in integration syncs

### DIFF
--- a/.github/workflows/Sync-ec2-integration-definition.yaml
+++ b/.github/workflows/Sync-ec2-integration-definition.yaml
@@ -189,7 +189,8 @@ jobs:
           set -euo pipefail
 
           check_status() {
-            gh pr checks "$branch" --json state --jq 'all(.[]; .state == "SUCCESS")'
+            # NEUTRAL/SKIPPED = skipped checks (e.g. Validate Configs); treat as pass
+            gh pr checks "$branch" --json state --jq 'all(.[]; .state == "SUCCESS" or .state == "NEUTRAL" or .state == "SKIPPED")'
           }
 
           max_wait_time=$((10 * 60))

--- a/.github/workflows/Sync-host-integration-definition.yaml
+++ b/.github/workflows/Sync-host-integration-definition.yaml
@@ -174,7 +174,8 @@ jobs:
         if: "${{ env.new_version_exist == 'false' }}"
         run: |
           check_status() {
-            gh pr checks ${{ env.branch_name }} --json state --jq 'all(.[]; .state == "SUCCESS")'
+            # NEUTRAL/SKIPPED = skipped checks (e.g. Validate Configs); treat as pass
+            gh pr checks ${{ env.branch_name }} --json state --jq 'all(.[]; .state == "SUCCESS" or .state == "NEUTRAL" or .state == "SKIPPED")'
           }
 
           max_wait_time=$((10 * 60))

--- a/.github/workflows/Sync-k8s-integration-definition.yaml
+++ b/.github/workflows/Sync-k8s-integration-definition.yaml
@@ -144,7 +144,8 @@ jobs:
         if: "${{env.new_version_exist == 'false' || github.event_name == 'workflow_dispatch'}}"
         run: |
           check_status() {
-            gh pr checks ${{ env.branch_name }} --json state --jq 'all(.[]; .state == "SUCCESS")'
+            # NEUTRAL/SKIPPED = skipped checks (e.g. Validate Configs); treat as pass
+            gh pr checks ${{ env.branch_name }} --json state --jq 'all(.[]; .state == "SUCCESS" or .state == "NEUTRAL" or .state == "SKIPPED")'
           }
 
           # Initialize the timeout variables

--- a/otel-linux-standalone/CHANGELOG.md
+++ b/otel-linux-standalone/CHANGELOG.md
@@ -161,6 +161,7 @@
 
 #### Changes from opentelemetry-collector 0.130.15:
 - [Fix] Use `syslog_parser` for macOS system log parsing logic.
+
 ### v0.0.25 / 2026-04-22
 
 - [Chore] Bump chart dependency to opentelemetry-collector 0.130.14

--- a/otel-macos-standalone/CHANGELOG.md
+++ b/otel-macos-standalone/CHANGELOG.md
@@ -161,6 +161,7 @@
 
 #### Changes from opentelemetry-collector 0.130.15:
 - [Fix] Use `syslog_parser` for macOS system log parsing logic.
+
 ### v0.0.25 / 2026-04-22
 
 - [Chore] Bump chart dependency to opentelemetry-collector 0.130.14

--- a/otel-windows-standalone/CHANGELOG.md
+++ b/otel-windows-standalone/CHANGELOG.md
@@ -161,6 +161,7 @@
 
 #### Changes from opentelemetry-collector 0.130.15:
 - [Fix] Use `syslog_parser` for macOS system log parsing logic.
+
 ### v0.0.25 / 2026-04-22
 
 - [Chore] Bump chart dependency to opentelemetry-collector 0.130.14


### PR DESCRIPTION
## Summary
- Update host, k8s, and EC2 integration-definitions sync workflows so the merge wait accepts `NEUTRAL` and `SKIPPED` check states in addition to `SUCCESS`.
- Prevents auto-merge from timing out when Argo skips `Validate Configs - integration-definitions`.

## Context
After creating sync PRs (e.g. https://github.com/coralogix/integration-definitions/pull/1319), the merge step waited up to 10 minutes and failed because:

```bash
gh pr checks ... --jq 'all(.[]; .state == "SUCCESS")'