### PR TITLE
fix(otel-ecs-fargate): map legacy http.status_code to http.response.status_code in semconv

### DIFF
--- a/otel-ecs-fargate/CHANGELOG.md
+++ b/otel-ecs-fargate/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 <!-- * [Update/Bug fix] message that describes the changes that you apply -->
 
+### 1.1.1 / 2026-07-21
+
+* [Bug fix] Map the legacy `http.status_code` attribute to `http.response.status_code` in the `semconv` transform so span metrics carry the status code for spans using the old HTTP semantic convention.
+
 ### 1.1.0 / 2026-06-30
 
 * [UPDATE] Use `otlp` v1.10.0 for profiles ingestion

--- a/otel-ecs-fargate/config.yaml
+++ b/otel-ecs-fargate/config.yaml
@@ -555,6 +555,8 @@ processors:
       statements:
       - set(attributes["http.method"], attributes["http.request.method"]) where attributes["http.request.method"]
         != nil
+      - set(attributes["http.response.status_code"], attributes["http.status_code"]) where attributes["http.response.status_code"]
+        == nil and attributes["http.status_code"] != nil
   transform/spanmetrics:
     error_mode: silent
     metric_statements:


### PR DESCRIPTION
## Story number

[CX-50554](https://coralogix.atlassian.net/browse/CX-50554)

# Description

Follow-up to the collector chart fix ([opentelemetry-helm-charts #490](https://github.com/coralogix/opentelemetry-helm-charts/pull/490), released as chart `0.135.2`). The chart-consuming shippers (otel-integration, otel-ecs-ec2, otel-linux/macos/windows-standalone) already inherited the fix via the automated dependency bump #973.

The **ECS Fargate** example config (`otel-ecs-fargate/config.yaml`) is hand-maintained and does **not** consume the helm chart, so the automated bump can't reach it — yet it has the same `spanmetrics` connector with the `http.response.status_code` dimension and the same `transform/semconv` (only mapping `http.method`). Spans using the old HTTP semantic convention therefore land as "empty status code" APM errors.

This mirrors the chart's semconv mapping into the Fargate config:

```
set(attributes["http.response.status_code"], attributes["http.status_code"]) where attributes["http.response.status_code"] == nil and attributes["http.status_code"] != nil
```

# How Has This Been Tested?

Validated `config.yaml` parses and the statement lands under `processors["transform/semconv"].trace_statements` (via `yq`). `transform/semconv` runs in the traces pipeline before the `spanmetrics` connector (a traces exporter), so the connector sees the populated attribute.

# Checklist:
- [ ] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)

[CX-50554]: https://coralogix.atlassian.net/browse/CX-50554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ