### PR TITLE
chore: bump opentelemetry-ebpf-instrumentation to 0.1.25

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## OpenTelemetry-Integration
 
+### v0.0.343 / 2026-08-26
+
+- [Chore] Bump chart dependency to opentelemetry-ebpf-instrumentation 0.1.25
+
+#### Changes from opentelemetry-ebpf-instrumentation 0.1.25:
+- [Feature] Enable peer name resolution by default with `name_resolver.sources: [k8s, rdns]`: peer/host IPs resolve to names from the Kubernetes informer metadata and from the DNS answers OBI already captures. Both sources are in-memory and generate no lookups; the active `dns` source stays disabled since it issues blocking PTR queries from the span pipeline
+
 ### v0.0.342 / 2026-08-25
 
 - [Chore] Bump chart dependency to opentelemetry-ebpf-instrumentation 0.1.24

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.342
+version: 0.0.343
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -61,7 +61,7 @@ dependencies:
     condition: opentelemetry-ebpf-profiler.enabled
   - name: opentelemetry-ebpf-instrumentation
     alias: opentelemetry-ebpf-instrumentation
-    version: "0.1.24"
+    version: "0.1.25"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts
     condition: opentelemetry-ebpf-instrumentation.enabled
   - name: coralogix-operator

--- a/otel-integration/k8s-helm/tests/golden/ebpf-profiler.yaml
+++ b/otel-integration/k8s-helm/tests/golden/ebpf-profiler.yaml
@@ -188,14 +188,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -217,13 +217,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:
@@ -1073,14 +1073,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -1102,13 +1102,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:
@@ -2063,7 +2063,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 96714df22467873da02bc797499f0ea2f6e05625602680e2c1bc089045d8726a
+        checksum/config: 5d4d38900a79ef0730fd8f10107d7c8c7108225dadde076d29750aa2aecad29c
 
       labels:
         app.kubernetes.io/name: opentelemetry-agent
@@ -2249,7 +2249,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9f2cc503be2722acba1e79fbc48e9ef5ed72a0697e9b6c7a6470ff77136e40b6
+        checksum/config: 88d04920ae89aab24411f5bc4162de93c286798aaf2a43b7f96abc2e91c6e5b2
 
       labels:
         app.kubernetes.io/name: opentelemetry-cluster-collector

--- a/otel-integration/k8s-helm/tests/golden/eks-fargate.yaml
+++ b/otel-integration/k8s-helm/tests/golden/eks-fargate.yaml
@@ -54,14 +54,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -86,7 +86,7 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
       debug: {}
     extensions:
       health_check:
@@ -347,14 +347,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -379,7 +379,7 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
       debug: {}
     extensions:
       health_check:
@@ -835,7 +835,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 86e973a4fcb65c5638684a89f9226373616c3ee1855da6a1d79b333d229bd56d
+        checksum/config: 3f592376f9ded347514086e62f4f14a3c252d0e9ba3630c5888f3f002006fee5
 
       labels:
         app.kubernetes.io/name: opentelemetry-agent-eks-fargate-monitoring
@@ -949,7 +949,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4e0008692b0d2dc9eb034d13ae2ab5274d3bbd16421d4f26805a971fc062ea23
+        checksum/config: b0089a85f01b240469b498e668b61674fdd7423f5442e341d5540c61eb3f58c0
 
       labels:
         app.kubernetes.io/name: opentelemetry-agent-eks-fargate

--- a/otel-integration/k8s-helm/tests/golden/tail-sampling.yaml
+++ b/otel-integration/k8s-helm/tests/golden/tail-sampling.yaml
@@ -192,14 +192,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -221,13 +221,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:
@@ -1074,14 +1074,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -1103,13 +1103,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:
@@ -1782,14 +1782,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -1811,7 +1811,7 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
       debug: {}
     extensions:
       health_check:
@@ -2263,7 +2263,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7f462d420c1b05f622b63caf9f3e3498f98adc4129a5d72d1c572816dc0a766b
+        checksum/config: 14d08433374c85785a19793f510ba9948ec54dbc5c2d2893e49185fcdc74e794
 
       labels:
         app.kubernetes.io/name: opentelemetry-agent
@@ -2449,7 +2449,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6da276714bee2a3fc4c351ee0aab832da1ff7b0f5bf076639059d284b0e9c5f8
+        checksum/config: 7728b961ab27cd00771789d5dc356d344d2aa91ba3e83e234c01f547a61bc8f7
 
       labels:
         app.kubernetes.io/name: opentelemetry-cluster-collector
@@ -2572,7 +2572,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 784124ebb0825aa16651317f371a3c026b5ceb51047623d8d05983e866e5fa0c
+        checksum/config: a5bf8cfaef73df43994b27c7b41d9056eadd3a7537fc62511ee26b282d33e58b
 
       labels:
         app.kubernetes.io/name: opentelemetry-gateway

--- a/otel-integration/k8s-helm/tests/golden/windows.yaml
+++ b/otel-integration/k8s-helm/tests/golden/windows.yaml
@@ -67,14 +67,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -96,7 +96,7 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
       debug: {}
     extensions:
       file_storage:
@@ -642,14 +642,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -671,13 +671,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:
@@ -1527,14 +1527,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -1556,13 +1556,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.342
+            X-Coralogix-Distribution: helm-otel-integration/0.0.343
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:
@@ -2467,7 +2467,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 1e1560aec2886c72157e3cd243638e3381e7ee900294911195f713928d013756
+        checksum/config: 55a20983278cc7080f1f2313fc1ef6e921acf09d75a098176a8fe9420b9345f9
 
       labels:
         app.kubernetes.io/name: opentelemetry-agent-windows
@@ -2641,7 +2641,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b806e3990e556950b850d065885ed1f2695adba94ed296eb27aa6205814f678f
+        checksum/config: 6a292c0fde2018b5500b4c287a7fbf5d12417f42c522b63fe66f790d8df36db1
 
       labels:
         app.kubernetes.io/name: opentelemetry-agent
@@ -2828,7 +2828,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 6da276714bee2a3fc4c351ee0aab832da1ff7b0f5bf076639059d284b0e9c5f8
+        checksum/config: 7728b961ab27cd00771789d5dc356d344d2aa91ba3e83e234c01f547a61bc8f7
 
       labels:
         app.kubernetes.io/name: opentelemetry-cluster-collector

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "info"
   collectionInterval: "30s"
-  version: "0.0.342"
+  version: "0.0.343"
   deploymentEnvironmentName: ""
 
   extensions:


### PR DESCRIPTION
Bumps the `opentelemetry-ebpf-instrumentation` chart dependency of otel-integration to `0.1.25`, and the chart itself to `0.0.343`.

Same content as the automated #1009, re-created with a signed, human-authored commit so `license/cla` passes, and rebased onto current master so it merges cleanly — #1009 was cut before #1007 landed, and both claimed chart version `0.0.342`.

The golden renders were regenerated and verified with `.github/scripts/check-helm-golden-renders.sh`.

#### Changes from opentelemetry-ebpf-instrumentation 0.1.25:
- [Feature] Enable peer name resolution by default with `name_resolver.sources: [k8s, rdns]`: peer/host IPs resolve to names from the Kubernetes informer metadata and from the DNS answers OBI already captures. Both sources are in-memory and generate no lookups; the active `dns` source stays disabled since it issues blocking PTR queries from the span pipeline

**Source:** https://github.com/coralogix/opentelemetry-helm-charts/pull/513
