### PR TITLE
feat(otel-integration): default resources for OBI eBPF instrumentation

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### v0.0.337 / 2026-08-18
 
-- [Feat] Set default resource requests and a memory limit for the eBPF instrumentation (OBI) DaemonSet (requests 100m CPU / 256Mi, limit 2Gi) and requests for its k8s cache Deployment (10m CPU / 64Mi). Previously both ran in BestEffort QoS with no bound on memory growth. Values derived from measured per-node usage; no CPU limit is set, as throttling OBI's ring buffer drain drops events.
+- [Feat] Set default resource requests and a memory limit for the eBPF instrumentation (OBI) DaemonSet (requests 100m CPU / 512Mi, limit 2Gi) and requests for its k8s cache Deployment (10m CPU / 64Mi). Previously both ran in BestEffort QoS with no bound on memory growth. Values derived from measured per-node usage; no CPU limit is set, as throttling OBI's ring buffer drain drops events.
 
 ### v0.0.336 / 2026-08-12
 

--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemetry-Integration
 
+### v0.0.337 / 2026-08-18
+
+- [Feat] Set default resource requests and a memory limit for the eBPF instrumentation (OBI) DaemonSet (requests 100m CPU / 256Mi, limit 2Gi) and requests for its k8s cache Deployment (10m CPU / 64Mi). Previously both ran in BestEffort QoS with no bound on memory growth. Values derived from measured per-node usage; no CPU limit is set, as throttling OBI's ring buffer drain drops events.
+
 ### v0.0.336 / 2026-08-12
 
 - [Chore] Bump chart dependency to opentelemetry-collector 0.136.5

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.336
+version: 0.0.337
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/tests/golden/ebpf-profiler.yaml
+++ b/otel-integration/k8s-helm/tests/golden/ebpf-profiler.yaml
@@ -188,14 +188,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -217,13 +217,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:
@@ -1073,14 +1073,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -1102,13 +1102,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:
@@ -2063,7 +2063,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7af2f5d7b9438f7a4e1e5db2b60ab87d54842ac419e9daa3299829f09fd17ffb
+        checksum/config: 85469233e02ed024bbbdaf0ea7e52dd4419d98138525334c1167424462661ec1
 
       labels:
         app.kubernetes.io/name: opentelemetry-agent
@@ -2249,7 +2249,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e51ae370e66ca60d199af62fff1a84f6dac47dd40cc599a3e86f1dcc1c368e33
+        checksum/config: a1dc1bfc551cc22ec6e811d85c385334a5915586472a26292d59f90daa5693b1
 
       labels:
         app.kubernetes.io/name: opentelemetry-cluster-collector

--- a/otel-integration/k8s-helm/tests/golden/eks-fargate.yaml
+++ b/otel-integration/k8s-helm/tests/golden/eks-fargate.yaml
@@ -54,14 +54,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -86,7 +86,7 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
       debug: {}
     extensions:
       health_check:
@@ -347,14 +347,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -379,7 +379,7 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
       debug: {}
     extensions:
       health_check:
@@ -835,7 +835,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4dcc566c83660e5a35d5c626692ea2b4012292807662c99eddc67e0065966f78
+        checksum/config: dc6478f52ad81c2ec6c8ce566608b47d6f0be9034140809d53d4c21347501346
 
       labels:
         app.kubernetes.io/name: opentelemetry-agent-eks-fargate-monitoring
@@ -949,7 +949,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cda120361ff2dcf07679c2f0b03398147f3558062f107d1296a0ca98d2bb279a
+        checksum/config: 317457e73bc193f67dae25232a22c3197e8c2b4edc8251b96933779cd036e768
 
       labels:
         app.kubernetes.io/name: opentelemetry-agent-eks-fargate

--- a/otel-integration/k8s-helm/tests/golden/tail-sampling.yaml
+++ b/otel-integration/k8s-helm/tests/golden/tail-sampling.yaml
@@ -192,14 +192,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -221,13 +221,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:
@@ -1074,14 +1074,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -1103,13 +1103,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:
@@ -1782,14 +1782,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -1811,7 +1811,7 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
       debug: {}
     extensions:
       health_check:
@@ -2263,7 +2263,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 0c232b20a9ae0a31e62bd393fe1150b5b10c84c587f1950a3db50ded8361039b
+        checksum/config: 453e7aaf4abade522739ea3747cf3ae5e96c23175ea0f3502290bd1d236535fd
 
       labels:
         app.kubernetes.io/name: opentelemetry-agent
@@ -2449,7 +2449,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 543611ed0eeb6930a6dc25aa3c070bbb41737eadee2a8602d542f7552858895a
+        checksum/config: df823bb1af7bd4c37dfc330f58706f3b6599d8d47ce7c15b74b19f53e385bd9c
 
       labels:
         app.kubernetes.io/name: opentelemetry-cluster-collector
@@ -2572,7 +2572,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7af997ef00a90f599170d69f72199bf582f7857a2fc3bd50b3ad66c8349e67ac
+        checksum/config: ee83b636cac6db8011cc0b9c73277b9fbec632e322c7453063de669997f5ecb2
 
       labels:
         app.kubernetes.io/name: opentelemetry-gateway

--- a/otel-integration/k8s-helm/tests/golden/windows.yaml
+++ b/otel-integration/k8s-helm/tests/golden/windows.yaml
@@ -67,14 +67,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -96,7 +96,7 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
       debug: {}
     extensions:
       file_storage:
@@ -642,14 +642,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -671,13 +671,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:
@@ -1527,14 +1527,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -1556,13 +1556,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.336
+            X-Coralogix-Distribution: helm-otel-integration/0.0.337
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:
@@ -2467,7 +2467,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e0d789c55f65913bcea5e2c873b73ebfac0979a22969f52b961a066de7ac9216
+        checksum/config: 5d656e420a57dbac80f998db296f799d7571d4bfbb8233991923aae518e42f6e
 
       labels:
         app.kubernetes.io/name: opentelemetry-agent-windows
@@ -2641,7 +2641,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 0bc6129e42c2209051abf615f633c1ed90462dbbc01385b34c7db125f4aefa2e
+        checksum/config: a4c99e93ea307e6775baf6b1750f01a36e8b758e91bfe4071396f6b0a4b9c51b
 
       labels:
         app.kubernetes.io/name: opentelemetry-agent
@@ -2828,7 +2828,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 543611ed0eeb6930a6dc25aa3c070bbb41737eadee2a8602d542f7552858895a
+        checksum/config: df823bb1af7bd4c37dfc330f58706f3b6599d8d47ce7c15b74b19f53e385bd9c
 
       labels:
         app.kubernetes.io/name: opentelemetry-cluster-collector

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -1020,8 +1020,26 @@ opentelemetry-ebpf-profiler:
 
 opentelemetry-ebpf-instrumentation:
   enabled: false
+  # Memory scales with the number of processes and TCP connections tracked on
+  # the node, not with cluster size. Derived from measured usage across
+  # Coralogix clusters: p50 566Mi, p90 934Mi, p95 of per-node peak 1.4Gi.
+  # No CPU limit: OBI is event driven off a BPF ring buffer, so throttling
+  # stalls the drain and silently drops events.
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 2Gi
   k8sCache:
     replicas: 2
+    # Small and stable: 12-22Mi typical, 40Mi peak, under 0.02 cores. No memory
+    # limit, as the footprint grows with the number of Kubernetes objects and
+    # has only been measured on small clusters.
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
 #  priorityClass:
 #    create: false
 #    name: ""

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -1020,15 +1020,18 @@ opentelemetry-ebpf-profiler:
 
 opentelemetry-ebpf-instrumentation:
   enabled: false
-  # Memory scales with the number of processes and TCP connections tracked on
-  # the node, not with cluster size. Derived from measured usage across
-  # Coralogix clusters: p50 566Mi, p90 934Mi, p95 of per-node peak 1.4Gi.
+  # OBI preallocates its BPF maps at startup: a measured 338Mi across 204 maps,
+  # charged to the container cgroup on every node whether idle or not. The
+  # request must sit above that floor. Beyond it, memory scales with the number
+  # of processes and TCP connections tracked on the node, not with cluster size.
+  # Measured across Coralogix clusters: p50 566Mi, p90 934Mi, p95 of per-node
+  # peak 1.4Gi.
   # No CPU limit: OBI is event driven off a BPF ring buffer, so throttling
   # stalls the drain and silently drops events.
   resources:
     requests:
       cpu: 100m
-      memory: 256Mi
+      memory: 512Mi
     limits:
       memory: 2Gi
   k8sCache:

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "info"
   collectionInterval: "30s"
-  version: "0.0.336"
+  version: "0.0.337"
   deploymentEnvironmentName: ""
 
   extensions:


### PR DESCRIPTION
## Story number

[CX-54672](https://coralogix.atlassian.net/browse/CX-54672)

# Description

The OBI eBPF instrumentation DaemonSet and its k8s cache Deployment shipped with no resource requests or limits, so a privileged, hostPID, hostNetwork DaemonSet ran in BestEffort QoS on every node with no bound on memory growth. Raised by a customer after a production incident.

| Component | Requests | Limits |
|---|---|---|
| eBPF instrumentation DaemonSet | 100m CPU / 512Mi | 2Gi memory |
| k8s cache Deployment | 10m CPU / 64Mi | none |

## Basis

OBI preallocates its BPF maps at startup. Measured directly from `/proc/<pid>/fdinfo/*` `memlock` on a live node: **338Mi across 204 unique maps**, matching static arithmetic over the compiled map specs (~327Mi). LRU hash maps are always preallocated by the kernel, so this is a hard floor on every node, idle or not, and it is charged to the container cgroup. The request has to sit above it, which is why 512Mi rather than the 128Mi used by sibling components.

Above that floor, memory scales with processes and TCP connections tracked per node, not with cluster size. Measured over 7 days, `container_memory_working_set_By` per pod:

| | Customer staging (~40 nodes, 79 pods) | Demo cluster (single live node) |
|---|---|---|
| Memory p50 | 566Mi | 1876Mi |
| Memory p90 | 934Mi | 4747Mi |
| Memory p95 of peak | 1397Mi | 6354Mi |
| Memory peak | 2560Mi | 6481Mi |
| CPU p50 | 0.051 | 0.108 |
| CPU p95 of peak | 0.639 | 0.232 |

k8s cache is small and stable: 12-22Mi typical, 40Mi peak, under 0.02 cores, and does not load BPF maps.

At a 2Gi limit, 4 of 79 pods on the customer cluster peaked above it over the window. 1.5Gi OOMKills the same 4, 1Gi would hit 17, and only 3Gi reaches zero. 2Gi matches the limit already used by `opentelemetry-agent`, `opentelemetry-cluster-collector` and `coralogix-ebpf-profiler`.

The demo cluster figures are inflated by a separate, now-diagnosed OBI defect (Prometheus metric children are only expired on scrape, and nothing scrapes that endpoint) plus a cluster-local config that puts ephemeral ports into TCP stat labels. They are shown for completeness; the customer staging cluster is the basis for these values.

## No CPU limit

Siblings set `cpu: 1`. OBI does not get one: it is event driven off a BPF ring buffer, so CPU throttling stalls the drain and silently drops events. The sampling based profiler degrades gracefully under a cap; OBI does not.

## No memory limit on k8s cache

Its footprint scales with the number of Kubernetes objects in the cluster and has only been measured on clusters of roughly 40 nodes. Requests are set so it leaves BestEffort; a limit can follow once there is data from a large cluster.

## Why here and not in the chart

Every chart in the helm-charts repo ships `resources: {}`, including `opentelemetry-collector` and `opentelemetry-ebpf-profiler`. Coralogix defaults are set in otel-integration. Placing them here also keeps the helm-charts fork from diverging further from upstream.

# How Has This Been Tested?

- `helm template` on otel-integration with `opentelemetry-ebpf-instrumentation.enabled=true` renders the expected requests and limits on both the DaemonSet and the k8s cache Deployment.
- `go test ./...` passes. Golden files are unaffected, since OBI is `enabled: false` by default and does not render into them.

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)


[CX-54672]: https://coralogix.atlassian.net/browse/CX-54672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ