### PR TITLE
[otel-ecs-supervisor] Use 30s as config apply timeout

### DIFF
--- a/otel-ecs-supervisor/CHANGELOG.md
+++ b/otel-ecs-supervisor/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## ecs-ec2-integration
 
+### 0.0.12 / 2026-08-25
+- [IMPROVEMENT] Use `30s` as config apply timeout for the Supervisor.
+
 ### 0.0.11 / 2026-08-11
 
 * [IMPROVEMENT] Migrated the `coralogix_domain` default from the legacy `coralogix.com` to the regional `eu1.coralogix.com`. ([#990](https://github.com/coralogix/telemetry-shippers/pull/990))

--- a/otel-ecs-supervisor/CHANGELOG.md
+++ b/otel-ecs-supervisor/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## ecs-ec2-integration
 
 ### 0.0.12 / 2026-08-25
-- [IMPROVEMENT] Use `30s` as config apply timeout for the Supervisor.
+- [IMPROVEMENT] Use `30s` as config apply timeout for the Supervisor. ([#1008](https://github.com/coralogix/telemetry-shippers/pull/1008))
 
 ### 0.0.11 / 2026-08-11
 

--- a/otel-ecs-supervisor/templates/supervisor.yaml
+++ b/otel-ecs-supervisor/templates/supervisor.yaml
@@ -16,6 +16,7 @@ capabilities:
 
 agent:
   executable: /otelcol-contrib
+  config_apply_timeout: 30s
   # This adds CLI arguments to the Collector.
   args:
     - ''


### PR DESCRIPTION
# Description

<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> 

Use 30s as config apply timeout for the ECS Supervisor.

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

Ran smoke tests.

# Checklist:
- [ ] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)
