### PR TITLE
ci: auto-bump OBI chart dependency (sync-obi workflow)

### DIFF
--- a/.github/workflows/sync-obi.yml
+++ b/.github/workflows/sync-obi.yml
@@ -1,0 +1,242 @@
+name: Sync OBI Chart Version
+
+on:
+  repository_dispatch:
+    types: [obi-chart-release]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'New opentelemetry-ebpf-instrumentation chart version'
+        required: true
+        type: string
+
+env:
+  DEPENDENCY_NAME: opentelemetry-ebpf-instrumentation
+  # Charts consuming the OBI chart dependency
+  CHARTS: otel-integration
+  # Path (relative to repo root) whose Chart.yaml carries the dependency
+  CHART_PATHS: otel-integration/k8s-helm
+  # Source of the chart + changelog
+  SOURCE_REPO: coralogix/opentelemetry-helm-charts
+  CHANGELOG_PATH: charts/opentelemetry-ebpf-instrumentation/CHANGELOG.md
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: azure/setup-helm@v4
+
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Add helm repos
+        run: |
+          helm repo add coralogix-charts https://cgx.jfrog.io/artifactory/coralogix-charts
+          helm repo add coralogix-charts-virtual https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
+          helm repo update
+
+      - name: Get version
+        id: version
+        run: |
+          if [[ "${{ github.event_name }}" == "repository_dispatch" ]]; then
+            VERSION="${{ github.event.client_payload.version }}"
+            SOURCE_PR="${{ github.event.client_payload.pr_url }}"
+          else
+            VERSION="${{ inputs.version }}"
+            SOURCE_PR=""
+          fi
+          echo "value=$VERSION" >> $GITHUB_OUTPUT
+          echo "source_pr=$SOURCE_PR" >> $GITHUB_OUTPUT
+
+      - name: Extract full changelog
+        id: changelog
+        run: |
+          TARGET_VERSION="${{ steps.version.outputs.value }}"
+          echo "Target version: $TARGET_VERSION"
+
+          # Current pinned dependency version across consuming charts
+          MIN_VERSION=""
+          for chart in $CHART_PATHS; do
+            if [[ -f "${chart}/Chart.yaml" ]]; then
+              VER=$(yq ".dependencies[] | select(.name == \"$DEPENDENCY_NAME\") | .version" "${chart}/Chart.yaml" 2>/dev/null | head -1 | tr -d '"')
+              if [[ -n "$VER" ]]; then
+                echo "  $chart: $VER"
+                if [[ -z "$MIN_VERSION" ]] || [[ "$(printf '%s\n' "$VER" "$MIN_VERSION" | sort -V | head -1)" == "$VER" ]]; then
+                  MIN_VERSION="$VER"
+                fi
+              fi
+            fi
+          done
+
+          echo "Minimum version across charts: $MIN_VERSION"
+
+          # Skip if minimum version is at or above target (all charts already up-to-date)
+          HIGHEST=$(printf '%s\n' "$MIN_VERSION" "$TARGET_VERSION" | sort -V | tail -1)
+          if [[ "$MIN_VERSION" == "$TARGET_VERSION" ]] || [[ "$HIGHEST" == "$MIN_VERSION" ]]; then
+            echo "All charts already at target version or newer (min=$MIN_VERSION >= target=$TARGET_VERSION)"
+            echo "status=skip" >> $GITHUB_OUTPUT
+            echo "file=" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "Baseline for changelog: $MIN_VERSION"
+
+          # Fetch the OBI chart CHANGELOG.md and extract entries between versions
+          CHANGELOG=$(gh api "repos/${SOURCE_REPO}/contents/${CHANGELOG_PATH}" \
+            --jq '.content' | base64 -d | awk -v current="$MIN_VERSION" -v target="$TARGET_VERSION" '
+            function semver_cmp(v1, v2,    a1, a2, i) {
+              split(v1, a1, "."); split(v2, a2, ".")
+              for (i = 1; i <= 3; i++) {
+                if (a1[i]+0 < a2[i]+0) return -1
+                if (a1[i]+0 > a2[i]+0) return 1
+              }
+              return 0
+            }
+            /^[[:space:]]*### v[0-9]/ {
+              match($0, /[0-9]+\.[0-9]+\.[0-9]+/)
+              ver = substr($0, RSTART, RLENGTH)
+              in_range = (semver_cmp(ver, current) > 0 && semver_cmp(ver, target) <= 0)
+              if (in_range) {
+                if (seen_version) print ""
+                print "#### Changes from " ENVIRON["DEPENDENCY_NAME"] " " ver ":"
+                seen_version = 1
+              }
+              next
+            }
+            in_range && /^[[:space:]]*-/ { print }
+          ')
+
+          if [[ -n "$CHANGELOG" ]]; then
+            echo "$CHANGELOG" > /tmp/changelog-entries.txt
+            echo "status=ok" >> $GITHUB_OUTPUT
+            echo "file=/tmp/changelog-entries.txt" >> $GITHUB_OUTPUT
+            echo "Extracted changelog entries from $MIN_VERSION to $TARGET_VERSION"
+            echo "$CHANGELOG" | head -10
+          else
+            echo "status=empty" >> $GITHUB_OUTPUT
+            echo "file=" >> $GITHUB_OUTPUT
+            echo "No changelog entries found"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if update needed
+        if: steps.changelog.outputs.status == 'skip'
+        run: |
+          echo "::notice::Already at target version or newer - skipping"
+          exit 0
+
+      - name: Close stale bump PRs
+        if: steps.changelog.outputs.status != 'skip'
+        run: |
+          VERSION="${{ steps.version.outputs.value }}"
+
+          gh pr list --label obi-bump --state open --json number,title | jq -c '.[]' | while read -r row; do
+            PR_NUM=$(echo "$row" | jq -r '.number')
+            PR_VERSION=$(echo "$row" | jq -r '.title' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+$' || true)
+
+            [[ -z "$PR_VERSION" || "$PR_VERSION" == "$VERSION" ]] && continue
+
+            HIGHEST=$(printf '%s\n' "$PR_VERSION" "$VERSION" | sort -V | tail -1)
+            if [[ "$HIGHEST" == "$VERSION" && "$PR_VERSION" != "$VERSION" ]]; then
+              echo "Closing stale PR #$PR_NUM (v$PR_VERSION < v$VERSION)"
+              gh pr close $PR_NUM --comment "🔄 Superseded by v${VERSION}. All changelog entries included in new PR." || true
+            fi
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create branch
+        if: steps.changelog.outputs.status != 'skip'
+        run: |
+          branch_name="chore/bump-obi-${{ steps.version.outputs.value }}"
+          echo "branch_name=$branch_name" >> $GITHUB_ENV
+
+          git push origin --delete "$branch_name" 2>/dev/null || true
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b $branch_name
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run bump script
+        if: steps.changelog.outputs.status != 'skip'
+        run: |
+          CHANGELOG_ARGS=""
+          if [[ -n "${{ steps.changelog.outputs.file }}" ]]; then
+            CHANGELOG_ARGS="--changelog-file ${{ steps.changelog.outputs.file }}"
+          fi
+
+          chmod +x ./scripts/bump-otel-collector-version.sh
+          ./scripts/bump-otel-collector-version.sh \
+            --version "${{ steps.version.outputs.value }}" \
+            --dependency-name "$DEPENDENCY_NAME" \
+            --charts "$CHARTS" \
+            $CHANGELOG_ARGS
+
+      - name: Commit and push
+        if: steps.changelog.outputs.status != 'skip'
+        run: |
+          git add -A
+          if git diff --staged --quiet; then
+            echo "::error::No changes to commit - version ${{ steps.version.outputs.value }} may already be applied"
+            exit 1
+          fi
+          git commit -m "chore: bump ${DEPENDENCY_NAME} to ${{ steps.version.outputs.value }}"
+          git push origin $branch_name
+
+      - name: Build PR body
+        if: steps.changelog.outputs.status != 'skip'
+        run: |
+          if [[ -f "/tmp/otel-bump-summary.md" ]]; then
+            cat /tmp/otel-bump-summary.md > /tmp/pr-body.md
+          else
+            echo "Bumping ${DEPENDENCY_NAME} to \`${{ steps.version.outputs.value }}\`" > /tmp/pr-body.md
+          fi
+          echo "" >> /tmp/pr-body.md
+          if [[ -n "${{ steps.version.outputs.source_pr }}" ]]; then
+            echo "**Source:** ${{ steps.version.outputs.source_pr }}" >> /tmp/pr-body.md
+            echo "" >> /tmp/pr-body.md
+          fi
+          case "${{ steps.changelog.outputs.status }}" in
+            empty)
+              echo "⚠️ **Changelog:** No entries found between versions - using default entry." >> /tmp/pr-body.md
+              echo "" >> /tmp/pr-body.md
+              ;;
+            ok)
+              echo "✅ **Changelog:** Includes all entries from current to target version." >> /tmp/pr-body.md
+              echo "" >> /tmp/pr-body.md
+              ;;
+          esac
+
+      - name: Ensure labels exist
+        if: steps.changelog.outputs.status != 'skip'
+        run: |
+          for label in obi-bump chart:otel-integration; do
+            gh label create "$label" --description "Auto-created for OBI chart sync" --color "0E8A16" 2>/dev/null || true
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create pull request
+        if: steps.changelog.outputs.status != 'skip'
+        run: |
+          gh pr create \
+            --base master \
+            --head "$branch_name" \
+            --title "chore: bump ${DEPENDENCY_NAME} to ${{ steps.version.outputs.value }}" \
+            --body-file /tmp/pr-body.md \
+            --label "obi-bump,chart:otel-integration"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-obi.yml
+++ b/.github/workflows/sync-obi.yml
@@ -47,13 +47,32 @@ jobs:
 
       - name: Get version
         id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+          PAYLOAD_VERSION: ${{ github.event.client_payload.version }}
+          PAYLOAD_PR_URL: ${{ github.event.client_payload.pr_url }}
         run: |
-          if [[ "${{ github.event_name }}" == "repository_dispatch" ]]; then
-            VERSION="${{ github.event.client_payload.version }}"
-            SOURCE_PR="${{ github.event.client_payload.pr_url }}"
+          if [[ "$EVENT_NAME" == "repository_dispatch" ]]; then
+            VERSION="$PAYLOAD_VERSION"
+            SOURCE_PR="$PAYLOAD_PR_URL"
           else
-            VERSION="${{ inputs.version }}"
+            VERSION="$INPUT_VERSION"
             SOURCE_PR=""
+          fi
+          # Validate untrusted fields at this single trust boundary. The strict
+          # patterns also forbid newlines, so a payload cannot forge extra
+          # $GITHUB_OUTPUT lines nor inject into the downstream run: steps that
+          # inline steps.version.outputs.*.
+          SEMVER_RE='^[0-9]+\.[0-9]+\.[0-9]+$'
+          PR_URL_RE='^https://github\.com/[A-Za-z0-9._/-]+$'
+          if [[ ! "$VERSION" =~ $SEMVER_RE ]]; then
+            echo "::error::Invalid version '$VERSION' - expected semver like 1.2.3"
+            exit 1
+          fi
+          if [[ -n "$SOURCE_PR" && ! "$SOURCE_PR" =~ $PR_URL_RE ]]; then
+            echo "::error::Invalid source PR URL '$SOURCE_PR'"
+            exit 1
           fi
           echo "value=$VERSION" >> $GITHUB_OUTPUT
           echo "source_pr=$SOURCE_PR" >> $GITHUB_OUTPUT
@@ -223,9 +242,7 @@ jobs:
       - name: Ensure labels exist
         if: steps.changelog.outputs.status != 'skip'
         run: |
-          for label in obi-bump chart:otel-integration; do
-            gh label create "$label" --description "Auto-created for OBI chart sync" --color "0E8A16" 2>/dev/null || true
-          done
+          gh label create obi-bump --description "Auto-created for OBI chart sync" --color "0E8A16" 2>/dev/null || true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -237,6 +254,6 @@ jobs:
             --head "$branch_name" \
             --title "chore: bump ${DEPENDENCY_NAME} to ${{ steps.version.outputs.value }}" \
             --body-file /tmp/pr-body.md \
-            --label "obi-bump,chart:otel-integration"
+            --label obi-bump
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/bump-otel-collector-version.sh
+++ b/scripts/bump-otel-collector-version.sh
@@ -2,11 +2,15 @@
 #
 # bump-otel-collector-version.sh
 #
-# Bumps the opentelemetry-collector chart dependency across all integration charts.
+# Bumps a helm chart dependency across integration charts.
 # Updates Chart.yaml, values.yaml, and CHANGELOG.md for each chart.
+# Defaults to the opentelemetry-collector dependency; use --dependency-name
+# and --charts to bump a different dependency (e.g. opentelemetry-ebpf-instrumentation).
 #
 # Options:
-#   --version VERSION       New opentelemetry-collector chart version (required)
+#   --version VERSION       New chart dependency version (required)
+#   --dependency-name NAME  Dependency to bump (default: opentelemetry-collector)
+#   --charts "A B C"        Space-separated charts to process (default: all collector consumers)
 #   --changelog-file FILE   File containing changelog entries to copy (optional)
 #   --source-commit SHA     Source commit SHA for reference (optional)
 #   --source-pr NUMBER      Source PR number for reference (optional)
@@ -22,6 +26,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 NEW_VERSION=""
+DEPENDENCY_NAME="opentelemetry-collector"
 CHANGELOG_FILE=""
 SOURCE_COMMIT=""
 SOURCE_PR=""
@@ -91,6 +96,14 @@ parse_args() {
       NEW_VERSION="$2"
       shift 2
       ;;
+    --dependency-name)
+      DEPENDENCY_NAME="$2"
+      shift 2
+      ;;
+    --charts)
+      ALL_CHARTS="$2"
+      shift 2
+      ;;
     --changelog-file)
       CHANGELOG_FILE="$2"
       shift 2
@@ -154,7 +167,7 @@ get_current_chart_version() {
 
 get_dependency_version() {
   local chart_yaml="$1"
-  yq '.dependencies[] | select(.name == "opentelemetry-collector") | .version' "$chart_yaml" | head -1 | tr -d '"'
+  yq ".dependencies[] | select(.name == \"$DEPENDENCY_NAME\") | .version" "$chart_yaml" | head -1 | tr -d '"'
 }
 
 update_chart_yaml() {
@@ -185,7 +198,7 @@ update_chart_yaml() {
   fi
 
   yq -i ".version = \"$new_chart_version\"" "$chart_yaml"
-  yq -i "(.dependencies[] | select(.name == \"opentelemetry-collector\") | .version) = \"$NEW_VERSION\"" "$chart_yaml"
+  yq -i "(.dependencies[] | select(.name == \"$DEPENDENCY_NAME\") | .version) = \"$NEW_VERSION\"" "$chart_yaml"
 
   echo "$new_chart_version"
 }
@@ -244,9 +257,9 @@ update_changelog() {
   entry_file=$(mktemp)
 
   local header_version="v${new_chart_version}"
-  local change_line="- [Chore] Bump chart dependency to opentelemetry-collector ${NEW_VERSION}"
+  local change_line="- [Chore] Bump chart dependency to ${DEPENDENCY_NAME} ${NEW_VERSION}"
 
-  if [[ "$chart" == "otel-ecs-ec2" ]]; then
+  if [[ "$chart" == "otel-ecs-ec2" && "$DEPENDENCY_NAME" == "opentelemetry-collector" ]]; then
     change_line="- [Change] Update Helm dependency \`opentelemetry-agent\` to chart version \`${NEW_VERSION}\`."
   fi
 
@@ -421,7 +434,7 @@ generate_summary() {
   log_info "Summary"
   log_info "=========================================="
   echo "" >&2
-  echo "New opentelemetry-collector version: $NEW_VERSION" >&2
+  echo "New $DEPENDENCY_NAME version: $NEW_VERSION" >&2
   echo "" >&2
   echo "Charts:" >&2
 
@@ -493,7 +506,7 @@ generate_markdown_summary() {
   local has_failures=false
 
   {
-    echo "## OpenTelemetry Collector Bump Summary"
+    echo "## ${DEPENDENCY_NAME} Bump Summary"
     echo ""
     echo "**Version:** \`$NEW_VERSION\`"
 
@@ -597,7 +610,7 @@ main() {
     exit 1
   }
 
-  log_info "Bumping opentelemetry-collector to version $NEW_VERSION"
+  log_info "Bumping $DEPENDENCY_NAME to version $NEW_VERSION"
   if [[ "$DRY_RUN" == "true" ]]; then
     log_warn "DRY RUN mode enabled"
   fi


### PR DESCRIPTION
## What

Replicates the `opentelemetry-collector` auto-bump pipeline for the OBI (`opentelemetry-ebpf-instrumentation`) helm chart.

- **New `.github/workflows/sync-obi.yml`** — triggered by `repository_dispatch` type `obi-chart-release` (and manual `workflow_dispatch` with a version input). When the coralogix `opentelemetry-ebpf-instrumentation` chart releases, it:
  - bumps the `opentelemetry-ebpf-instrumentation` dependency in `otel-integration/k8s-helm` (the only consumer),
  - regenerates the CHANGELOG entry + golden renders,
  - opens a bump PR to `master`.
  - Merging publishes a new `otel-integration` chart version via the existing `otel-integration.yml` release workflow — no publish changes needed.
- **Generalizes `scripts/bump-otel-collector-version.sh`** with `--dependency-name` and `--charts` flags. Collector defaults are unchanged (verified via dry-run: default path still targets `opentelemetry-collector` across all 5 charts).
- The dispatch payload is validated at the `Get version` trust boundary (semver + PR-URL patterns, values passed via `env:`), matching the `sync-otel-collector` hardening from CX-49059.
- Bump PRs are labelled `obi-bump` only — `process-chart-selection` reverts `chart:*` labels for `otel-collector-bump` PRs only, and `otel-integration` is the sole consumer, so a `chart:` label would advertise a selection that never happens.

## How this mirrors the collector flow

| | Collector | OBI (this PR) |
|---|---|---|
| Dispatch event | `otel-collector-release` | `obi-chart-release` |
| Consumers bumped | 5 charts | `otel-integration` only |
| Changelog source | `charts/opentelemetry-collector/CHANGELOG.md` | `charts/opentelemetry-ebpf-instrumentation/CHANGELOG.md` |
| Publish on merge | per-chart release workflows | `otel-integration.yml` (unchanged) |

## Follow-up (separate repo, human-only)

The **dispatch side** must be added to `coralogix/opentelemetry-helm-charts`: a sync job (mirroring `sync-telemetry-shippers.yaml`) keyed on the OBI chart release workflow that fires `repository_dispatch obi-chart-release`. That repo is a fork of open-telemetry upstream, so per Coralogix fork rules a human commits/pushes it. Until then, this workflow is runnable manually via `workflow_dispatch`.

## Testing

- `bash -n` + shellcheck clean; workflow YAML parses.
- Dry-run OBI path: detects dep `0.1.18 → 0.1.19`, bumps chart `0.0.336 → 0.0.337`, updates `global.version`, CHANGELOG, golden renders.
- Dry-run default path: still targets `opentelemetry-collector` across all 5 charts (no regression).
- `Get version` validation: accepts `0.1.19` (+ optional github.com PR URL); rejects shell metacharacters, embedded newlines, and non-github URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CX-50939]: https://coralogix.atlassian.net/browse/CX-50939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
