### PR TITLE
fix(otel-integration): map legacy http.status_code to http.response.status_code for span metrics

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemetry-Integration
 
+### v0.0.329 / 2026-07-21
+
+- [Fix] Populate the `http.response.status_code` span-metrics dimension from the legacy `http.status_code` attribute so APM error tracking works for spans still using the old HTTP semantic convention.
+
 ### v0.0.328 / 2026-07-15
 
 - [Chore] Bump chart dependency to opentelemetry-collector 0.135.1

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.328
+version: 0.0.329
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -260,6 +260,8 @@ opentelemetry-agent:
       enabled: true
       collectionInterval: "{{.Values.global.collectionInterval}}"
       metricsExpiration: 5m
+      transformStatements:
+        - set(span.attributes["http.response.status_code"], span.attributes["http.status_code"]) where span.attributes["http.response.status_code"] == nil and span.attributes["http.status_code"] != nil
       # histogramBuckets:
       #   [1ms, 4ms, 10ms, 20ms, 50ms, 100ms, 200ms, 500ms, 1s, 2s, 5s]
     transactions:


### PR DESCRIPTION
## Story number

[CX-50554](https://coralogix.atlassian.net/browse/CX-50554)

# Description

APM error tracking groups errors by the new `http.response.status_code` span-metrics dimension. Spans emitted with the **old** HTTP semantic convention only carry `http.status_code`, so their status code is missing from the span metrics and they surface in the APM UI as **"empty status code"** errors.

This fixes it at the source: a `presets.spanMetrics.transformStatements` OTTL statement copies `http.status_code` → `http.response.status_code` (only when the new attribute is absent) in the traces pipeline, before the `spanmetrics` connector builds metrics. The span-metrics dimension is then correct and the existing APM drilldown query works — no frontend change needed.

```
set(span.attributes["http.response.status_code"], span.attributes["http.status_code"]) where span.attributes["http.response.status_code"] == nil and span.attributes["http.status_code"] != nil
```

Scope: `otel-integration` k8s chart only (the `opentelemetry-agent` collector — the sole span-metrics producer).

Supersedes the earlier frontend-query approach (cx-web-workspace #19953, closed).

# How Has This Been Tested?

Rendered the `otel-integration` `opentelemetry-collector` subchart with `helm template` against both the currently-vendored `0.131.6` and the master-pinned `0.135.1` chart versions. In both, the statement renders into `transform/spanmetrics.trace_statements` (context: span), and `transform/spanmetrics` is a `traces` pipeline processor while `spanmetrics` is a traces exporter — so the connector consumes spans after the mapping runs.

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)

[CX-50554]: https://coralogix.atlassian.net/browse/CX-50554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ