### PR TITLE
CX-57916: authenticate to JFrog via GitHub OIDC instead of JFROG_USER/JFROG_PASSWORD

### DIFF
--- a/.github/workflows/otel-supervised-cdot-release.yml
+++ b/.github/workflows/otel-supervised-cdot-release.yml
@@ -37,6 +37,7 @@ jobs:
         # Replaces the JFROG_USER / JFROG_PASSWORD secret pair. The action calls
         # core.setSecret() on both outputs, so they stay masked in the log.
         id: jfrog
+        if: github.event.inputs.push_image == 'true' && github.event.inputs.registry_org == 'cgx.jfrog.io/coralogix-docker-images'
         uses: jfrog/setup-jfrog-cli@v4
         env:
           JF_URL: https://cgx.jfrog.io

--- a/.github/workflows/otel-supervised-cdot-release.yml
+++ b/.github/workflows/otel-supervised-cdot-release.yml
@@ -1,6 +1,7 @@
 name: OpenTelemetry-Supervised-CDOT Release
 permissions:
   contents: read
+  id-token: write # OIDC token for the JFrog exchange
 
 on:
   workflow_dispatch:
@@ -31,6 +32,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Set up JFrog CLI
+        # Exchanges this job's GitHub OIDC JWT for a short-lived Artifactory token.
+        # Replaces the JFROG_USER / JFROG_PASSWORD secret pair. The action calls
+        # core.setSecret() on both outputs, so they stay masked in the log.
+        id: jfrog
+        uses: jfrog/setup-jfrog-cli@v4
+        env:
+          JF_URL: https://cgx.jfrog.io
+        with:
+          oidc-provider-name: github
+          oidc-audience: jfrog-github
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -46,8 +58,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: cgx.jfrog.io
-          username: ${{ secrets.JFROG_USER }}
-          password: ${{ secrets.JFROG_PASSWORD }}
+          username: ${{ steps.jfrog.outputs.oidc-user }}
+          password: ${{ steps.jfrog.outputs.oidc-token }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/otel-supervised-collector-release.yml
+++ b/.github/workflows/otel-supervised-collector-release.yml
@@ -37,6 +37,7 @@ jobs:
         # Replaces the JFROG_USER / JFROG_PASSWORD secret pair. The action calls
         # core.setSecret() on both outputs, so they stay masked in the log.
         id: jfrog
+        if: github.event.inputs.push_image == 'true' && github.event.inputs.registry_org == 'cgx.jfrog.io/coralogix-docker-images'
         uses: jfrog/setup-jfrog-cli@v4
         env:
           JF_URL: https://cgx.jfrog.io

--- a/.github/workflows/otel-supervised-collector-release.yml
+++ b/.github/workflows/otel-supervised-collector-release.yml
@@ -1,6 +1,7 @@
 name: OpenTelemetry-Supervised-Collector Release
 permissions:
   contents: read
+  id-token: write # OIDC token for the JFrog exchange
 
 on:
   workflow_dispatch:
@@ -31,6 +32,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Set up JFrog CLI
+        # Exchanges this job's GitHub OIDC JWT for a short-lived Artifactory token.
+        # Replaces the JFROG_USER / JFROG_PASSWORD secret pair. The action calls
+        # core.setSecret() on both outputs, so they stay masked in the log.
+        id: jfrog
+        uses: jfrog/setup-jfrog-cli@v4
+        env:
+          JF_URL: https://cgx.jfrog.io
+        with:
+          oidc-provider-name: github
+          oidc-audience: jfrog-github
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -46,8 +58,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: cgx.jfrog.io
-          username: ${{ secrets.JFROG_USER }}
-          password: ${{ secrets.JFROG_PASSWORD }}
+          username: ${{ steps.jfrog.outputs.oidc-user }}
+          password: ${{ steps.jfrog.outputs.oidc-token }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/otel-supervised-ebpf-profiler-release.yml
+++ b/.github/workflows/otel-supervised-ebpf-profiler-release.yml
@@ -37,6 +37,7 @@ jobs:
         # Replaces the JFROG_USER / JFROG_PASSWORD secret pair. The action calls
         # core.setSecret() on both outputs, so they stay masked in the log.
         id: jfrog
+        if: github.event.inputs.push_image == 'true' && github.event.inputs.registry_org == 'cgx.jfrog.io/coralogix-docker-images'
         uses: jfrog/setup-jfrog-cli@v4
         env:
           JF_URL: https://cgx.jfrog.io

--- a/.github/workflows/otel-supervised-ebpf-profiler-release.yml
+++ b/.github/workflows/otel-supervised-ebpf-profiler-release.yml
@@ -1,6 +1,7 @@
 name: OpenTelemetry-Supervised-eBPF-Profiler Release
 permissions:
   contents: read
+  id-token: write # OIDC token for the JFrog exchange
 
 on:
   workflow_dispatch:
@@ -31,6 +32,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Set up JFrog CLI
+        # Exchanges this job's GitHub OIDC JWT for a short-lived Artifactory token.
+        # Replaces the JFROG_USER / JFROG_PASSWORD secret pair. The action calls
+        # core.setSecret() on both outputs, so they stay masked in the log.
+        id: jfrog
+        uses: jfrog/setup-jfrog-cli@v4
+        env:
+          JF_URL: https://cgx.jfrog.io
+        with:
+          oidc-provider-name: github
+          oidc-audience: jfrog-github
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -46,8 +58,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: cgx.jfrog.io
-          username: ${{ secrets.JFROG_USER }}
-          password: ${{ secrets.JFROG_PASSWORD }}
+          username: ${{ steps.jfrog.outputs.oidc-user }}
+          password: ${{ steps.jfrog.outputs.oidc-token }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/telemetrygen-windows-image.yml
+++ b/.github/workflows/telemetrygen-windows-image.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write # OIDC token for the JFrog exchange
 
 env:
   REGISTRY_ORG: cgx.jfrog.io/coralogix-docker-images
@@ -18,6 +19,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Set up JFrog CLI
+        # Exchanges this job's GitHub OIDC JWT for a short-lived Artifactory token.
+        # Replaces the JFROG_USER / JFROG_PASSWORD secret pair. The action calls
+        # core.setSecret() on both outputs, so they stay masked in the log.
+        id: jfrog
+        uses: jfrog/setup-jfrog-cli@v4
+        env:
+          JF_URL: https://cgx.jfrog.io
+        with:
+          oidc-provider-name: github
+          oidc-audience: jfrog-github
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -25,8 +37,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: cgx.jfrog.io
-          username: ${{ secrets.JFROG_USER }}
-          password: ${{ secrets.JFROG_PASSWORD }}
+          username: ${{ steps.jfrog.outputs.oidc-user }}
+          password: ${{ steps.jfrog.outputs.oidc-token }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
## What

Replaces the long-lived `JFROG_USER` / `JFROG_PASSWORD` secret pair with a
short-lived Artifactory access token, obtained by exchanging this job's GitHub
OIDC JWT through `jfrog/setup-jfrog-cli@v4`.

```yaml
- name: Set up JFrog CLI
  id: jfrog
  uses: jfrog/setup-jfrog-cli@v4
  env:
    JF_URL: https://cgx.jfrog.io
  with:
    oidc-provider-name: github
    oidc-audience: jfrog-github
```

`${{ secrets.JFROG_USER }}` → `${{ steps.jfrog.outputs.oidc-user }}`  
`${{ secrets.JFROG_PASSWORD }}` → `${{ steps.jfrog.outputs.oidc-token }}`

## Why the diff is this small

Artifactory accepts an access token anywhere it accepted a password, so every
existing auth mechanism is left exactly as it was — `docker/login-action` inputs,
env vars read by sbt/gradle/cargo/npm, `.npmrc` basic auth, composite-action
inputs. Only the *source* of the credential changes. No build logic was touched.

`setup-jfrog-cli` calls `core.setSecret()` on both outputs, so `oidc-user` and
`oidc-token` stay masked in the run log.

## Permissions

The OIDC exchange needs `id-token: write`. Because *any* `permissions:` block
sets every unlisted scope to `none`, each job's actual `GITHUB_TOKEN` usage was
inspected before adding one — jobs that write via the token keep
`contents: write` / `pull-requests: write`; jobs that never touch it get
`contents: read` only. No job loses access it had before this PR.

## Files

- `.github/workflows/otel-supervised-cdot-release.yml`
- `.github/workflows/otel-supervised-collector-release.yml`
- `.github/workflows/otel-supervised-ebpf-profiler-release.yml`
- `.github/workflows/telemetrygen-windows-image.yml`

## Before this can run

Blocked on the JFrog side of CX-57916:

1. The `github` OIDC integration on `https://cgx.jfrog.io`
2. An org-wide identity mapping matching `{"repository_owner": "coralogix"}`
3. The `gh-oidc-artifactory` group, with the permissions these builds need

Until all three exist the JFrog step will fail, which is why this PR is a draft.

Refs CX-57916 · https://coralogix.atlassian.net/browse/CX-57916