### PR TITLE
test(otel-integration): cover the OTel eBPF profiler preset and validate its config against the pinned image

### DIFF
--- a/.github/scripts/check-collector-config-validity.sh
+++ b/.github/scripts/check-collector-config-validity.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Validates the collector configs embedded in the golden renders against the
+# container image the chart actually renders, using `otelcol ... validate`
+# (config unmarshal + pipeline construction — no eBPF probes, no cluster).
+#
+# Golden renders alone cannot catch an upstream config-key removal: the rendered
+# YAML stays byte-identical while the binary stops accepting it. That is how
+# `tracers: all` shipped in otel-integration 0.0.333 and crash-looped every
+# profiler pod with:
+#   'config.Config' has invalid keys: tracers
+#
+# Only configs that wire the `profiling` receiver are checked. The agent and
+# cluster-collector configs reference Coralogix-distribution-only components,
+# which no published upstream image can resolve.
+
+CHART_DIR="${CHART_DIR:-otel-integration/k8s-helm}"
+GOLDEN_DIR="${GOLDEN_DIR:-${CHART_DIR}/tests/golden}"
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || { echo "Missing required command: $1" >&2; exit 1; }
+}
+require_cmd docker
+require_cmd awk
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+# Splits a golden render into the `relay` config of every collector ConfigMap.
+extract_configs() {
+  local golden="$1" outdir="$2"
+  awk -v outdir="$outdir" '
+    /^# Source: /            { source = $3 }
+    /^  relay: \|/           { name = source; gsub(/[^A-Za-z0-9]/, "_", name);
+                               file = outdir "/" name ".yaml"; capturing = 1; next }
+    capturing && /^$/        { print "" > file; next }
+    capturing && /^    /     { print substr($0, 5) > file; next }
+    capturing                { capturing = 0; close(file) }
+  ' "$golden"
+}
+
+# Echoes the profiler image the given golden render pins, or nothing.
+profiler_image() {
+  local golden="$1" images
+  images="$(grep -hoE '[^"[:space:]]*opentelemetry-collector-ebpf-profiler:[^"[:space:]]+' "$golden" | sort -u)"
+  if [ "$(printf '%s\n' "$images" | grep -c .)" -gt 1 ]; then
+    echo "Golden $(basename "$golden") pins more than one profiler image:" >&2
+    printf '%s\n' "$images" | sed 's/^/  /' >&2
+    return 1
+  fi
+  printf '%s' "$images"
+}
+
+# Runs `validate` inside the pinned image. The config is handed over through an
+# environment variable rather than a bind mount so this works the same on CI and
+# on a laptop whose Docker VM does not share $TMPDIR.
+#
+# `validate` builds the pipelines, so components are constructed for real. The
+# `eks` resource detector builds a Kubernetes client at construction time, so a
+# service-account token has to exist for it — it is never used, no request is
+# made. The missing ca.crt only produces a klog warning.
+validate_config() {
+  local image="$1" binary="$2" config="$3"
+  local -a env_args=(
+    -e "CX_COLLECTOR_CONFIG"
+    -e "KUBERNETES_SERVICE_HOST=127.0.0.1"
+    -e "KUBERNETES_SERVICE_PORT=443"
+  )
+
+  # `validate` resolves ${env:...} references, so stub every variable the config
+  # expects — these are supplied by the DaemonSet at runtime.
+  local var
+  while read -r var; do
+    case "$var" in
+      *_IP|*_ADDR) env_args+=(-e "${var}=127.0.0.1") ;;
+      *_PORT) env_args+=(-e "${var}=4317") ;;
+      *) env_args+=(-e "${var}=placeholder") ;;
+    esac
+  done < <(grep -oE '\$\{env:[A-Za-z_][A-Za-z0-9_]*\}' "$config" | sed "s/\${env://; s/}//" | sort -u)
+
+  CX_COLLECTOR_CONFIG="$(cat "$config")" docker run --rm --entrypoint sh "${env_args[@]}" "$image" -c '
+    mkdir -p /var/run/secrets/kubernetes.io/serviceaccount
+    printf stub > /var/run/secrets/kubernetes.io/serviceaccount/token
+    exec "$1" validate --config=env:CX_COLLECTOR_CONFIG --feature-gates=+service.profilesSupport
+  ' sh "$binary" 2>&1
+}
+
+failed=0
+found=0
+profiler_configs=0
+
+for golden in "${GOLDEN_DIR}"/*.yaml; do
+  case_name="$(basename "$golden" .yaml)"
+  outdir="${tmpdir}/${case_name}"
+  mkdir -p "$outdir"
+  extract_configs "$golden" "$outdir"
+
+  image=""
+  for config in "$outdir"/*.yaml; do
+    [ -e "$config" ] || continue
+    found=$((found + 1))
+    label="${case_name}/$(basename "$config" .yaml)"
+
+    grep -qE '^  profiling:' "$config" || continue
+    profiler_configs=$((profiler_configs + 1))
+
+    if [ -z "$image" ]; then
+      image="$(profiler_image "$golden")"
+      if [ -z "$image" ]; then
+        echo "FAIL  ${label}"
+        echo "      config uses the 'profiling' receiver but ${case_name}.yaml pins no profiler image" >&2
+        failed=1
+        continue
+      fi
+      echo "Validating against ${image}"
+      docker pull -q "$image" >/dev/null
+      binary="$(docker image inspect --format '{{index .Config.Entrypoint 0}}' "$image")"
+    fi
+
+    if output="$(validate_config "$image" "$binary" "$config")"; then
+      echo "OK    ${label}"
+    else
+      echo "FAIL  ${label}"
+      echo "$output" | sed 's/^/      /' | head -20
+      failed=1
+    fi
+  done
+done
+
+if [ "$found" -eq 0 ]; then
+  echo "No collector configs found under ${GOLDEN_DIR}" >&2
+  exit 1
+fi
+
+# Guard against silently losing coverage: the golden case that exercises the
+# profiling receiver must keep existing.
+if [ "$profiler_configs" -eq 0 ]; then
+  echo "No config using the 'profiling' receiver found under ${GOLDEN_DIR}" >&2
+  exit 1
+fi
+
+if [ "$failed" -ne 0 ]; then
+  echo "Collector config validation failed." >&2
+  exit 1
+fi
+
+echo "All validated collector configs are accepted by the pinned image."

--- a/.github/scripts/check-helm-golden-renders.sh
+++ b/.github/scripts/check-helm-golden-renders.sh
@@ -13,6 +13,7 @@ cases=(
   "windows:values-windows.yaml"
   "eks-fargate:values-eks-fargate.yaml"
   "ebpf-profiler:values-ebpf-profiler.yaml"
+  "otel-ebpf-profiler:values-otel-ebpf-profiler.yaml"
 )
 
 usage() {

--- a/.github/workflows/security-hygiene.yml
+++ b/.github/workflows/security-hygiene.yml
@@ -91,3 +91,6 @@ jobs:
 
       - name: Check high-risk preset renders
         run: .github/scripts/check-helm-golden-renders.sh
+
+      - name: Validate rendered collector configs against the pinned image
+        run: .github/scripts/check-collector-config-validity.sh

--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### v0.0.335 / 2026-08-10
 
 - [Chore] Bump chart dependency to opentelemetry-collector 0.136.4
+- [Chore] Add an `otel-ebpf-profiler` golden case covering the `opentelemetry-ebpf-profiler` sub-chart (the configuration the wizard generates). The existing `ebpf-profiler` case only covers the legacy `coralogix-ebpf-profiler` sub-chart, so the path that broke in 0.0.333 had no coverage.
+- [Chore] Add `check-collector-config-validity.sh`: the collector config embedded in each golden render is now fed to `otelcol validate` inside the exact image the chart renders. Golden diffs cannot catch an upstream config-key removal — the YAML stays identical while the binary starts rejecting it.
 
 #### Changes from opentelemetry-collector 0.136.4:
 - [Fix] `presets.ebpfProfiler`: stop rendering `tracers` on the `profiling` receiver. The option was removed from the receiver in profiler v0.156.0 ([open-telemetry/opentelemetry-ebpf-profiler#1436](https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/1436)), so every profiler pod on appVersion 0.156.0 crash-looped with `'config.Config' has invalid keys: tracers`. The key was rendered unconditionally, so it could not be removed via values either.

--- a/otel-integration/k8s-helm/tests/golden/otel-ebpf-profiler.yaml
+++ b/otel-integration/k8s-helm/tests/golden/otel-ebpf-profiler.yaml
@@ -1,0 +1,2522 @@
+---
+# Source: otel-integration/charts/opentelemetry-agent/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: coralogix-opentelemetry
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-agent-0.136.4
+    app.kubernetes.io/name: opentelemetry-agent
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.156.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: otel-integration/charts/opentelemetry-cluster-collector/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: coralogix-opentelemetry-collector
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-cluster-collector-0.136.4
+    app.kubernetes.io/name: opentelemetry-cluster-collector
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.156.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: otel-integration/charts/opentelemetry-ebpf-profiler/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: coralogix-opentelemetry-ebpf-profiler
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-ebpf-profiler-0.136.4
+    app.kubernetes.io/name: opentelemetry-ebpf-profiler
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.156.0"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: otel-integration/charts/opentelemetry-agent/templates/configmap-agent.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coralogix-opentelemetry-agent
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-agent-0.136.4
+    app.kubernetes.io/name: opentelemetry-agent
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.156.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  relay: |
+    connectors:
+      forward/compact: {}
+      forward/db: {}
+      forward/db_compact: {}
+      spanmetrics:
+        add_resource_attributes: true
+        aggregation_cardinality_limit: 100000
+        dimensions:
+        - name: http.method
+        - name: cgx.transaction
+        - name: cgx.transaction.root
+        - name: status_code
+        - name: db.namespace
+        - name: db.operation.name
+        - name: db.collection.name
+        - name: db.system
+        - name: graphql.operation.type
+        - name: http.response.status_code
+        - name: rpc.grpc.status_code
+        - name: service.version
+        exclude_dimensions:
+        - collector.instance.id
+        histogram:
+          explicit:
+            buckets:
+            - 1ms
+            - 4ms
+            - 10ms
+            - 20ms
+            - 50ms
+            - 100ms
+            - 200ms
+            - 500ms
+            - 1s
+            - 2s
+            - 5s
+          unit: ms
+        metrics_expiration: 5m
+        metrics_flush_interval: '30s'
+        namespace: ""
+        series_expiration: 5m
+      spanmetrics/compact:
+        add_resource_attributes: true
+        aggregation_cardinality_limit: 100000
+        exclude_dimensions:
+        - collector.instance.id
+        - span.name
+        histogram:
+          explicit:
+            buckets:
+            - 1ms
+            - 4ms
+            - 10ms
+            - 20ms
+            - 50ms
+            - 100ms
+            - 200ms
+            - 500ms
+            - 1s
+            - 2s
+            - 5s
+          unit: ms
+        metrics_expiration: 5m
+        metrics_flush_interval: '30s'
+        namespace: compact
+        series_expiration: 5m
+      spanmetrics/db:
+        add_resource_attributes: true
+        aggregation_cardinality_limit: 100000
+        dimensions:
+        - name: db.namespace
+        - name: db.operation.name
+        - name: db.collection.name
+        - name: db.system
+        - name: service.version
+        exclude_dimensions:
+        - collector.instance.id
+        histogram:
+          explicit:
+            buckets:
+            - 1ms
+            - 4ms
+            - 10ms
+            - 20ms
+            - 50ms
+            - 100ms
+            - 200ms
+            - 500ms
+            - 1s
+            - 2s
+            - 5s
+          unit: ms
+        metrics_expiration: 5m
+        metrics_flush_interval: '30s'
+        namespace: db
+        series_expiration: 5m
+      spanmetrics/db_compact:
+        add_resource_attributes: true
+        aggregation_cardinality_limit: 100000
+        dimensions:
+        - name: db.namespace
+        - name: db.system
+        exclude_dimensions:
+        - collector.instance.id
+        - span.name
+        - span.kind
+        histogram:
+          explicit:
+            buckets:
+            - 1ms
+            - 4ms
+            - 10ms
+            - 20ms
+            - 50ms
+            - 100ms
+            - 200ms
+            - 500ms
+            - 1s
+            - 2s
+            - 5s
+          unit: ms
+        metrics_expiration: 5m
+        metrics_flush_interval: '30s'
+        namespace: db_compact
+        series_expiration: 5m
+    exporters:
+      coralogix:
+        application_name: otel
+        application_name_attributes:
+        - k8s.namespace.name
+        - service.namespace
+        domain: eu2.coralogix.com
+        domain_settings:
+          keepalive:
+            enabled: true
+            permit_without_stream: false
+            time: 30s
+            timeout: 10s
+        logs:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.335
+        metrics:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.335
+        private_key: ${env:CORALOGIX_PRIVATE_KEY}
+        profiles:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.335
+            x-coralogix-ingress: otlp/v1.10.0
+        sending_queue:
+          batch:
+            flush_timeout: 250ms
+            max_size: 2097152
+            min_size: 1048576
+            sizer: bytes
+          enabled: true
+          num_consumers: 20
+          queue_size: 209715200
+          sizer: bytes
+        subsystem_name: integration
+        subsystem_name_attributes:
+        - k8s.deployment.name
+        - k8s.statefulset.name
+        - k8s.daemonset.name
+        - k8s.cronjob.name
+        - service.name
+        timeout: 30s
+        traces:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.335
+      coralogix/resource_catalog:
+        application_name: resource
+        domain: eu2.coralogix.com
+        logs:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.335
+            x-coralogix-ingress: metadata-as-otlp-logs/v1
+        private_key: ${CORALOGIX_PRIVATE_KEY}
+        sending_queue:
+          batch:
+            flush_timeout: 250ms
+            max_size: 2097152
+            min_size: 1048576
+            sizer: bytes
+          enabled: true
+          num_consumers: 20
+          queue_size: 209715200
+          sizer: bytes
+        subsystem_name: catalog
+        timeout: 30s
+      debug: {}
+    extensions:
+      file_storage:
+        directory: /var/lib/otelcol
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
+      opamp:
+        agent_description:
+          include_resource_attributes: true
+          non_identifying_attributes:
+            cx.agent.type: agent
+            cx.cluster.name: 'golden-render'
+            helm.chart.opentelemetry-agent.version: 0.136.4
+        server:
+          http:
+            endpoint: https://ingress.eu2.coralogix.com/opamp/v1
+            headers:
+              Authorization: Bearer ${env:CORALOGIX_PRIVATE_KEY}
+            polling_interval: 2m
+      pprof:
+        endpoint: localhost:1777
+      zpages:
+        endpoint: localhost:55679
+    processors:
+      batch:
+        send_batch_max_size: 2048
+        send_batch_size: 1024
+        timeout: 1s
+      coralogix:
+        transactions:
+          enabled: true
+      filter/db_compact_spanmetrics:
+        traces:
+          span:
+          - span.kind != SPAN_KIND_CLIENT or span.attributes["db.namespace"] == nil or
+            (span.attributes["db.system"] == nil and span.attributes["db.system.name"]
+            == nil)
+      filter/db_spanmetrics:
+        traces:
+          span:
+          - span.attributes["db.system"] == nil and span.attributes["db.system.name"]
+            == nil
+      filter/k8s_extra_metrics:
+        metrics:
+          metric:
+          - resource.attributes["service.name"] == "kubernetes-cadvisor" and (metric.name
+            != "container_fs_writes_total" and metric.name != "container_fs_reads_total"
+            and metric.name != "container_fs_writes_bytes_total" and metric.name != "container_fs_reads_bytes_total"
+            and metric.name != "container_fs_usage_bytes" and metric.name != "container_cpu_cfs_throttled_periods_total"
+            and metric.name != "container_cpu_cfs_periods_total")
+      groupbytrace/transactions:
+        wait_duration: 30s
+      k8sattributes:
+        extract:
+          deployment_name_from_replicaset: true
+          metadata:
+          - k8s.namespace.name
+          - k8s.deployment.name
+          - k8s.statefulset.name
+          - k8s.daemonset.name
+          - k8s.cronjob.name
+          - k8s.job.name
+          - k8s.node.name
+          - k8s.pod.name
+        filter:
+          node_from_env_var: K8S_NODE_NAME
+        passthrough: false
+        pod_association:
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.ip
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.uid
+        - sources:
+          - from: connection
+        - sources:
+          - from: resource_attribute
+            name: k8s.job.name
+      k8sattributes/profiles:
+        extract:
+          annotations:
+          - from: pod
+            key: app.coralogix.com/service
+            tag_name: service.annotation
+          labels:
+          - from: pod
+            key: app.kubernetes.io/name
+            tag_name: k8s.label.name
+          - from: pod
+            key: app.kubernetes.io/instance
+            tag_name: k8s.label.instance
+          - from: pod
+            key: app.kubernetes.io/name
+            tag_name: service.label
+          metadata:
+          - k8s.namespace.name
+          - k8s.replicaset.name
+          - k8s.statefulset.name
+          - k8s.daemonset.name
+          - k8s.deployment.name
+          - k8s.cronjob.name
+          - k8s.job.name
+          - k8s.pod.name
+          - k8s.node.name
+          - container.id
+          - k8s.container.name
+          - service.version
+          otel_annotations: true
+        filter:
+          node_from_env_var: K8S_NODE_NAME
+        passthrough: false
+        pod_association:
+        - sources:
+          - from: resource_attribute
+            name: container.id
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.uid
+        - sources:
+          - from: connection
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
+      redaction/spanname:
+        allow_all_keys: true
+        db_sanitizer:
+          es:
+            attributes:
+            - db.statement
+            - elasticsearch.body
+            enabled: true
+          memcached:
+            attributes:
+            - db.statement
+            - memcached.command
+            enabled: true
+          mongo:
+            attributes:
+            - db.statement
+            - mongodb.query
+            enabled: true
+          opensearch:
+            attributes:
+            - db.statement
+            - opensearch.body
+            enabled: true
+          redis:
+            attributes:
+            - db.statement
+            - redis.command
+            enabled: true
+          sql:
+            attributes:
+            - db.statement
+            - db.query
+            enabled: true
+        url_sanitizer:
+          enabled: true
+      resource/metadata:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: 'golden-render'
+        - action: upsert
+          key: cx.otel_integration.name
+          value: coralogix-integration-helm
+      resourcedetection/entity:
+        detectors:
+        - system
+        - env
+        override: false
+        system:
+          resource_attributes:
+            host.cpu.cache.l2.size:
+              enabled: true
+            host.cpu.family:
+              enabled: true
+            host.cpu.model.id:
+              enabled: true
+            host.cpu.model.name:
+              enabled: true
+            host.cpu.stepping:
+              enabled: true
+            host.cpu.vendor.id:
+              enabled: true
+            host.id:
+              enabled: true
+            host.ip:
+              enabled: true
+            host.mac:
+              enabled: true
+            os.description:
+              enabled: true
+        timeout: 2s
+      resourcedetection/env:
+        detectors:
+        - system
+        - env
+        override: false
+        system:
+          resource_attributes:
+            host.id:
+              enabled: true
+        timeout: 2s
+      resourcedetection/region:
+        detectors:
+        - gcp
+        - ec2
+        - azure
+        - eks
+        eks:
+          node_from_env_var: K8S_NODE_NAME
+        override: true
+        timeout: 2s
+      transform/compact:
+        trace_statements:
+        - context: resource
+          statements:
+          - keep_keys(resource.attributes, ["service.name", "k8s.cluster.name", "host.name",
+            "deployment.environment.name"])
+      transform/db:
+        error_mode: silent
+        trace_statements:
+        - context: span
+          statements:
+          - set(attributes["db.system"], attributes["db.system.name"]) where attributes["db.system.name"]
+            != nil and attributes["db.system"] == nil
+      transform/db_compact:
+        trace_statements:
+        - context: resource
+          statements:
+          - keep_keys(resource.attributes, ["service.name", "k8s.cluster.name", "host.name",
+            "deployment.environment.name"])
+        - context: span
+          statements:
+          - set(attributes["db.system"], attributes["db.system.name"]) where attributes["db.system.name"]
+            != nil and attributes["db.system"] == nil
+          - keep_keys(span.attributes, ["db.namespace", "db.system"])
+      transform/entity-event:
+        error_mode: silent
+        log_statements:
+        - context: log
+          statements:
+          - set(log.attributes["otel.entity.id"]["host.id"], resource.attributes["host.id"])
+          - merge_maps(log.attributes, resource.attributes, "insert")
+        - context: resource
+          statements:
+          - keep_keys(resource.attributes, [""])
+      transform/kubeletstatscpu:
+        error_mode: ignore
+        metric_statements:
+        - context: metric
+          statements:
+          - set(metric.unit, "1") where metric.name == "container.cpu.usage"
+          - set(metric.name, "container.cpu.utilization") where metric.name == "container.cpu.usage"
+          - set(metric.unit, "1") where metric.name == "k8s.pod.cpu.usage"
+          - set(metric.name, "k8s.pod.cpu.utilization") where metric.name == "k8s.pod.cpu.usage"
+          - set(metric.unit, "1") where metric.name == "k8s.node.cpu.usage"
+          - set(metric.name, "k8s.node.cpu.utilization") where metric.name == "k8s.node.cpu.usage"
+      transform/profiles:
+        profile_statements:
+        - set(resource.attributes["service.name"], resource.attributes["service.annotation"])
+          where resource.attributes["service.name"] == nil and resource.attributes["service.annotation"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["service.label"])
+          where resource.attributes["service.name"] == nil and resource.attributes["service.label"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["k8s.label.instance"])
+          where resource.attributes["service.name"] == nil and resource.attributes["k8s.label.instance"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["k8s.label.name"])
+          where resource.attributes["service.name"] == nil and resource.attributes["k8s.label.name"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["k8s.deployment.name"])
+          where resource.attributes["service.name"] == nil and resource.attributes["k8s.deployment.name"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["k8s.replicaset.name"])
+          where resource.attributes["service.name"] == nil and resource.attributes["k8s.replicaset.name"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["k8s.statefulset.name"])
+          where resource.attributes["service.name"] == nil and resource.attributes["k8s.statefulset.name"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["k8s.daemonset.name"])
+          where resource.attributes["service.name"] == nil and resource.attributes["k8s.daemonset.name"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["k8s.cronjob.name"])
+          where resource.attributes["service.name"] == nil and resource.attributes["k8s.cronjob.name"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["k8s.job.name"])
+          where resource.attributes["service.name"] == nil and resource.attributes["k8s.job.name"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["k8s.pod.name"])
+          where resource.attributes["service.name"] == nil and resource.attributes["k8s.pod.name"]
+          != nil
+        - set(resource.attributes["service.name"], resource.attributes["k8s.container.name"])
+          where resource.attributes["service.name"] == nil and resource.attributes["k8s.container.name"]
+          != nil
+      transform/prometheus:
+        error_mode: ignore
+        metric_statements:
+        - context: metric
+          statements:
+          - replace_pattern(metric.name, "_total$", "") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_cpu_seconds_seconds$", "otelcol_process_cpu_seconds")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_runtime_heap_alloc_bytes_bytes$",
+            "otelcol_process_runtime_heap_alloc_bytes") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_runtime_total_alloc_bytes_bytes$",
+            "otelcol_process_runtime_total_alloc_bytes") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_runtime_total_sys_memory_bytes_bytes$",
+            "otelcol_process_runtime_total_sys_memory_bytes") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_fileconsumer_open_files$", "otelcol_fileconsumer_open_files_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_fileconsumer_reading_files$", "otelcol_fileconsumer_reading_files_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_ip_lookup_miss$", "otelcol_otelsvc_k8s_ip_lookup_miss_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_pod_added$", "otelcol_otelsvc_k8s_pod_added_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_pod_updated$", "otelcol_otelsvc_k8s_pod_updated_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_pod_deleted$", "otelcol_otelsvc_k8s_pod_deleted_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_processor_memory_limiter_accepted_log_records$",
+            "otelcol_processor_accepted_log_records") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_processor_memory_limiter_accepted_metric_points$",
+            "otelcol_processor_accepted_metric_points") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_processor_memory_limiter_accepted_spans$",
+            "otelcol_processor_accepted_spans") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_processor_memory_limiter_refused_log_records$",
+            "otelcol_processor_refused_log_records") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_processor_memory_limiter_refused_metric_points$",
+            "otelcol_processor_refused_metric_points") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_processor_memory_limiter_refused_spans$",
+            "otelcol_processor_refused_spans") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_processor_filter_spans\\.filtered$",
+            "otelcol_processor_filter_spans.filtered_ratio") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+        - context: resource
+          statements:
+          - set(resource.attributes["k8s.pod.ip"], resource.attributes["net.host.name"])
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - delete_key(resource.attributes, "service_name") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+        - context: datapoint
+          statements:
+          - delete_key(datapoint.attributes, "service_name") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - delete_key(datapoint.attributes, "otel_scope_name") where datapoint.attributes["service.name"]
+            == "opentelemetry-collector"
+      transform/semconv:
+        error_mode: ignore
+        trace_statements:
+        - context: span
+          statements:
+          - set(span.attributes["http.method"], span.attributes["http.request.method"])
+            where span.attributes["http.request.method"] != nil
+          - set(span.attributes["http.response.status_code"], span.attributes["http.status_code"])
+            where span.attributes["http.response.status_code"] == nil and span.attributes["http.status_code"]
+            != nil
+      transform/spanmetrics:
+        error_mode: silent
+        metric_statements:
+        - context: datapoint
+          statements:
+          - set(datapoint.attributes["status.code"], "STATUS_CODE_ERROR") where datapoint.attributes["status.code"]
+            == nil and instrumentation_scope.name == "spanmetricsconnector" and datapoint.attributes["otel.status_code"]
+            == "ERROR"
+          - set(datapoint.attributes["status.code"], "STATUS_CODE_OK") where datapoint.attributes["status.code"]
+            == nil and instrumentation_scope.name == "spanmetricsconnector" and datapoint.attributes["otel.status_code"]
+            == "OK"
+          - set(datapoint.attributes["status.code"], "STATUS_CODE_UNSET") where datapoint.attributes["status.code"]
+            == nil and instrumentation_scope.name == "spanmetricsconnector" and (datapoint.attributes["otel.status_code"]
+            == "UNSET" or datapoint.attributes["otel.status_code"] == nil)
+    receivers:
+      filelog:
+        exclude: []
+        force_flush_period: 0
+        include:
+        - /var/log/pods/*/*/*.log
+        include_file_name: false
+        include_file_path: true
+        operators:
+        - id: get-format
+          routes:
+          - expr: body matches "^\\{"
+            output: parser-docker
+          - expr: body matches "^[^ Z]+ "
+            output: parser-crio
+          - expr: body matches "^[^ Z]+Z"
+            output: parser-containerd
+          type: router
+        - id: parser-crio
+          regex: ^(?P<time>[^ Z]+) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$
+          timestamp:
+            layout: 2006-01-02T15:04:05.999999999Z07:00
+            layout_type: gotime
+            parse_from: attributes.time
+          type: regex_parser
+        - combine_field: attributes.log
+          combine_with: ""
+          id: crio-recombine
+          is_last_entry: attributes.logtag == 'F'
+          max_batch_size: 1000
+          max_log_size: 1048576
+          output: handle_empty_log
+          source_identifier: attributes["log.file.path"]
+          type: recombine
+        - id: parser-containerd
+          regex: ^(?P<time>[^ ^Z]+Z) (?P<stream>stdout|stderr) (?P<logtag>[^ ]*) ?(?P<log>.*)$
+          timestamp:
+            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+            parse_from: attributes.time
+          type: regex_parser
+        - combine_field: attributes.log
+          combine_with: ""
+          id: containerd-recombine
+          is_last_entry: attributes.logtag == 'F'
+          max_batch_size: 1000
+          max_log_size: 1048576
+          output: handle_empty_log
+          source_identifier: attributes["log.file.path"]
+          type: recombine
+        - id: parser-docker
+          timestamp:
+            layout: '%Y-%m-%dT%H:%M:%S.%LZ'
+            parse_from: attributes.time
+          type: json_parser
+        - combine_field: attributes.log
+          combine_with: ""
+          id: docker-recombine
+          is_last_entry: attributes.log endsWith "\n"
+          max_batch_size: 1000
+          max_log_size: 1048576
+          output: handle_empty_log
+          source_identifier: attributes["log.file.path"]
+          type: recombine
+        - field: attributes.log
+          id: handle_empty_log
+          if: attributes.log == nil
+          type: add
+          value: ""
+        - parse_from: attributes["log.file.path"]
+          regex: ^.*\/(?P<namespace>[^_]+)_(?P<pod_name>[^_]+)_(?P<uid>[a-f0-9\-]+)\/(?P<container_name>[^\._]+)\/(?P<restart_count>\d+)\.log$
+          type: regex_parser
+        - from: attributes.stream
+          to: attributes["log.iostream"]
+          type: move
+        - from: attributes.container_name
+          to: resource["k8s.container.name"]
+          type: move
+        - from: attributes.namespace
+          to: resource["k8s.namespace.name"]
+          type: move
+        - from: attributes.pod_name
+          to: resource["k8s.pod.name"]
+          type: move
+        - from: attributes.restart_count
+          to: resource["k8s.container.restart_count"]
+          type: move
+        - from: attributes.uid
+          to: resource["k8s.pod.uid"]
+          type: move
+        - from: attributes.log
+          id: clean-up-log-record
+          to: body
+          type: move
+        - default: skip-collector-logs-recombine
+          routes:
+          - expr: (attributes["log.file.path"] matches "/var/log/pods/default_coralogix-opentelemetry.*_.*/opentelemetry-agent/.*.log")
+            output: collector-logs-recombine
+          type: router
+        - combine_field: body
+          combine_with: |2+
+
+          id: collector-logs-recombine
+          is_first_entry: body matches "^\\{"
+          max_batch_size: 1000
+          max_log_size: 1048576
+          source_identifier: attributes["log.file.path"]
+          type: recombine
+        - id: skip-collector-logs-recombine
+          type: noop
+        - field: body
+          if: (attributes["log.file.path"] matches "/var/log/pods/default_coralogix-opentelemetry.*_.*/opentelemetry-agent/.*.log")
+          regex: (?s)("stacktrace":"[^"]*)"}\n(.*)$
+          replace_with: $${1}\\n$${2}"}
+          type: regex_replace
+        - drop_ratio: 1
+          expr: (attributes["log.file.path"] matches "/var/log/pods/default_coralogix-opentelemetry.*_.*/opentelemetry-agent/.*.log")
+            and ((body contains "logRecord") or (body contains "ResourceLog"))
+          type: filter
+        - default: logs-collection-continue
+          routes:
+          - expr: (body matches "\"resource\":{.*?},?") and not (body matches "\"logger\":\"supervisor\\.collector\"")
+            output: parse-body
+          type: router
+        - id: parse-body
+          if: (attributes["log.file.path"] matches "/var/log/pods/default_coralogix-opentelemetry.*_.*/.*/.*.log")
+            and not (body matches "\"logger\":\"supervisor\\.collector\"")
+          on_error: send_quiet
+          parse_to: attributes["parsed_body_tmp"]
+          type: json_parser
+        - field: body
+          if: (attributes["log.file.path"] matches "/var/log/pods/default_coralogix-opentelemetry.*_.*/.*/.*.log")
+            and not (body matches "\"logger\":\"supervisor\\.collector\"")
+          on_error: send_quiet
+          regex: \"resource\":{.*?},?
+          replace_with: ""
+          type: regex_replace
+        - from: attributes["parsed_body_tmp"]["resource"]
+          if: (attributes["log.file.path"] matches "/var/log/pods/default_coralogix-opentelemetry.*_.*/.*/.*.log")
+            and not (body matches "\"logger\":\"supervisor\\.collector\"")
+          on_error: send_quiet
+          to: resource["attributes_tmp"]
+          type: move
+        - field: attributes["parsed_body_tmp"]
+          if: (attributes["log.file.path"] matches "/var/log/pods/default_coralogix-opentelemetry.*_.*/.*/.*.log")
+            and not (body matches "\"logger\":\"supervisor\\.collector\"")
+          on_error: send_quiet
+          type: remove
+        - field: resource["attributes_tmp"]
+          id: flatten-resource
+          if: (attributes["log.file.path"] matches "/var/log/pods/default_coralogix-opentelemetry.*_.*/.*/.*.log")
+            and not (body matches "\"logger\":\"supervisor\\.collector\"")
+          on_error: send_quiet
+          type: flatten
+        - id: logs-collection-continue
+          type: noop
+        retry_on_failure:
+          enabled: true
+        start_at: beginning
+        storage: file_storage
+      hostmetrics:
+        collection_interval: '30s'
+        root_path: /hostfs
+        scrapers:
+          cpu:
+            metrics:
+              system.cpu.utilization:
+                enabled: true
+          disk: null
+          filesystem:
+            exclude_fs_types:
+              fs_types:
+              - autofs
+              - binfmt_misc
+              - bpf
+              - cgroup2
+              - configfs
+              - debugfs
+              - devpts
+              - devtmpfs
+              - fusectl
+              - hugetlbfs
+              - iso9660
+              - mqueue
+              - nsfs
+              - overlay
+              - proc
+              - procfs
+              - pstore
+              - rpc_pipefs
+              - securityfs
+              - selinuxfs
+              - squashfs
+              - sysfs
+              - tracefs
+              match_type: strict
+            exclude_mount_points:
+              match_type: regexp
+              mount_points:
+              - /dev/*
+              - /proc/*
+              - /sys/*
+              - /run/k3s/containerd/*
+              - /run/containerd/runc/*
+              - /var/lib/docker/*
+              - /var/lib/kubelet/*
+              - /snap/*
+          load: null
+          memory:
+            metrics:
+              system.memory.utilization:
+                enabled: true
+          network: null
+      jaeger:
+        protocols:
+          grpc:
+            endpoint: ${env:MY_POD_IP}:14250
+          thrift_binary:
+            endpoint: ${env:MY_POD_IP}:6832
+          thrift_compact:
+            endpoint: ${env:MY_POD_IP}:6831
+          thrift_http:
+            endpoint: ${env:MY_POD_IP}:14268
+      kubeletstats:
+        auth_type: serviceAccount
+        collect_all_network_interfaces:
+          node: true
+          pod: true
+        collection_interval: '30s'
+        endpoint: ${env:K8S_NODE_IP}:10250
+        insecure_skip_verify: true
+      otlp:
+        protocols:
+          grpc:
+            endpoint: ${env:MY_POD_IP}:4317
+            max_recv_msg_size_mib: 20
+          http:
+            endpoint: ${env:MY_POD_IP}:4318
+      prometheus:
+        config:
+          scrape_configs:
+          - job_name: opentelemetry-collector
+            scrape_interval: '30s'
+            static_configs:
+            - targets:
+              - ${env:MY_POD_IP}:8888
+      prometheus/k8s_extra_metrics:
+        config:
+          scrape_configs:
+          - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            honor_timestamps: true
+            job_name: kubernetes-cadvisor
+            metrics_path: /metrics/cadvisor
+            scheme: https
+            static_configs:
+            - targets:
+              - ${env:K8S_NODE_IP}:10250
+            tls_config:
+              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              insecure_skip_verify: true
+      statsd:
+        endpoint: ${env:MY_POD_IP}:8125
+      zipkin:
+        endpoint: ${env:MY_POD_IP}:9411
+    service:
+      extensions:
+      - health_check
+      - file_storage
+      - opamp
+      - zpages
+      - pprof
+      pipelines:
+        logs:
+          exporters:
+          - coralogix
+          processors:
+          - memory_limiter
+          - resourcedetection/region
+          - resourcedetection/env
+          - resource/metadata
+          - k8sattributes
+          - batch
+          receivers:
+          - filelog
+          - otlp
+        logs/resource_catalog:
+          exporters:
+          - coralogix/resource_catalog
+          processors:
+          - memory_limiter
+          - resource/metadata
+          - k8sattributes
+          - resourcedetection/entity
+          - resourcedetection/region
+          - transform/entity-event
+          receivers:
+          - hostmetrics
+        metrics:
+          exporters:
+          - coralogix
+          processors:
+          - memory_limiter
+          - resourcedetection/region
+          - resourcedetection/env
+          - resource/metadata
+          - k8sattributes
+          - transform/kubeletstatscpu
+          - filter/k8s_extra_metrics
+          - transform/spanmetrics
+          - transform/prometheus
+          - batch
+          receivers:
+          - hostmetrics
+          - kubeletstats
+          - prometheus/k8s_extra_metrics
+          - spanmetrics
+          - spanmetrics/db
+          - prometheus
+          - otlp
+          - statsd
+        metrics/compact:
+          exporters:
+          - coralogix
+          processors:
+          - memory_limiter
+          - transform/spanmetrics
+          - batch
+          receivers:
+          - spanmetrics/compact
+        metrics/db_compact:
+          exporters:
+          - coralogix
+          processors:
+          - memory_limiter
+          - transform/spanmetrics
+          - batch
+          receivers:
+          - spanmetrics/db_compact
+        profiles:
+          exporters:
+          - coralogix
+          processors:
+          - memory_limiter
+          - resourcedetection/region
+          - resourcedetection/env
+          - resource/metadata
+          - k8sattributes/profiles
+          - transform/profiles
+          receivers:
+          - otlp
+        traces:
+          exporters:
+          - spanmetrics
+          - forward/db
+          - forward/compact
+          - forward/db_compact
+          - coralogix
+          processors:
+          - memory_limiter
+          - resourcedetection/region
+          - resourcedetection/env
+          - resource/metadata
+          - k8sattributes
+          - transform/spanmetrics
+          - redaction/spanname
+          - transform/semconv
+          - groupbytrace/transactions
+          - coralogix
+          - batch
+          receivers:
+          - jaeger
+          - zipkin
+          - otlp
+        traces/compact:
+          exporters:
+          - spanmetrics/compact
+          processors:
+          - transform/compact
+          - batch
+          receivers:
+          - forward/compact
+        traces/db:
+          exporters:
+          - spanmetrics/db
+          processors:
+          - filter/db_spanmetrics
+          - transform/db
+          - batch
+          receivers:
+          - forward/db
+        traces/db_compact:
+          exporters:
+          - spanmetrics/db_compact
+          processors:
+          - filter/db_compact_spanmetrics
+          - transform/db_compact
+          - batch
+          receivers:
+          - forward/db_compact
+      telemetry:
+        logs:
+          encoding: json
+          level: 'info'
+        metrics:
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: ${env:MY_POD_IP}
+                  port: 8888
+                  without_scope_info: false
+                  without_type_suffix: false
+                  without_units: false
+        resource:
+          cx.agent.type: agent
+          k8s.daemonset.name: coralogix-opentelemetry
+          k8s.namespace.name: default
+          k8s.node.name: ${env:KUBE_NODE_NAME}
+          k8s.pod.name: ${env:KUBE_POD_NAME}
+          service.name: opentelemetry-collector
+---
+# Source: otel-integration/charts/opentelemetry-cluster-collector/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coralogix-opentelemetry-collector
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-cluster-collector-0.136.4
+    app.kubernetes.io/name: opentelemetry-cluster-collector
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.156.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  relay: |
+    exporters:
+      coralogix:
+        application_name: otel
+        application_name_attributes:
+        - k8s.namespace.name
+        - service.namespace
+        domain: eu2.coralogix.com
+        domain_settings:
+          keepalive:
+            enabled: true
+            permit_without_stream: false
+            time: 30s
+            timeout: 10s
+        logs:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.335
+        metrics:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.335
+        private_key: ${env:CORALOGIX_PRIVATE_KEY}
+        profiles:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.335
+            x-coralogix-ingress: otlp/v1.10.0
+        sending_queue:
+          batch:
+            flush_timeout: 250ms
+            max_size: 2097152
+            min_size: 1048576
+            sizer: bytes
+          enabled: true
+          num_consumers: 20
+          queue_size: 209715200
+          sizer: bytes
+        subsystem_name: integration
+        subsystem_name_attributes:
+        - k8s.deployment.name
+        - k8s.statefulset.name
+        - k8s.daemonset.name
+        - k8s.cronjob.name
+        - service.name
+        timeout: 30s
+        traces:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.335
+      coralogix/resource_catalog:
+        application_name: resource
+        domain: eu2.coralogix.com
+        logs:
+          headers:
+            X-Coralogix-Distribution: helm-otel-integration/0.0.335
+            x-coralogix-ingress: metadata-as-otlp-logs/v1
+        private_key: ${CORALOGIX_PRIVATE_KEY}
+        sending_queue:
+          batch:
+            flush_timeout: 250ms
+            max_size: 2097152
+            min_size: 1048576
+            sizer: bytes
+          enabled: true
+          num_consumers: 20
+          queue_size: 209715200
+          sizer: bytes
+        subsystem_name: catalog
+        timeout: 30s
+      debug: {}
+    extensions:
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
+      k8s_observer:
+        auth_type: serviceAccount
+        observe_pods: true
+      opamp:
+        agent_description:
+          include_resource_attributes: true
+          non_identifying_attributes:
+            cx.agent.type: cluster-collector
+            cx.cluster.name: 'golden-render'
+            helm.chart.opentelemetry-cluster-collector.version: 0.136.4
+        server:
+          http:
+            endpoint: https://ingress.eu2.coralogix.com/opamp/v1
+            headers:
+              Authorization: Bearer ${env:CORALOGIX_PRIVATE_KEY}
+            polling_interval: 2m
+      pprof:
+        endpoint: localhost:1777
+      zpages:
+        endpoint: localhost:55679
+    processors:
+      batch:
+        send_batch_max_size: 2048
+        send_batch_size: 1024
+        timeout: 1s
+      filter/k8s_apiserver_metrics:
+        metrics:
+          metric:
+          - resource.attributes["service.name"] == "kubernetes-apiserver" and metric.name
+            != "kubernetes_build_info"
+      filter/workflow:
+        error_mode: silent
+        logs:
+          log_record:
+          - log.body["object"]["kind"] == "Pod" and not IsMatch(String(log.body["object"]["metadata"]["ownerReferences"]),
+            ".*StatefulSet.*|.*ReplicaSet.*|.*Job.*|.*DaemonSet.*")
+          - log.body["kind"] == "Pod" and not IsMatch(String(log.body["metadata"]["ownerReferences"]),
+            ".*StatefulSet.*|.*ReplicaSet.*|.*Job.*|.*DaemonSet.*")
+      k8sattributes:
+        extract:
+          deployment_name_from_replicaset: true
+          metadata:
+          - k8s.namespace.name
+          - k8s.deployment.name
+          - k8s.statefulset.name
+          - k8s.daemonset.name
+          - k8s.cronjob.name
+          - k8s.job.name
+          - k8s.node.name
+          - k8s.pod.name
+        passthrough: false
+        pod_association:
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.ip
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.uid
+        - sources:
+          - from: connection
+        - sources:
+          - from: resource_attribute
+            name: k8s.job.name
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
+      metricstransform/k8s-dashboard:
+        transforms:
+        - action: insert
+          include: k8s.pod.phase
+          match_type: strict
+          new_name: kube_pod_status_qos_class
+        - action: insert
+          include: k8s.pod.status_reason
+          match_type: strict
+          new_name: kube_pod_status_reason
+        - action: insert
+          include: k8s.node.allocatable_cpu
+          match_type: strict
+          new_name: kube_node_info
+        - action: insert
+          include: k8s.container.ready
+          match_type: strict
+          new_name: k8s.container.status.last_terminated_reason
+      resource/kube-events:
+        attributes:
+        - action: upsert
+          key: service.name
+          value: kube-events
+        - action: upsert
+          key: k8s.cluster.name
+          value: golden-render
+      resource/metadata:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: 'golden-render'
+        - action: upsert
+          key: cx.otel_integration.name
+          value: coralogix-integration-helm
+      resourcedetection/env:
+        detectors:
+        - system
+        - env
+        override: false
+        system:
+          resource_attributes:
+            host.id:
+              enabled: true
+        timeout: 2s
+      resourcedetection/region:
+        detectors:
+        - gcp
+        - ec2
+        - azure
+        - eks
+        eks:
+          node_from_env_var: K8S_NODE_NAME
+        override: true
+        timeout: 2s
+      resourcedetection/resource_catalog:
+        azure:
+          resource_attributes:
+            azure.resourcegroup.name:
+              enabled: false
+            azure.vm.name:
+              enabled: false
+            azure.vm.scaleset.name:
+              enabled: false
+            azure.vm.size:
+              enabled: false
+            host.id:
+              enabled: false
+            host.name:
+              enabled: false
+        detectors:
+        - gcp
+        - ec2
+        - azure
+        - eks
+        ec2:
+          resource_attributes:
+            host.id:
+              enabled: false
+            host.image.id:
+              enabled: false
+            host.name:
+              enabled: false
+            host.type:
+              enabled: false
+        eks:
+          node_from_env_var: K8S_NODE_NAME
+        gcp:
+          resource_attributes:
+            host.id:
+              enabled: false
+            host.name:
+              enabled: false
+            host.type:
+              enabled: false
+            k8s.cluster.name:
+              enabled: false
+        override: true
+        timeout: 2s
+      transform/entity-event:
+        error_mode: silent
+        log_statements:
+        - context: log
+          statements:
+          - set(log.attributes["otel.entity.interval"], Milliseconds(Duration("1h")))
+      transform/k8s-dashboard:
+        error_mode: ignore
+        metric_statements:
+        - context: metric
+          statements:
+          - set(metric.unit, "1") where metric.name == "k8s.pod.phase"
+          - set(metric.unit, "") where metric.name == "kube_node_info"
+          - set(metric.unit, "") where metric.name == "k8s.container.status.last_terminated_reason"
+        - context: datapoint
+          statements:
+          - set(datapoint.value_int, 1) where metric.name == "kube_pod_status_qos_class"
+          - set(datapoint.attributes["qos_class"], resource.attributes["k8s.pod.qos_class"])
+            where metric.name == "kube_pod_status_qos_class"
+          - set(datapoint.attributes["pod"], resource.attributes["k8s.pod.name"]) where
+            metric.name == "kube_pod_status_reason"
+          - set(datapoint.attributes["reason"], "Evicted") where metric.name == "kube_pod_status_reason"
+            and datapoint.value_int == 1
+          - set(datapoint.attributes["reason"], "NodeAffinity") where metric.name == "kube_pod_status_reason"
+            and datapoint.value_int == 2
+          - set(datapoint.attributes["reason"], "NodeLost") where metric.name == "kube_pod_status_reason"
+            and datapoint.value_int == 3
+          - set(datapoint.attributes["reason"], "Shutdown") where metric.name == "kube_pod_status_reason"
+            and datapoint.value_int == 4
+          - set(datapoint.attributes["reason"], "UnexpectedAdmissionError") where metric.name
+            == "kube_pod_status_reason" and datapoint.value_int == 5
+          - set(datapoint.value_int, 0) where metric.name == "kube_pod_status_reason"
+            and datapoint.value_int == 6
+          - set(datapoint.value_int, 1) where metric.name == "kube_pod_status_reason"
+            and datapoint.value_int != 0
+          - set(datapoint.value_int, 1) where metric.name == "kube_node_info"
+          - set(datapoint.attributes["kubelet_version"], resource.attributes["k8s.kubelet.version"])
+            where metric.name == "kube_node_info"
+          - set(datapoint.value_int, 1) where metric.name == "k8s.container.status.last_terminated_reason"
+          - set(datapoint.attributes["reason"], "") where metric.name == "k8s.container.status.last_terminated_reason"
+          - set(datapoint.attributes["reason"], resource.attributes["k8s.container.status.last_terminated_reason"])
+            where metric.name == "k8s.container.status.last_terminated_reason"
+        - context: resource
+          statements:
+          - delete_key(resource.attributes, "k8s.container.status.last_terminated_reason")
+          - delete_key(resource.attributes, "k8s.pod.qos_class")
+          - delete_key(resource.attributes, "k8s.kubelet.version")
+      transform/kube-events:
+        log_statements:
+        - context: log
+          statements:
+          - keep_keys(log.body["object"], ["type", "eventTime", "reason", "regarding",
+            "note", "metadata", "deprecatedFirstTimestamp", "deprecatedLastTimestamp"])
+            where IsMap(log.body) and IsMap(log.body["object"])
+          - keep_keys(log.body["object"]["metadata"], ["creationTimestamp"]) where IsMap(log.body)
+            and IsMap(log.body["object"]) and IsMap(log.body["object"]["metadata"])
+          - keep_keys(log.body["object"]["regarding"], ["kind", "name", "namespace"])
+            where IsMap(log.body) and IsMap(log.body["object"]) and IsMap(log.body["object"]["regarding"])
+      transform/prometheus:
+        error_mode: ignore
+        metric_statements:
+        - context: metric
+          statements:
+          - replace_pattern(metric.name, "_total$", "") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_cpu_seconds_seconds$", "otelcol_process_cpu_seconds")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_runtime_heap_alloc_bytes_bytes$",
+            "otelcol_process_runtime_heap_alloc_bytes") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_runtime_total_alloc_bytes_bytes$",
+            "otelcol_process_runtime_total_alloc_bytes") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_process_runtime_total_sys_memory_bytes_bytes$",
+            "otelcol_process_runtime_total_sys_memory_bytes") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_fileconsumer_open_files$", "otelcol_fileconsumer_open_files_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_fileconsumer_reading_files$", "otelcol_fileconsumer_reading_files_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_ip_lookup_miss$", "otelcol_otelsvc_k8s_ip_lookup_miss_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_pod_added$", "otelcol_otelsvc_k8s_pod_added_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_pod_updated$", "otelcol_otelsvc_k8s_pod_updated_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_otelsvc_k8s_pod_deleted$", "otelcol_otelsvc_k8s_pod_deleted_ratio")
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_processor_memory_limiter_accepted_log_records$",
+            "otelcol_processor_accepted_log_records") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_processor_memory_limiter_accepted_metric_points$",
+            "otelcol_processor_accepted_metric_points") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_processor_memory_limiter_accepted_spans$",
+            "otelcol_processor_accepted_spans") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_processor_memory_limiter_refused_log_records$",
+            "otelcol_processor_refused_log_records") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_processor_memory_limiter_refused_metric_points$",
+            "otelcol_processor_refused_metric_points") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_processor_memory_limiter_refused_spans$",
+            "otelcol_processor_refused_spans") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - replace_pattern(metric.name, "^otelcol_processor_filter_spans\\.filtered$",
+            "otelcol_processor_filter_spans.filtered_ratio") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+        - context: resource
+          statements:
+          - set(resource.attributes["k8s.pod.ip"], resource.attributes["net.host.name"])
+            where resource.attributes["service.name"] == "opentelemetry-collector"
+          - delete_key(resource.attributes, "service_name") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+        - context: datapoint
+          statements:
+          - delete_key(datapoint.attributes, "service_name") where resource.attributes["service.name"]
+            == "opentelemetry-collector"
+          - delete_key(datapoint.attributes, "otel_scope_name") where datapoint.attributes["service.name"]
+            == "opentelemetry-collector"
+    receivers:
+      k8s_cluster:
+        allocatable_types_to_report:
+        - cpu
+        - memory
+        - pods
+        collection_interval: '30s'
+        metrics:
+          k8s.pod.status_reason:
+            enabled: true
+        resource_attributes:
+          k8s.container.status.last_terminated_reason:
+            enabled: true
+          k8s.kubelet.version:
+            enabled: true
+          k8s.pod.qos_class:
+            enabled: true
+      k8sobjects:
+        objects:
+        - exclude_watch_type:
+          - DELETED
+          group: events.k8s.io
+          mode: watch
+          name: events
+      k8sobjects/resource_catalog:
+        objects:
+        - group: ""
+          initial_delay: 0s
+          mode: pull
+          name: namespaces
+        - group: ""
+          initial_delay: 5s
+          mode: pull
+          name: nodes
+        - group: ""
+          initial_delay: 10s
+          mode: pull
+          name: persistentvolumeclaims
+        - group: ""
+          initial_delay: 15s
+          mode: pull
+          name: persistentvolumes
+        - group: ""
+          initial_delay: 20s
+          mode: pull
+          name: pods
+        - group: ""
+          initial_delay: 25s
+          mode: pull
+          name: services
+        - group: apps
+          initial_delay: 30s
+          mode: pull
+          name: daemonsets
+        - group: apps
+          initial_delay: 35s
+          mode: pull
+          name: deployments
+        - group: apps
+          initial_delay: 40s
+          mode: pull
+          name: replicasets
+        - group: apps
+          initial_delay: 45s
+          mode: pull
+          name: statefulsets
+        - group: autoscaling
+          initial_delay: 50s
+          mode: pull
+          name: horizontalpodautoscalers
+        - group: batch
+          initial_delay: 55s
+          mode: pull
+          name: cronjobs
+        - group: batch
+          initial_delay: 60s
+          mode: pull
+          name: jobs
+        - group: extensions
+          initial_delay: 65s
+          mode: pull
+          name: ingresses
+        - group: networking.k8s.io
+          initial_delay: 65s
+          mode: pull
+          name: ingresses
+        - group: policy
+          initial_delay: 70s
+          mode: pull
+          name: poddisruptionbudgets
+        - group: rbac.authorization.k8s.io
+          initial_delay: 75s
+          mode: pull
+          name: clusterrolebindings
+        - group: rbac.authorization.k8s.io
+          initial_delay: 80s
+          mode: pull
+          name: clusterroles
+        - group: rbac.authorization.k8s.io
+          initial_delay: 85s
+          mode: pull
+          name: rolebindings
+        - group: rbac.authorization.k8s.io
+          initial_delay: 90s
+          mode: pull
+          name: roles
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: ""
+          mode: watch
+          name: namespaces
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: ""
+          mode: watch
+          name: nodes
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: ""
+          mode: watch
+          name: persistentvolumeclaims
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: ""
+          mode: watch
+          name: persistentvolumes
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: ""
+          mode: watch
+          name: pods
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: apps
+          mode: watch
+          name: daemonsets
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: apps
+          mode: watch
+          name: deployments
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: apps
+          mode: watch
+          name: replicasets
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: apps
+          mode: watch
+          name: statefulsets
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: autoscaling
+          mode: watch
+          name: horizontalpodautoscalers
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: batch
+          mode: watch
+          name: cronjobs
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: batch
+          mode: watch
+          name: jobs
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: extensions
+          mode: watch
+          name: ingresses
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: networking.k8s.io
+          mode: watch
+          name: ingresses
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: policy
+          mode: watch
+          name: poddisruptionbudgets
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: rbac.authorization.k8s.io
+          mode: watch
+          name: clusterrolebindings
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: rbac.authorization.k8s.io
+          mode: watch
+          name: clusterroles
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: rbac.authorization.k8s.io
+          mode: watch
+          name: rolebindings
+        - exclude_watch_type:
+          - BOOKMARK
+          - ERROR
+          group: rbac.authorization.k8s.io
+          mode: watch
+          name: roles
+      otlp:
+        protocols:
+          grpc:
+            endpoint: ${env:MY_POD_IP}:4317
+            max_recv_msg_size_mib: 20
+          http:
+            endpoint: ${env:MY_POD_IP}:4318
+      prometheus:
+        config:
+          scrape_configs:
+          - job_name: opentelemetry-collector
+            scrape_interval: '30s'
+            static_configs:
+            - targets:
+              - ${env:MY_POD_IP}:8888
+      prometheus/k8s_apiserver_metrics:
+        config:
+          scrape_configs:
+          - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            honor_timestamps: true
+            job_name: kubernetes-apiserver
+            kubernetes_sd_configs:
+            - role: endpoints
+            relabel_configs:
+            - action: keep
+              regex: default;kubernetes;https
+              source_labels:
+              - __meta_kubernetes_namespace
+              - __meta_kubernetes_service_name
+              - __meta_kubernetes_endpoint_port_name
+            scheme: https
+            tls_config:
+              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              insecure_skip_verify: true
+    service:
+      extensions:
+      - health_check
+      - k8s_observer
+      - opamp
+      - zpages
+      - pprof
+      pipelines:
+        logs:
+          exporters:
+          - coralogix
+          processors:
+          - memory_limiter
+          - resource/metadata
+          - resource/kube-events
+          - resourcedetection/region
+          - resourcedetection/env
+          - k8sattributes
+          - transform/kube-events
+          - batch
+          receivers:
+          - k8sobjects
+          - otlp
+        logs/resource_catalog:
+          exporters:
+          - coralogix/resource_catalog
+          processors:
+          - memory_limiter
+          - resourcedetection/resource_catalog
+          - transform/entity-event
+          - filter/workflow
+          - resource/metadata
+          - batch
+          receivers:
+          - k8sobjects/resource_catalog
+        metrics:
+          exporters:
+          - coralogix
+          processors:
+          - memory_limiter
+          - resource/metadata
+          - resourcedetection/region
+          - resourcedetection/env
+          - k8sattributes
+          - metricstransform/k8s-dashboard
+          - transform/k8s-dashboard
+          - filter/k8s_apiserver_metrics
+          - transform/prometheus
+          - batch
+          receivers:
+          - k8s_cluster
+          - prometheus/k8s_apiserver_metrics
+          - prometheus
+          - otlp
+        traces:
+          exporters:
+          - debug
+          - coralogix
+          processors:
+          - memory_limiter
+          - resource/metadata
+          - resourcedetection/region
+          - resourcedetection/env
+          - k8sattributes
+          - batch
+          receivers:
+          - otlp
+      telemetry:
+        logs:
+          encoding: json
+          level: 'info'
+        metrics:
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: ${env:MY_POD_IP}
+                  port: 8888
+                  without_scope_info: false
+                  without_type_suffix: false
+                  without_units: false
+        resource:
+          cx.agent.type: cluster-collector
+          service.name: opentelemetry-collector
+---
+# Source: otel-integration/charts/opentelemetry-ebpf-profiler/templates/configmap-agent.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coralogix-opentelemetry-ebpf-profiler-agent
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-ebpf-profiler-0.136.4
+    app.kubernetes.io/name: opentelemetry-ebpf-profiler
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.156.0"
+    app.kubernetes.io/managed-by: Helm
+data:
+  relay: |
+    exporters:
+      debug: {}
+      otlp:
+        endpoint: ${env:K8S_NODE_IP}:4317
+        tls:
+          insecure: true
+    extensions:
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
+      opamp:
+        agent_description:
+          include_resource_attributes: true
+          non_identifying_attributes:
+            cx.agent.type: ebpf-profiler
+            cx.cluster.name: 'golden-render'
+            helm.chart.opentelemetry-ebpf-profiler.version: 0.136.4
+        server:
+          http:
+            endpoint: https://ingress.eu2.coralogix.com/opamp/v1
+            headers:
+              Authorization: Bearer ${env:CORALOGIX_PRIVATE_KEY}
+            polling_interval: 2m
+    processors:
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
+      resource/metadata:
+        attributes:
+        - action: upsert
+          key: k8s.cluster.name
+          value: 'golden-render'
+        - action: upsert
+          key: cx.otel_integration.name
+          value: coralogix-integration-helm
+      resourcedetection/env:
+        detectors:
+        - system
+        - env
+        override: false
+        system:
+          resource_attributes:
+            host.id:
+              enabled: true
+        timeout: 2s
+      resourcedetection/region:
+        detectors:
+        - gcp
+        - ec2
+        - azure
+        - eks
+        eks:
+          node_from_env_var: K8S_NODE_NAME
+        override: true
+        timeout: 2s
+    receivers:
+      profiling:
+        off_cpu_threshold: 0
+        probabilistic_interval: 1m
+        probabilistic_threshold: 100
+        reporter_interval: 5s
+        samples_per_second: 20
+        verbose_mode: false
+    service:
+      extensions:
+      - health_check
+      - opamp
+      pipelines:
+        profiles:
+          exporters:
+          - otlp
+          processors:
+          - memory_limiter
+          - resourcedetection/region
+          - resourcedetection/env
+          receivers:
+          - profiling
+      telemetry:
+        logs:
+          encoding: json
+          level: 'info'
+        metrics:
+          readers:
+          - pull:
+              exporter:
+                prometheus:
+                  host: ${env:MY_POD_IP}
+                  port: 8888
+                  without_scope_info: false
+                  without_type_suffix: false
+                  without_units: false
+        resource:
+          cx.agent.type: ebpf-profiler
+          service.name: opentelemetry-collector
+---
+# Source: otel-integration/charts/opentelemetry-agent/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: coralogix-opentelemetry-agent
+  labels:
+    helm.sh/chart: opentelemetry-agent-0.136.4
+    app.kubernetes.io/name: opentelemetry-agent
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.156.0"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "namespaces"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes", "nodes/stats", "nodes/metrics"]
+    verbs: ["get", "watch", "list"]
+  - nonResourceURLs:
+    - "/metrics"
+    verbs: ["get"]
+---
+# Source: otel-integration/charts/opentelemetry-cluster-collector/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: coralogix-opentelemetry-collector
+  labels:
+    helm.sh/chart: opentelemetry-cluster-collector-0.136.4
+    app.kubernetes.io/name: opentelemetry-cluster-collector
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.156.0"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "namespaces"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events", "namespaces", "namespaces/status", "nodes", "nodes/spec", "pods", "pods/status", "replicationcontrollers", "replicationcontrollers/status", "resourcequotas", "services" ]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources: ["daemonsets", "deployments", "replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods", "endpoints", "nodes/stats", "nodes/metrics", "nodes", "services"]
+    verbs: ["get", "watch", "list"]
+  - nonResourceURLs:
+    - "/metrics"
+    verbs: ["get"]
+  - apiGroups: ["events.k8s.io"]
+    resources: ["events"]
+    verbs: ["watch", "list"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["aws-auth"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources:
+    - namespaces
+    - nodes
+    - persistentvolumeclaims
+    - persistentvolumes
+    - pods
+    - services
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources:
+    - daemonsets
+    - deployments
+    - replicasets
+    - statefulsets
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["autoscaling"]
+    resources:
+    - horizontalpodautoscalers
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources:
+    - cronjobs
+    - jobs
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources:
+    - ingresses
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+    - ingresses
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["policy"]
+    resources:
+    - poddisruptionbudgets
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources:
+    - clusterrolebindings
+    - clusterroles
+    - rolebindings
+    - roles
+    verbs: ["get", "list", "watch"]
+---
+# Source: otel-integration/charts/opentelemetry-agent/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: coralogix-opentelemetry-agent
+  labels:
+    helm.sh/chart: opentelemetry-agent-0.136.4
+    app.kubernetes.io/name: opentelemetry-agent
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.156.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: coralogix-opentelemetry-agent
+subjects:
+- kind: ServiceAccount
+  name: coralogix-opentelemetry
+  namespace: default
+---
+# Source: otel-integration/charts/opentelemetry-cluster-collector/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: coralogix-opentelemetry-collector
+  labels:
+    helm.sh/chart: opentelemetry-cluster-collector-0.136.4
+    app.kubernetes.io/name: opentelemetry-cluster-collector
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.156.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: coralogix-opentelemetry-collector
+subjects:
+- kind: ServiceAccount
+  name: coralogix-opentelemetry-collector
+  namespace: default
+---
+# Source: otel-integration/charts/opentelemetry-cluster-collector/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: coralogix-opentelemetry-collector
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-cluster-collector-0.136.4
+    app.kubernetes.io/name: opentelemetry-cluster-collector
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.156.0"
+    app.kubernetes.io/managed-by: Helm
+    component: standalone-collector
+spec:
+  type: ClusterIP
+  ports:
+
+    - name: otlp
+      port: 4317
+      targetPort: 4317
+      protocol: TCP
+      appProtocol: grpc
+  selector:
+    app.kubernetes.io/name: opentelemetry-cluster-collector
+    app.kubernetes.io/instance: render-check
+    component: standalone-collector
+  internalTrafficPolicy: Cluster
+---
+# Source: otel-integration/charts/opentelemetry-agent/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: coralogix-opentelemetry-agent
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-agent-0.136.4
+    app.kubernetes.io/name: opentelemetry-agent
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.156.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opentelemetry-agent
+      app.kubernetes.io/instance: render-check
+      component: agent-collector
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: 9b8ba6144744118ac36e9492c1bb61566ae0fc2d39fce5257d8c116ad98693fc
+
+      labels:
+        app.kubernetes.io/name: opentelemetry-agent
+        app.kubernetes.io/instance: render-check
+        component: agent-collector
+
+    spec:
+
+      serviceAccountName: coralogix-opentelemetry
+      securityContext:
+        {}
+      containers:
+        - name: opentelemetry-agent
+          command:
+            - /otelcol-contrib
+            - --config=/conf/relay.yaml
+            - --feature-gates=+service.profilesSupport
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+          image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.156.0"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: jaeger-binary
+              containerPort: 6832
+              protocol: TCP
+              hostPort: 6832
+            - name: jaeger-compact
+              containerPort: 6831
+              protocol: UDP
+              hostPort: 6831
+            - name: jaeger-grpc
+              containerPort: 14250
+              protocol: TCP
+              hostPort: 14250
+            - name: jaeger-thrift
+              containerPort: 14268
+              protocol: TCP
+              hostPort: 14268
+            - name: otlp
+              containerPort: 4317
+              protocol: TCP
+              hostPort: 4317
+            - name: otlp-http
+              containerPort: 4318
+              protocol: TCP
+              hostPort: 4318
+            - name: statsd
+              containerPort: 8125
+              protocol: UDP
+              hostPort: 8125
+            - name: zipkin
+              containerPort: 9411
+              protocol: TCP
+              hostPort: 9411
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: KUBE_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+            - name: GOMEMLIMIT
+              value: "1525MiB"
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "k8s.node.name=$(K8S_NODE_NAME),deployment.environment.name=golden-render"
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: CORALOGIX_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: PRIVATE_KEY
+                  name: coralogix-keys
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          resources:
+            limits:
+              cpu: 1
+              memory: 2G
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          volumeMounts:
+            - mountPath: /conf
+              name: opentelemetry-agent-configmap
+            - name: varlogpods
+              mountPath: /var/log/pods
+              readOnly: true
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+            - name: varlibotelcol
+              mountPath: /var/lib/otelcol
+            - name: hostfs
+              mountPath: /hostfs
+              readOnly: true
+              mountPropagation: HostToContainer
+            - mountPath: /etc/machine-id
+              mountPropagation: HostToContainer
+              name: etcmachineid
+              readOnly: true
+            - mountPath: /var/lib/dbus/machine-id
+              mountPropagation: HostToContainer
+              name: varlibdbusmachineid
+              readOnly: true
+      volumes:
+        - name: opentelemetry-agent-configmap
+          configMap:
+            name: coralogix-opentelemetry-agent
+            items:
+              - key: relay
+                path: relay.yaml
+        - name: varlogpods
+          hostPath:
+            path: /var/log/pods
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+        - name: varlibotelcol
+          hostPath:
+            path: /var/lib/otelcol
+            type: DirectoryOrCreate
+        - name: hostfs
+          hostPath:
+            path: /
+        - name: etcmachineid
+          hostPath:
+            path: /etc/machine-id
+        - name: varlibdbusmachineid
+          hostPath:
+            path: /var/lib/dbus/machine-id
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - operator: Exists
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+---
+# Source: otel-integration/charts/opentelemetry-ebpf-profiler/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: coralogix-opentelemetry-ebpf-profiler-agent
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-ebpf-profiler-0.136.4
+    app.kubernetes.io/name: opentelemetry-ebpf-profiler
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.156.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opentelemetry-ebpf-profiler
+      app.kubernetes.io/instance: render-check
+      component: agent-collector
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: f26d1ca2f81f1c8c1a74dc2cada3b40736d86c3c2d1e2f7564bd7bd1a2228a0e
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8888"
+        prometheus.io/scrape: "true"
+      labels:
+        app.kubernetes.io/name: opentelemetry-ebpf-profiler
+        app.kubernetes.io/instance: render-check
+        component: agent-collector
+
+    spec:
+
+      serviceAccountName: coralogix-opentelemetry-ebpf-profiler
+      securityContext:
+        {}
+      containers:
+        - name: opentelemetry-ebpf-profiler
+          command:
+            - /otelcol-ebpf-profiler
+            - --config=/conf/relay.yaml
+            - --feature-gates=+service.profilesSupport
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+            privileged: true
+          image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-ebpf-profiler:0.156.0"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: metrics
+              containerPort: 8888
+              protocol: TCP
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: K8S_NODE_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "k8s.node.name=$(K8S_NODE_NAME),deployment.environment.name=golden-render"
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: CORALOGIX_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: PRIVATE_KEY
+                  name: coralogix-keys
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          volumeMounts:
+            - mountPath: /conf
+              name: opentelemetry-ebpf-profiler-configmap
+            - name: lsb-release
+              mountPath: /etc/lsb-release.host
+              readOnly: false
+            - name: os-release
+              mountPath: /etc/os-release.host
+              readOnly: false
+            - name: modules-dir
+              mountPath: /lib/modules
+              readOnly: false
+            - name: modules-host
+              mountPath: /lib/modules.host
+              readOnly: false
+            - name: linux-headers-generated
+              mountPath: /usr/src/
+              readOnly: false
+            - name: boot-host
+              mountPath: /boot.host
+              readOnly: false
+            - name: debug
+              mountPath: /sys/kernel/debug
+              readOnly: false
+            - mountPath: /etc/machine-id
+              mountPropagation: HostToContainer
+              name: etcmachineid
+              readOnly: true
+            - mountPath: /var/lib/dbus/machine-id
+              mountPropagation: HostToContainer
+              name: varlibdbusmachineid
+              readOnly: true
+      volumes:
+        - name: opentelemetry-ebpf-profiler-configmap
+          configMap:
+            name: coralogix-opentelemetry-ebpf-profiler-agent
+            items:
+              - key: relay
+                path: relay.yaml
+        - name: lsb-release
+          hostPath:
+            path: /etc/lsb-release
+        - name: os-release
+          hostPath:
+            path: /etc/os-release
+        - name: modules-dir
+          hostPath:
+            path: /var/cache/linux-headers/modules_dir
+        - name: linux-headers-generated
+          hostPath:
+            path: /var/cache/linux-headers/generated
+        - name: boot-host
+          hostPath:
+            path: /
+        - name: modules-host
+          hostPath:
+            path: /lib/modules
+        - name: debug
+          hostPath:
+            path: /sys/kernel/debug
+        - name: etcmachineid
+          hostPath:
+            path: /etc/machine-id
+        - name: varlibdbusmachineid
+          hostPath:
+            path: /var/lib/dbus/machine-id
+      nodeSelector:
+        kubernetes.io/os: linux
+      hostNetwork: false
+      hostPID: true
+---
+# Source: otel-integration/charts/opentelemetry-cluster-collector/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coralogix-opentelemetry-collector
+  namespace: default
+  labels:
+    helm.sh/chart: opentelemetry-cluster-collector-0.136.4
+    app.kubernetes.io/name: opentelemetry-cluster-collector
+    app.kubernetes.io/instance: render-check
+    app.kubernetes.io/version: "0.156.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opentelemetry-cluster-collector
+      app.kubernetes.io/instance: render-check
+      component: standalone-collector
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/config: 8d1d479ae4c1a8894b66a6b6eb74abcc64b22a7a19b719c31d9a560c8063bdc9
+
+      labels:
+        app.kubernetes.io/name: opentelemetry-cluster-collector
+        app.kubernetes.io/instance: render-check
+        component: standalone-collector
+
+    spec:
+
+      serviceAccountName: coralogix-opentelemetry-collector
+      securityContext:
+        {}
+      containers:
+        - name: opentelemetry-cluster-collector
+          command:
+            - /otelcol-contrib
+            - --config=/conf/relay.yaml
+          securityContext:
+            {}
+          image: "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.156.0"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: otlp
+              containerPort: 4317
+              protocol: TCP
+          env:
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: GOMEMLIMIT
+              value: "1525MiB"
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "deployment.environment.name=golden-render"
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: CORALOGIX_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: PRIVATE_KEY
+                  name: coralogix-keys
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          startupProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            failureThreshold: 4
+            httpGet:
+              port: 13133
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 13133
+          resources:
+            limits:
+              cpu: 1
+              memory: 2G
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          volumeMounts:
+            - mountPath: /conf
+              name: opentelemetry-cluster-collector-configmap
+            - mountPath: /etc/machine-id
+              mountPropagation: HostToContainer
+              name: etcmachineid
+              readOnly: true
+            - mountPath: /var/lib/dbus/machine-id
+              mountPropagation: HostToContainer
+              name: varlibdbusmachineid
+              readOnly: true
+      volumes:
+        - name: opentelemetry-cluster-collector-configmap
+          configMap:
+            name: coralogix-opentelemetry-collector
+            items:
+              - key: relay
+                path: relay.yaml
+        - name: etcmachineid
+          hostPath:
+            path: /etc/machine-id
+        - name: varlibdbusmachineid
+          hostPath:
+            path: /var/lib/dbus/machine-id
+      nodeSelector:
+        kubernetes.io/os: linux
+      hostNetwork: false

--- a/otel-integration/k8s-helm/values-otel-ebpf-profiler.yaml
+++ b/otel-integration/k8s-helm/values-otel-ebpf-profiler.yaml
@@ -1,0 +1,24 @@
+# Profiling via the otelcol-ebpf-profiler distribution (`opentelemetry-ebpf-profiler`
+# sub-chart), i.e. the configuration the Coralogix wizard generates today.
+# The legacy `coralogix-ebpf-profiler` path is covered by values-ebpf-profiler.yaml.
+opentelemetry-agent:
+  enabled: true
+
+opentelemetry-ebpf-profiler:
+  enabled: true
+  presets:
+    otlpExporter:
+      enabled: true
+      endpoint: ${env:K8S_NODE_IP}:4317
+      pipelines:
+        - profiles
+      tls:
+        insecure: true
+    resourceDetection:
+      enabled: true
+    fleetManagement:
+      enabled: true
+      supervisor:
+        enabled: false
+    ebpfProfiler:
+      samplesPerSecond: 20


### PR DESCRIPTION
Closes the test gaps that let the profiler crash ship. The crash itself is fixed upstream in [coralogix/opentelemetry-helm-charts#497](https://github.com/coralogix/opentelemetry-helm-charts/pull/497), which landed here via #988 (opentelemetry-collector 0.136.4, chart 0.0.335) — so this PR is now test coverage only, on top of that.

## Background

Profiling was broken in otel-integration 0.0.333: the chart rendered `tracers: all` on the `profiling` receiver, a key removed from the profiler in v0.156.0, so every profiler pod crash-looped with `'config.Config' has invalid keys: tracers`. 0.0.333 (#984) is where the image moved to 0.156.0.

## Two gaps let it through

1. **The broken path had no golden coverage.** The `ebpf-profiler` case uses `values-ebpf-profiler.yaml`, which enables the legacy `coralogix-ebpf-profiler` sub-chart — not the `opentelemetry-ebpf-profiler` sub-chart the wizard emits and that users actually run.
2. **Golden diffs structurally cannot catch this.** When upstream removes a config key, the rendered YAML stays byte-identical; only the binary's acceptance of it changes. The check was green while every profiler pod was crash-looping.

## Changes

- **New golden case `otel-ebpf-profiler`** built from `values-otel-ebpf-profiler.yaml`, i.e. the wizard configuration from the report (otlpExporter to the node agent, resourceDetection, fleetManagement without supervisor, `samplesPerSecond: 20`). The legacy `ebpf-profiler` case is left in place; it can be dropped when that sub-chart is retired.
- **New `.github/scripts/check-collector-config-validity.sh`**, wired into the `helm-golden-render` job. For every golden render it extracts the collector config from each ConfigMap and, for configs that declare the `profiling` receiver, runs `otelcol validate` against them. Details:
  - It runs inside **the profiler image the chart actually renders** (`ghcr.io/…/opentelemetry-collector-ebpf-profiler:0.156.0`, read out of the golden), so the check follows every dependency bump with no extra maintenance and needs no separate binary download.
  - `validate` unmarshals the config and builds the pipelines — no eBPF probes, no privileges, no cluster. It is the same code path that produced the crash message in production.
  - `${env:…}` references are stubbed, since `validate` resolves them. The config is passed in via `--config=env:…` rather than a bind mount, so it behaves the same in CI and on a laptop whose Docker VM doesn't share `$TMPDIR`.
  - Because pipelines are built for real, the `eks` resource detector constructs a Kubernetes client; a stub service-account token is written inside the container so it can. Nothing reads it and no request is made.
  - The script **fails if no `profiling` config is found** in the goldens, so this coverage cannot silently disappear again.

## Validation

Both checks run clean locally, and the new one was verified in both directions:

- `check-helm-golden-renders.sh` — clean, including the new case.
- `check-collector-config-validity.sh` — `OK otel-ebpf-profiler/…configmap_agent_yaml`.
- Re-inserting `tracers: all` into the golden makes it fail with exactly the production error: `'config.Config' has invalid keys: tracers`.
- `shellcheck` (v0.10.0, as CI pins) clean on both scripts; `helmlog validate` and `make check-docs` clean.
