### PR TITLE
fix(ecs-ec2): take the template from cloudformation-coralogix-aws

### DIFF
--- a/.github/workflows/Sync-ec2-integration-definition.yaml
+++ b/.github/workflows/Sync-ec2-integration-definition.yaml
@@ -7,6 +7,13 @@ on:
       - 'otel-ecs-ec2/Chart.yaml'
   workflow_dispatch:
 
+# cloudformation-coralogix-aws also writes to this integration's directory when the template
+# changes, overwriting template.yaml in the latest revision. This serialises our own runs; the
+# cross-repo case surfaces as a pull request conflict rather than a corrupt manifest.
+concurrency:
+  group: sync-ecs-ec2-from-chart
+  cancel-in-progress: false
+
 jobs:
   Get_version:
     runs-on: ubuntu-latest
@@ -96,7 +103,19 @@ jobs:
           mkdir -p "$new_dir"
           cp "$base_dir/commands.yaml" "$new_dir/"
           cp "$base_dir/fields.yaml" "$new_dir/"
-          cp "$base_dir/template.yaml" "$new_dir/"
+
+          # The template is owned by cloudformation-coralogix-aws, so take it from there rather
+          # than copying the previous revision's forward -- copying forward is what let the two
+          # diverge. Fetched as a single file because a nested checkout would land inside this
+          # repo's tree and be swept up by the commit action's file_pattern.
+          gh api "repos/coralogix/cloudformation-coralogix-aws/contents/opentelemetry/ecs-ec2/template.yaml" \
+            -H "Accept: application/vnd.github.raw" > "$new_dir/template.yaml"
+
+          if [ ! -s "$new_dir/template.yaml" ]; then
+            echo "::error::Fetched ecs-ec2 template is empty"
+            exit 1
+          fi
+          echo "Fetched template: $(wc -c < "$new_dir/template.yaml") bytes"
           
           current_time=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           


### PR DESCRIPTION
## What

When a collector chart is released, this workflow creates a new ecs-ec2 revision in `integration-definitions`. It used to copy the previous revision's `template.yaml` forward. Now it fetches the template from `cloudformation-coralogix-aws`, which owns it.

## Why

Copying forward meant template changes never reached customers. The template in this repo's chain has been stuck since 2026-08-11 — 71 lines behind, including the migration of every region endpoint off the legacy domains and the new `US3` region.

Each chart release also made it worse, since every new revision carried the old template forward again.

## Also

Adds a concurrency group. `cloudformation-coralogix-aws` writes to the same integration directory when the template changes, so this stops our own runs overlapping.

## Goes with

`coralogix/cloudformation-coralogix-aws#249`, which adds the sync on the other side. Either can merge first — this one just stops the old template being re-shipped on the next chart release.

## Testing

The fetch was verified end to end from #249: it pulled the template, wrote it into the latest revision, and opened `integration-definitions#1393`. Same `gh api` call, same token.

`shellcheck` findings unchanged from master (11 before, 11 after) — none introduced here.
