### PR TITLE
chore: bump opentelemetry-ebpf-instrumentation to 0.1.26

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## OpenTelemetry-Integration
 
+### v0.0.345 / 2026-09-06
+
+- [Chore] Bump chart dependency to opentelemetry-ebpf-instrumentation 0.1.26
+
+#### Changes from opentelemetry-ebpf-instrumentation 0.1.26:
+- [Change] Bump OBI image to v0.13.0
+- [Fix] Note for upgraders: v0.13.0 fixes a group of memory-safety bugs in the socket-layer context propagation. The header injector no longer acts on a leftover message buffer, which could write a `traceparent` into the middle of a TLS stream and reset the instrumented connection; message-buffer reads are bounded by the mapped data window, so a failed pull no longer copies adjacent kernel memory into span payloads, and sends of 8 KiB or more are captured again. Installs running `presets.contextPropagation` should take this image
+- [Change] Note for upgraders: `service.name` and `service.namespace` are no longer default metric attributes. They remain resource attributes, so the OTLP metrics this chart exports still carry the service identity and the Coralogix pipeline is unaffected. Prometheus scrapers lose the `service_name` / `service_namespace` labels on application metric series; restore them with `config.data.attributes.extra_group_attributes.app: [service.name, service.namespace]`, or join through `target_info`
+- [Change] Note for upgraders: Go runtime metric probes now require the `application_runtime` feature. The `presets.runtimeMetrics` preset already adds it, so a default install keeps Go runtime metrics; installs that configure `metrics.features` by hand must include it
+- [Change] Note for upgraders: `error.type` values are unified across spans and metrics, and TCP client/server roles are classified by the local port, which corrects previously swapped roles for same-namespace clients
+- [Feature] The image adds runtime metrics for Python, the JVM and Node.js, Aerospike server spans, Go 1.27 support, `db.response.status_code`, `db.namespace` and `server.port` on database duration metrics, `messaging.operation.name` on messaging spans, and IPv6 reverse DNS
+
 ### v0.0.344 / 2026-08-27
 
 - [Chore] Bump chart dependency to opentelemetry-collector 0.137.0

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.344
+version: 0.0.345
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent
@@ -61,7 +61,7 @@ dependencies:
     condition: opentelemetry-ebpf-profiler.enabled
   - name: opentelemetry-ebpf-instrumentation
     alias: opentelemetry-ebpf-instrumentation
-    version: "0.1.25"
+    version: "0.1.26"
     repository: https://cgx.jfrog.io/artifactory/coralogix-charts
     condition: opentelemetry-ebpf-instrumentation.enabled
   - name: coralogix-operator

--- a/otel-integration/k8s-helm/tests/golden/ebpf-profiler.yaml
+++ b/otel-integration/k8s-helm/tests/golden/ebpf-profiler.yaml
@@ -188,14 +188,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -217,13 +217,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:
@@ -1080,14 +1080,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -1109,13 +1109,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:
@@ -2070,7 +2070,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ca9780e3e1e29f5ddd5a414cd0b82631800e736f82c2c1e1ebd2a38009da2da9
+        checksum/config: 13ebd2916d2d3d68d5dd38ecb8ec8fce17a36ed3ed70c7a8ed37ecfeac772126
 
       labels:
         app.kubernetes.io/name: opentelemetry-agent
@@ -2256,7 +2256,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 34d5db644a7da6beffecbdff582a390551b7057bac43942bed671320b7d2925c
+        checksum/config: 1ccfbf94a3ef0d8d337e97e46db2097fd8f747e3f8cad8dc686c40861846a4bb
 
       labels:
         app.kubernetes.io/name: opentelemetry-cluster-collector

--- a/otel-integration/k8s-helm/tests/golden/eks-fargate.yaml
+++ b/otel-integration/k8s-helm/tests/golden/eks-fargate.yaml
@@ -54,14 +54,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -86,7 +86,7 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
       debug: {}
     extensions:
       health_check:
@@ -347,14 +347,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -379,7 +379,7 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
       debug: {}
     extensions:
       health_check:
@@ -835,7 +835,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 87603f0bb68082f695616371ff4f65fbf7f9f10ed902ca29a09972f105e89a19
+        checksum/config: 4531556c2dcb676a61c1cc15e6591cfc4686ddd4a67e116ef77a34e6d87a333a
 
       labels:
         app.kubernetes.io/name: opentelemetry-agent-eks-fargate-monitoring
@@ -949,7 +949,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 87536e9d3f3424ccf14a06d399942be8fc23a95f2c44320350c836c7f891cc1e
+        checksum/config: e2cffa2ff394411c03084d1e5b0bd664b9046a92b2747e6044126017b51f2a20
 
       labels:
         app.kubernetes.io/name: opentelemetry-agent-eks-fargate

--- a/otel-integration/k8s-helm/tests/golden/tail-sampling.yaml
+++ b/otel-integration/k8s-helm/tests/golden/tail-sampling.yaml
@@ -192,14 +192,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -221,13 +221,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:
@@ -1081,14 +1081,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -1110,13 +1110,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:
@@ -1789,14 +1789,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -1818,7 +1818,7 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
       debug: {}
     extensions:
       health_check:
@@ -2270,7 +2270,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9905120b556e9b365da4e4668eeba0bc8eab9188d7e3b0718a7b88a7d7a60526
+        checksum/config: 86348f4f676e91d3a09cf81afd848ebf60e0279974e105a2d0f45332ea22bb64
 
       labels:
         app.kubernetes.io/name: opentelemetry-agent
@@ -2456,7 +2456,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e4fd9e4cfe0b55b51e78c7e88fcda88f245f3e07fb1fac74cd1bc4f5acefd733
+        checksum/config: ee7e437a5d3977a8981021f4f50ff79be897a8604dccf26cf5e41e750bab0b78
 
       labels:
         app.kubernetes.io/name: opentelemetry-cluster-collector
@@ -2579,7 +2579,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c75251baf3e62bd90c69d9b5090586b22820297b7ad81a1509cdd6bc303ddc1d
+        checksum/config: 5df1dcea70985e72488748671f0f698fcdb2c7daf5660d14692b8af75ab89897
 
       labels:
         app.kubernetes.io/name: opentelemetry-gateway

--- a/otel-integration/k8s-helm/tests/golden/windows.yaml
+++ b/otel-integration/k8s-helm/tests/golden/windows.yaml
@@ -67,14 +67,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -96,7 +96,7 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
       debug: {}
     extensions:
       file_storage:
@@ -649,14 +649,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -678,13 +678,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:
@@ -1541,14 +1541,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -1570,13 +1570,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.344
+            X-Coralogix-Distribution: helm-otel-integration/0.0.345
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:
@@ -2481,7 +2481,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 76eb03da083a239441f5739a4e24151c17a88e5b5f2c6f0436f955262c057c01
+        checksum/config: 7aa04576add91b56e78e10f0219f4b0d6a287e8f00ed68560cd6464681867559
 
       labels:
         app.kubernetes.io/name: opentelemetry-agent-windows
@@ -2655,7 +2655,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: b44d4fbbbbd4053c14e03214498b8f583ed1f9217fd106456149ebf531bf874a
+        checksum/config: fe37fa42ad3ac5f104f00c80b072d43afb8b3a94d6711d1ce9313f797151d295
 
       labels:
         app.kubernetes.io/name: opentelemetry-agent
@@ -2842,7 +2842,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e4fd9e4cfe0b55b51e78c7e88fcda88f245f3e07fb1fac74cd1bc4f5acefd733
+        checksum/config: ee7e437a5d3977a8981021f4f50ff79be897a8604dccf26cf5e41e750bab0b78
 
       labels:
         app.kubernetes.io/name: opentelemetry-cluster-collector

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "info"
   collectionInterval: "30s"
-  version: "0.0.344"
+  version: "0.0.345"
   deploymentEnvironmentName: ""
 
   extensions:


### PR DESCRIPTION
## Story number

[CX-57652](https://coralogix.atlassian.net/browse/CX-57652)

# Description

Bumps the `otel-integration` dependency on `opentelemetry-ebpf-instrumentation` from `0.1.25` to `0.1.26`, which carries OBI image `v0.13.0`. Chart side merged in coralogix/opentelemetry-helm-charts#519.

Opened by hand because the `sync-obi` dispatch failed with HTTP 403 on `repository_dispatch`.

#### Changes from opentelemetry-ebpf-instrumentation 0.1.26:
- [Change] Bump OBI image to v0.13.0
- [Fix] Note for upgraders: v0.13.0 fixes a group of memory-safety bugs in the socket-layer context propagation. The header injector no longer acts on a leftover message buffer, which could write a `traceparent` into the middle of a TLS stream and reset the instrumented connection; message-buffer reads are bounded by the mapped data window, so a failed pull no longer copies adjacent kernel memory into span payloads, and sends of 8 KiB or more are captured again. Installs running `presets.contextPropagation` should take this image
- [Change] Note for upgraders: `service.name` and `service.namespace` are no longer default metric attributes. They remain resource attributes, so the OTLP metrics this chart exports still carry the service identity and the Coralogix pipeline is unaffected. Prometheus scrapers lose the `service_name` / `service_namespace` labels on application metric series; restore them with `config.data.attributes.extra_group_attributes.app: [service.name, service.namespace]`, or join through `target_info`
- [Change] Note for upgraders: Go runtime metric probes now require the `application_runtime` feature. The `presets.runtimeMetrics` preset already adds it, so a default install keeps Go runtime metrics; installs that configure `metrics.features` by hand must include it
- [Change] Note for upgraders: `error.type` values are unified across spans and metrics, and TCP client/server roles are classified by the local port, which corrects previously swapped roles for same-namespace clients
- [Feature] The image adds runtime metrics for Python, the JVM and Node.js, Aerospike server spans, Go 1.27 support, `db.response.status_code`, `db.namespace` and `server.port` on database duration metrics, `messaging.operation.name` on messaging spans, and IPv6 reverse DNS

# How Has This Been Tested?

Generated with `scripts/bump-otel-collector-version.sh`. `.github/scripts/check-helm-golden-renders.sh` exits 0 with no drift, and `go test ./...` passes. Golden diffs are limited to the distribution version header and the config checksums that follow it, since OBI is not enabled in the golden values.

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)


[CX-57652]: https://coralogix.atlassian.net/browse/CX-57652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ