### PR TITLE
fix: guard db.namespace fallback transforms on db.system

### DIFF
--- a/otel-ecs-ec2-windows/values.yaml
+++ b/otel-ecs-ec2-windows/values.yaml
@@ -102,9 +102,9 @@ opentelemetry-agent:
 
     #   transformStatements:
     #     - set(attributes["db.namespace"], attributes["db.name"]) where attributes["db.namespace"] == nil
-    #     - set(attributes["db.namespace"], attributes["server.address"]) where attributes["db.namespace"] == nil
-    #     - set(attributes["db.namespace"], attributes["network.peer.name"]) where attributes["db.namespace"] == nil
-    #     - set(attributes["db.namespace"], attributes["net.peer.name"]) where attributes["db.namespace"] == nil
+    #     - set(attributes["db.namespace"], attributes["server.address"]) where attributes["db.namespace"] == nil and attributes["db.system"] != nil
+    #     - set(attributes["db.namespace"], attributes["network.peer.name"]) where attributes["db.namespace"] == nil and attributes["db.system"] != nil
+    #     - set(attributes["db.namespace"], attributes["net.peer.name"]) where attributes["db.namespace"] == nil and attributes["db.system"] != nil
     #     - set(attributes["db.namespace"], attributes["db.system"]) where attributes["db.namespace"] == nil
     #     - set(attributes["db.operation.name"], attributes["db.operation"]) where attributes["db.operation.name"] == nil
     #     - set(attributes["db.collection.name"], attributes["db.sql.table"]) where attributes["db.collection.name"] == nil

--- a/otel-ecs-ec2/values.yaml
+++ b/otel-ecs-ec2/values.yaml
@@ -97,9 +97,9 @@ opentelemetry-agent:
 
     #   transformStatements:
     #     - set(attributes["db.namespace"], attributes["db.name"]) where attributes["db.namespace"] == nil
-    #     - set(attributes["db.namespace"], attributes["server.address"]) where attributes["db.namespace"] == nil
-    #     - set(attributes["db.namespace"], attributes["network.peer.name"]) where attributes["db.namespace"] == nil
-    #     - set(attributes["db.namespace"], attributes["net.peer.name"]) where attributes["db.namespace"] == nil
+    #     - set(attributes["db.namespace"], attributes["server.address"]) where attributes["db.namespace"] == nil and attributes["db.system"] != nil
+    #     - set(attributes["db.namespace"], attributes["network.peer.name"]) where attributes["db.namespace"] == nil and attributes["db.system"] != nil
+    #     - set(attributes["db.namespace"], attributes["net.peer.name"]) where attributes["db.namespace"] == nil and attributes["db.system"] != nil
     #     - set(attributes["db.namespace"], attributes["db.system"]) where attributes["db.namespace"] == nil
     #     - set(attributes["db.operation.name"], attributes["db.operation"]) where attributes["db.operation.name"] == nil
     #     - set(attributes["db.collection.name"], attributes["db.sql.table"]) where attributes["db.collection.name"] == nil

--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemetry-Integration
 
+### v0.0.340 / 2026-08-23
+
+- [Fix] Guard the documented `spanMetrics.transformStatements` `db.namespace` fallbacks on `db.system != nil`. The `server.address`, `network.peer.name` and `net.peer.name` fallbacks also matched plain HTTP and gRPC client spans, giving every outgoing call a `db.namespace` equal to its peer host, both as a `duration_ms_*` / `calls_total` label and on the span itself
+
 ### v0.0.339 / 2026-08-23
 
 - [Chore] Bump chart dependency to opentelemetry-ebpf-instrumentation 0.1.23

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.339
+version: 0.0.340
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/README.md
+++ b/otel-integration/k8s-helm/README.md
@@ -1892,14 +1892,16 @@ To do that, you can add the configuration below. It will take care of defining t
 
 > [!IMPORTANT] Correlation might be broken if the transform statements below are applied only at the `dbMetrics` level.
 
+The `server.address`, `network.peer.name` and `net.peer.name` fallbacks are guarded on `db.system != nil`. Without that guard they also fire on plain HTTP and gRPC client spans, which carry those attributes too, giving every outgoing call a `db.namespace` equal to its peer host. Since `db.namespace` is a dimension of the general `spanmetrics` connector, that value becomes a metric label on `duration_ms_*` and `calls_total`, and the spans themselves are rewritten because the processor runs in the `traces` pipeline.
+
 ```yaml
     spanMetrics:
       enabled: true
       transformStatements:
       - set(attributes["db.namespace"], attributes["db.name"]) where attributes["db.namespace"] == nil
-      - set(attributes["db.namespace"], attributes["server.address"]) where attributes["db.namespace"] == nil
-      - set(attributes["db.namespace"], attributes["network.peer.name"]) where attributes["db.namespace"] == nil
-      - set(attributes["db.namespace"], attributes["net.peer.name"]) where attributes["db.namespace"] == nil
+      - set(attributes["db.namespace"], attributes["server.address"]) where attributes["db.namespace"] == nil and attributes["db.system"] != nil
+      - set(attributes["db.namespace"], attributes["network.peer.name"]) where attributes["db.namespace"] == nil and attributes["db.system"] != nil
+      - set(attributes["db.namespace"], attributes["net.peer.name"]) where attributes["db.namespace"] == nil and attributes["db.system"] != nil
       - set(attributes["db.namespace"], attributes["db.system"]) where attributes["db.namespace"] == nil
       - set(attributes["db.operation.name"], attributes["db.operation"]) where attributes["db.operation.name"] == nil
       - set(attributes["db.collection.name"], attributes["db.sql.table"]) where attributes["db.collection.name"] == nil

--- a/otel-integration/k8s-helm/tests/golden/ebpf-profiler.yaml
+++ b/otel-integration/k8s-helm/tests/golden/ebpf-profiler.yaml
@@ -188,14 +188,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -217,13 +217,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:
@@ -1073,14 +1073,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -1102,13 +1102,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:
@@ -2063,7 +2063,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7afc942edc3cf2e8c3a08b24a517b551fd5323ff6006d72e235b890380968fca
+        checksum/config: f02b7131cd489941f72f0ed7897425af94379a4fc4eb152bfe61905682110c2e
 
       labels:
         app.kubernetes.io/name: opentelemetry-agent
@@ -2249,7 +2249,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 73b0e7d47ce61df7ed55334edbfcf5808221edf02ba024ca87694e9733690973
+        checksum/config: e185bed5d4b6152aee1a0004ad5c4d55c57e60a386bf9bdd845a93180a2af8cd
 
       labels:
         app.kubernetes.io/name: opentelemetry-cluster-collector

--- a/otel-integration/k8s-helm/tests/golden/eks-fargate.yaml
+++ b/otel-integration/k8s-helm/tests/golden/eks-fargate.yaml
@@ -54,14 +54,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -86,7 +86,7 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
       debug: {}
     extensions:
       health_check:
@@ -347,14 +347,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -379,7 +379,7 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
       debug: {}
     extensions:
       health_check:
@@ -835,7 +835,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a991326a3312f3319ff8177900a25e3335c56ffccaf920b679e198d0ccdadd72
+        checksum/config: 286217d07c6d9efae7fda25b8cd2134fe0195a867b09eb11726a38131de1c69b
 
       labels:
         app.kubernetes.io/name: opentelemetry-agent-eks-fargate-monitoring
@@ -949,7 +949,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: fd68c468209dde29376d7dc1790a76be7a664385617ee0ea40fe5210aa884670
+        checksum/config: 5eed9ce00a930f1104f27b7f26604fc113106aca8c7f912f86ce9cacec1129fb
 
       labels:
         app.kubernetes.io/name: opentelemetry-agent-eks-fargate

--- a/otel-integration/k8s-helm/tests/golden/tail-sampling.yaml
+++ b/otel-integration/k8s-helm/tests/golden/tail-sampling.yaml
@@ -192,14 +192,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -221,13 +221,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:
@@ -1074,14 +1074,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -1103,13 +1103,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:
@@ -1782,14 +1782,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -1811,7 +1811,7 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
       debug: {}
     extensions:
       health_check:
@@ -2263,7 +2263,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 816a61d165b39b64c5bac8bb724a36a06f848a242153fd2df3d6fd426b0b66fd
+        checksum/config: df061574be173e638d2bfc40ccdfcaa2264dacbd4ebde66596e11fd6d3295ceb
 
       labels:
         app.kubernetes.io/name: opentelemetry-agent
@@ -2449,7 +2449,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5eb757c72a875a363df2e6105ae8817be921e1edad6b1740541110bb43f44396
+        checksum/config: 44cb3fadc5b5b57e500b5e5390b9318efeb496c0ea3b5f3fe32c663f8389a038
 
       labels:
         app.kubernetes.io/name: opentelemetry-cluster-collector
@@ -2572,7 +2572,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b904834f96f67ccf9c811e2d07678edfa2b82333e7b9494fed9256baeae5c485
+        checksum/config: 398740c9334656f5a25cb0a1a0d97531dff70796e7075980f4f70cde150b41b2
 
       labels:
         app.kubernetes.io/name: opentelemetry-gateway

--- a/otel-integration/k8s-helm/tests/golden/windows.yaml
+++ b/otel-integration/k8s-helm/tests/golden/windows.yaml
@@ -67,14 +67,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -96,7 +96,7 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
       debug: {}
     extensions:
       file_storage:
@@ -642,14 +642,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -671,13 +671,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:
@@ -1527,14 +1527,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -1556,13 +1556,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.339
+            X-Coralogix-Distribution: helm-otel-integration/0.0.340
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:
@@ -2467,7 +2467,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 63b4dd00b0d1312602ddb67ea01a0448d0a4f3ae6502d0c8002855be6240a8f8
+        checksum/config: 8e5bef0f7b057709f717a95d978bb3155f4b130829dd9a72c3675f6fcce9569f
 
       labels:
         app.kubernetes.io/name: opentelemetry-agent-windows
@@ -2641,7 +2641,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 3905d3a9de6f7ac9329abbb6faafdabeae0706e561671f30e8b72a1f3df89cbe
+        checksum/config: 47e9b90a8cab40333ca0c3cf1ddf9c6caa7b4cf4c1068e38879d802c5a0858d7
 
       labels:
         app.kubernetes.io/name: opentelemetry-agent
@@ -2828,7 +2828,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5eb757c72a875a363df2e6105ae8817be921e1edad6b1740541110bb43f44396
+        checksum/config: 44cb3fadc5b5b57e500b5e5390b9318efeb496c0ea3b5f3fe32c663f8389a038
 
       labels:
         app.kubernetes.io/name: opentelemetry-cluster-collector

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "info"
   collectionInterval: "30s"
-  version: "0.0.339"
+  version: "0.0.340"
   deploymentEnvironmentName: ""
 
   extensions:
@@ -268,9 +268,9 @@ opentelemetry-agent:
 
     #   transformStatements:
     #     - set(attributes["db.namespace"], attributes["db.name"]) where attributes["db.namespace"] == nil
-    #     - set(attributes["db.namespace"], attributes["server.address"]) where attributes["db.namespace"] == nil
-    #     - set(attributes["db.namespace"], attributes["network.peer.name"]) where attributes["db.namespace"] == nil
-    #     - set(attributes["db.namespace"], attributes["net.peer.name"]) where attributes["db.namespace"] == nil
+    #     - set(attributes["db.namespace"], attributes["server.address"]) where attributes["db.namespace"] == nil and attributes["db.system"] != nil
+    #     - set(attributes["db.namespace"], attributes["network.peer.name"]) where attributes["db.namespace"] == nil and attributes["db.system"] != nil
+    #     - set(attributes["db.namespace"], attributes["net.peer.name"]) where attributes["db.namespace"] == nil and attributes["db.system"] != nil
     #     - set(attributes["db.namespace"], attributes["db.system"]) where attributes["db.namespace"] == nil
     #     - set(attributes["db.operation.name"], attributes["db.operation"]) where attributes["db.operation.name"] == nil
     #     - set(attributes["db.collection.name"], attributes["db.sql.table"]) where attributes["db.collection.name"] == nil


### PR DESCRIPTION
# Description

The documented `spanMetrics.transformStatements` recipe fills `db.namespace` from `server.address`, `network.peer.name` and `net.peer.name` without checking that the span is a database span. Those three attributes are present on every HTTP and gRPC client span, so each outgoing call gets a `db.namespace` equal to its peer host.

`db.namespace` is a dimension of the general `spanmetrics` connector, so the value becomes a label on `duration_ms_*` and `calls_total`. The processor runs in the `traces` pipeline, so the spans themselves are rewritten too.

This adds `and attributes["db.system"] != nil` to those three fallbacks in the README recipe and in the commented examples in the k8s and ECS values files. The `db.name` and `db.system` fallbacks and all `db.collection.name` statements are left alone — their source attributes only exist on database spans.

# How Has This Been Tested?

- `helm lint otel-integration/k8s-helm` passes (0 charts failed).
- All three modified `values.yaml` files parse as YAML.
- `.github/scripts/check-helm-golden-renders.sh` exits 0 after regenerating the goldens for the version bump. The only golden diffs are the `X-Coralogix-Distribution` version string and the resulting `checksum/config` values.
- OTTL `where X == nil and Y != nil` is already used in shipped configs in this repo (`otel-ecs-ec2/examples/otel-config.yaml`), so the grammar is supported by the collector version in use.

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)


[CX-55283]: https://coralogix.atlassian.net/browse/CX-55283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ