### PR TITLE
chore: bump opentelemetry-ebpf-instrumentation to 0.1.24

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## OpenTelemetry-Integration
 
+### v0.0.342 / 2026-08-25
+
+- [Chore] Bump chart dependency to opentelemetry-ebpf-instrumentation 0.1.24
+
+#### Changes from opentelemetry-ebpf-instrumentation 0.1.24:
+- [Feature] Add a `presets.runtimeMetrics` preset, exporting application runtime metrics (Go memory limits, completed GC cycles, GOMAXPROCS and GOGC; HotSpot JVM heap used/committed/limit; Node.js event loop). It is enabled by default for every language OBI supports, adding the `application_runtime` metrics feature. `presets.runtimeMetrics.languages` narrows it to a list of detected languages, named as OBI names them, by giving every `discovery.instrument` selector a language-scoped copy carrying the feature, so it never widens the set of instrumented processes; a selector that already sets `languages` is left untouched. Note that Node.js runtime metrics are collected by injecting a JavaScript agent into every discovered Node.js process through the Node.js inspector, and that agent writes progress lines to the process' own stdout: `languages: [go, java]` leaves Node.js processes alone, and `nodejs.enabled: false` turns the injector off entirely
+- [Change] The `runtimeMetrics.go.enabled` / `runtimeMetrics.jvm.enabled` values are replaced by `presets.runtimeMetrics`, and runtime metrics are now exported by default. `runtimeMetrics.jvm.samplingInterval` moves to `presets.runtimeMetrics.jvm.samplingInterval`. The previous per-language split was cosmetic: both flags mapped to the single `application_runtime` feature, and the `jvm_runtime_metrics.enabled` key the chart rendered does not exist in the OBI configuration
+- [Feature] Add a `presets.logEnricher` preset, injecting the active trace context into the logs written by the instrumented processes. It is disabled by default; enabling it enriches the workloads selected by `config.data.discovery.instrument`, and `presets.logEnricher.plainText.enabled: false` keeps the enrichment to JSON logs only, leaving plain-text output untouched
+- [Fix] Enabling `stats` no longer drops application metrics. The chart appended `stats` to an empty feature list, rendering `features: [stats]`, which replaced the OBI default of `[application]`
+
 ### v0.0.341 / 2026-08-25
 
 - [Fix] Guard the documented `spanMetrics.transformStatements` `db.namespace` fallbacks on `db.system != nil`. The `server.address`, `network.peer.name` and `net.peer.name` fallbacks also matched plain HTTP and gRPC client spans, giving every outgoing call a `db.namespace` equal to its peer host, both as a `duration_ms_*` / `calls_total` label and on the span itself

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.341
+version: 0.0.342
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -61,7 +61,7 @@ dependencies:
     condition: opentelemetry-ebpf-profiler.enabled
   - name: opentelemetry-ebpf-instrumentation
     alias: opentelemetry-ebpf-instrumentation
-    version: "0.1.23"
+    version: "0.1.24"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts
     condition: opentelemetry-ebpf-instrumentation.enabled
   - name: coralogix-operator

--- a/otel-integration/k8s-helm/tests/golden/ebpf-profiler.yaml
+++ b/otel-integration/k8s-helm/tests/golden/ebpf-profiler.yaml
@@ -188,14 +188,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -217,13 +217,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:
@@ -1073,14 +1073,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -1102,13 +1102,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:
@@ -2063,7 +2063,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a6a980cd8769c6d25ca119c7cde07f9094c130c030421c932d9fee43211c0af2
+        checksum/config: 96714df22467873da02bc797499f0ea2f6e05625602680e2c1bc089045d8726a
 
       labels:
         app.kubernetes.io/name: opentelemetry-agent
@@ -2249,7 +2249,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4d311c7b96e42ac018021f5c6628d55b41a6d38dcf9b2ed76b4cc9e294d57f21
+        checksum/config: 9f2cc503be2722acba1e79fbc48e9ef5ed72a0697e9b6c7a6470ff77136e40b6
 
       labels:
         app.kubernetes.io/name: opentelemetry-cluster-collector

--- a/otel-integration/k8s-helm/tests/golden/eks-fargate.yaml
+++ b/otel-integration/k8s-helm/tests/golden/eks-fargate.yaml
@@ -54,14 +54,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -86,7 +86,7 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
       debug: {}
     extensions:
       health_check:
@@ -347,14 +347,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -379,7 +379,7 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
       debug: {}
     extensions:
       health_check:
@@ -835,7 +835,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ca768677b37b104e793f609a3d5e1d582ecd2bec9b353e8ab5ce1186a293a4eb
+        checksum/config: 86e973a4fcb65c5638684a89f9226373616c3ee1855da6a1d79b333d229bd56d
 
       labels:
         app.kubernetes.io/name: opentelemetry-agent-eks-fargate-monitoring
@@ -949,7 +949,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 87fa73f6295aff5e814fb1f824753db28faf0af4bc28475a53b3c1be3a0b1772
+        checksum/config: 4e0008692b0d2dc9eb034d13ae2ab5274d3bbd16421d4f26805a971fc062ea23
 
       labels:
         app.kubernetes.io/name: opentelemetry-agent-eks-fargate

--- a/otel-integration/k8s-helm/tests/golden/tail-sampling.yaml
+++ b/otel-integration/k8s-helm/tests/golden/tail-sampling.yaml
@@ -192,14 +192,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -221,13 +221,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:
@@ -1074,14 +1074,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -1103,13 +1103,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:
@@ -1782,14 +1782,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -1811,7 +1811,7 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
       debug: {}
     extensions:
       health_check:
@@ -2263,7 +2263,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 64eb90f7d79012033bedd5ed836020acd7135f2f6685aec7663b592c3d58dd42
+        checksum/config: 7f462d420c1b05f622b63caf9f3e3498f98adc4129a5d72d1c572816dc0a766b
 
       labels:
         app.kubernetes.io/name: opentelemetry-agent
@@ -2449,7 +2449,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6e1e8ba2fb9502bda1b59910af647ef156ed73c14de61e5165b8c932fded76c0
+        checksum/config: 6da276714bee2a3fc4c351ee0aab832da1ff7b0f5bf076639059d284b0e9c5f8
 
       labels:
         app.kubernetes.io/name: opentelemetry-cluster-collector
@@ -2572,7 +2572,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 73c46b18e51f5cc66543056f4e71f1ae259c29fac60519c6d67bba1df4880007
+        checksum/config: 784124ebb0825aa16651317f371a3c026b5ceb51047623d8d05983e866e5fa0c
 
       labels:
         app.kubernetes.io/name: opentelemetry-gateway

--- a/otel-integration/k8s-helm/tests/golden/windows.yaml
+++ b/otel-integration/k8s-helm/tests/golden/windows.yaml
@@ -67,14 +67,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -96,7 +96,7 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
       debug: {}
     extensions:
       file_storage:
@@ -642,14 +642,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -671,13 +671,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:
@@ -1527,14 +1527,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -1556,13 +1556,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.341
+            X-Coralogix-Distribution: helm-otel-integration/0.0.342
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:
@@ -2467,7 +2467,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: efc59120e124ab93e0384e605fbc6b2c3adb0b011d60b6d019bb38b966f54e9e
+        checksum/config: 1e1560aec2886c72157e3cd243638e3381e7ee900294911195f713928d013756
 
       labels:
         app.kubernetes.io/name: opentelemetry-agent-windows
@@ -2641,7 +2641,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f96fe7291ab16047636b95cfb2a69050a35c2a6bd4f316042d345ca639acd861
+        checksum/config: b806e3990e556950b850d065885ed1f2695adba94ed296eb27aa6205814f678f
 
       labels:
         app.kubernetes.io/name: opentelemetry-agent
@@ -2828,7 +2828,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6e1e8ba2fb9502bda1b59910af647ef156ed73c14de61e5165b8c932fded76c0
+        checksum/config: 6da276714bee2a3fc4c351ee0aab832da1ff7b0f5bf076639059d284b0e9c5f8
 
       labels:
         app.kubernetes.io/name: opentelemetry-cluster-collector

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "info"
   collectionInterval: "30s"
-  version: "0.0.341"
+  version: "0.0.342"
   deploymentEnvironmentName: ""
 
   extensions:


### PR DESCRIPTION
Bumps the `opentelemetry-ebpf-instrumentation` chart dependency of otel-integration to `0.1.24`, and the chart itself to `0.0.342`.

Same content as the automated #1006, re-created with a signed, human-authored commit so `license/cla` passes, and rebased onto current master so it merges cleanly — #1006 was cut before #1003 landed, and both claimed chart version `0.0.341`.

Produced with `scripts/bump-otel-collector-version.sh`; the golden renders were regenerated and verified with `.github/scripts/check-helm-golden-renders.sh`.

#### Changes from opentelemetry-ebpf-instrumentation 0.1.24:
- [Feature] Add a `presets.runtimeMetrics` preset, exporting application runtime metrics (Go memory limits, completed GC cycles, GOMAXPROCS and GOGC; HotSpot JVM heap used/committed/limit; Node.js event loop). It is enabled by default for every language OBI supports, adding the `application_runtime` metrics feature. `presets.runtimeMetrics.languages` narrows it to a list of detected languages, named as OBI names them, by giving every `discovery.instrument` selector a language-scoped copy carrying the feature, so it never widens the set of instrumented processes; a selector that already sets `languages` is left untouched. Note that Node.js runtime metrics are collected by injecting a JavaScript agent into every discovered Node.js process through the Node.js inspector, and that agent writes progress lines to the process' own stdout: `languages: [go, java]` leaves Node.js processes alone, and `nodejs.enabled: false` turns the injector off entirely
- [Change] The `runtimeMetrics.go.enabled` / `runtimeMetrics.jvm.enabled` values are replaced by `presets.runtimeMetrics`, and runtime metrics are now exported by default. `runtimeMetrics.jvm.samplingInterval` moves to `presets.runtimeMetrics.jvm.samplingInterval`. The previous per-language split was cosmetic: both flags mapped to the single `application_runtime` feature, and the `jvm_runtime_metrics.enabled` key the chart rendered does not exist in the OBI configuration
- [Feature] Add a `presets.logEnricher` preset, injecting the active trace context into the logs written by the instrumented processes. It is disabled by default; enabling it enriches the workloads selected by `config.data.discovery.instrument`, and `presets.logEnricher.plainText.enabled: false` keeps the enrichment to JSON logs only, leaving plain-text output untouched
- [Fix] Enabling `stats` no longer drops application metrics. The chart appended `stats` to an empty feature list, rendering `features: [stats]`, which replaced the OBI default of `[application]`

**Source:** https://github.com/coralogix/opentelemetry-helm-charts/pull/512
