### PR TITLE
[otel-installer] Use 30s as config apply timeout for Supervisor

### DIFF
--- a/otel-installer/CHANGELOG.md
+++ b/otel-installer/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the OTel Installer scripts will be documented in this file.
 
+## [0.2.1] - 2026-08-25
+
+### Changed
+- Set the Supervisor configuration apply timeout to 30 seconds in the standalone, Docker, and Windows installers.
+
 ## [0.2.0] - 2026-03-31
 
 ### Changed

--- a/otel-installer/docker/docker-install.sh
+++ b/otel-installer/docker/docker-install.sh
@@ -440,6 +440,7 @@ capabilities:
 agent:
   executable: /otelcol-contrib
   passthrough_logs: true
+  config_apply_timeout: 30s
 
   description:
     non_identifying_attributes:

--- a/otel-installer/standalone/coralogix-otel-collector.sh
+++ b/otel-installer/standalone/coralogix-otel-collector.sh
@@ -1441,6 +1441,7 @@ capabilities:
 agent:
   executable: /usr/local/bin/otelcol-contrib
   passthrough_logs: true
+  config_apply_timeout: 30s
   description:
     non_identifying_attributes:
       service.name: "opentelemetry-collector"

--- a/otel-installer/windows/coralogix-otel-collector.ps1
+++ b/otel-installer/windows/coralogix-otel-collector.ps1
@@ -1146,6 +1146,7 @@ capabilities:
 agent:
   executable: $($BINARY_PATH -replace '\\', '/')
   passthrough_logs: true
+  config_apply_timeout: 30s
   description:
     non_identifying_attributes:
       service.name: "opentelemetry-collector"


### PR DESCRIPTION
# Description

This should make configuration application smoother and with less probability of failing at random if the agents take a little time to start up. In the integration chart this is already the default value.

# How Has This Been Tested?

Local tests ran.

# Checklist:
- [ ] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
