### PR TITLE
fix: unescape HTML entities in split directives for the new mdox

### DIFF
--- a/otel-installer/standalone/README.md
+++ b/otel-installer/standalone/README.md
@@ -10,7 +10,7 @@ This script deploys the Coralogix OpenTelemetry Collector as:
 
 Both support **local configuration mode** (configuration file provided locally) and **supervisor mode** (remote configuration via Fleet Management).
 
-<!-- split title=&#34;Linux Installation&#34; path=&#34;installation/linux/index.md&#34; -->
+<!-- split title="Linux Installation" path="installation/linux/index.md" -->
 
 # Linux Installation
 
@@ -293,7 +293,7 @@ CORALOGIX_DOMAIN="<your-domain>" CORALOGIX_PRIVATE_KEY="<your-private-key>" \
 
 <!-- /split -->
 
-<!-- split title=&#34;macOS Installation&#34; path=&#34;installation/macos/index.md&#34; -->
+<!-- split title="macOS Installation" path="installation/macos/index.md" -->
 
 # macOS Installation
 

--- a/otel-integration/k8s-helm/README.md
+++ b/otel-integration/k8s-helm/README.md
@@ -1,4 +1,4 @@
-<!-- split path=&#34;kubernetes-observability/kubernetes-observability-using-opentelemetry/index.md&#34; -->
+<!-- split path="kubernetes-observability/kubernetes-observability-using-opentelemetry/index.md" -->
 
 # Kubernetes observability using OpenTelemetry
 
@@ -78,7 +78,7 @@ View our **basic configuration** instructions [here](https://coralogix.com/docs/
 
 <!-- /split -->
 
-<!-- split path=&#34;kubernetes-observability/kubernetes-complete-observability-basic-configuration/index.md&#34; -->
+<!-- split path="kubernetes-observability/kubernetes-complete-observability-basic-configuration/index.md" -->
 
 # Kubernetes Complete Observability: Basic configuration
 
@@ -251,7 +251,7 @@ This is a known validation bug in Helm (see this [issue](https://github.com/helm
 
 <!-- /split -->
 
-<!-- split path=&#34;kubernetes-observability/advanced-configuration/index.md&#34; -->
+<!-- split path="kubernetes-observability/advanced-configuration/index.md" -->
 
 # Kubernetes complete observability: Advanced configuration
 
@@ -1622,7 +1622,7 @@ To enable the Coralogix Operator, set `coralogix-operator.enabled` to `true` in 
 
 <!-- /split -->
 
-<!-- split path=&#34;kubernetes-observability/how-to-use-it/index.md&#34; -->
+<!-- split path="kubernetes-observability/how-to-use-it/index.md" -->
 
 # How to use it
 
@@ -2046,7 +2046,7 @@ Example:
 
 <!-- /split -->
 
-<!-- split path=&#34;kubernetes-observability/troubleshooting/index.md&#34; -->
+<!-- split path="kubernetes-observability/troubleshooting/index.md" -->
 
 # Troubleshooting
 
@@ -2174,7 +2174,7 @@ service:
 
 <!-- /split -->
 
-<!-- split path=&#34;kubernetes-observability/filtering-and-reducing-costs/index.md&#34; -->
+<!-- split path="kubernetes-observability/filtering-and-reducing-costs/index.md" -->
 
 # Filtering and reducing costs
 
@@ -2321,7 +2321,7 @@ processors:
 
 <!-- /split -->
 
-<!-- split path=&#34;kubernetes-observability/performance-of-the-collector/index.md&#34; -->
+<!-- split path="kubernetes-observability/performance-of-the-collector/index.md" -->
 
 # Performance of the Collector
 
@@ -2347,7 +2347,7 @@ tracerProvider.addSpanProcessor(new BatchSpanProcessor(exporter));
 
 <!-- /split -->
 
-<!-- split path=&#34;kubernetes-observability/infrastructure-monitoring/index.md&#34; -->
+<!-- split path="kubernetes-observability/infrastructure-monitoring/index.md" -->
 
 # Infrastructure monitoring
 
@@ -2385,7 +2385,7 @@ This configuration is filtering out any event that has the field `reason` with o
 
 <!-- /split -->
 
-<!-- split path=&#34;kubernetes-observability/integration-presets/index.md&#34; -->
+<!-- split path="kubernetes-observability/integration-presets/index.md" -->
 
 # Integration presets
 
@@ -2481,7 +2481,7 @@ Optional settings:
 
 <!-- /split -->
 
-<!-- split path=&#34;kubernetes-observability/dependencies/index.md&#34; -->
+<!-- split path="kubernetes-observability/dependencies/index.md" -->
 
 # Dependencies
 


### PR DESCRIPTION
`Check Documentation formatting and links` is failing on **every open PR**, including ones that touch no markdown at all. This unblocks them.

### Cause

#992 (*security: fix Dependabot CVEs in Go module dependencies*) bumped mdox's transitive dependencies in `.github/tools/go.mod`. The resulting mdox build no longer escapes quotes inside raw HTML comments, so it now wants

```
<!-- split title="Linux Installation" path="installation/linux/index.md" -->
```

where these two READMEs carry `&#34;`. The README content did not change — only the toolchain that lints it.

Timeline: the docs job passed on every run up to 07:07 UTC on 11 Aug; #992's own branch failed this check at 10:11 and was merged at 11:45; every PR run since has failed. Since `pull_request` checks run against the merge commit, all open PRs inherited it immediately.

### Reproduction

Same repo content, same files, only the dependency set differs:

| mdox built from | Result |
|---|---|
| `.github/tools/go.mod` @ `90c0ded` (pre-#992) | exit 0 |
| `.github/tools/go.mod` @ `45c0344` (post-#992) | exit 1 — the `&#34;` diff CI reports |

Pinning `yuin/goldmark` back on its own does **not** fix it, so this isn't a one-line dependency revert — the behaviour comes from the wider bump (the modfile also moved `go 1.19` → `go 1.26.0`).

### The change

The two affected files repo-wide, rewritten with the formatter's own output. 12 lines, entity unescaping only, no prose or structural edits.

### Why this is safe for the docs pipeline

These directives are consumed by `scripts/sync-external-repos.py` in `coralogix/documentation`, which accepts both forms and strips either:

```python
attr_pattern = r'(\w+)=(".*?"|&#34;.*?&#34;|[^"\s]+)'
a_val = a_val.strip('"').replace('&#34;', '')
```

Both spellings parse to identical attributes — verified against that regex, not assumed.

### Caveat

This pins the repo to the post-#992 toolchain. The previous mdox build wanted the escaped form, so reverting those tooling dependencies would require reverting this commit too.

### Verified

- New mdox (post-#992 deps), repo-wide over all tracked `.md`: passes.
- Downstream regex simulated against both spellings: identical output.
- Old mdox flags exactly these two files in the inverse direction, confirming the two toolchains disagree only here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)