### PR TITLE
CX-48050: bump java and python autoinstrumentation images already on GHCR

### DIFF
--- a/otel-integration/CHANGELOG.md
+++ b/otel-integration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## OpenTelemetry-Integration
 
+### v0.0.348 / 2026-09-11
+
+- [Chore] Bump autoinstrumentation images already published on GHCR (java `2.30.0` -> `2.31.1`, python `0.64b0` -> `0.65b0`). .NET `1.16.0` and Apache/nginx `1.0.4` are unchanged.
+
 ### v0.0.347 / 2026-09-08
 
 - [Chore] Bump chart dependency to opentelemetry-collector 0.138.1

--- a/otel-integration/k8s-helm/Chart.yaml
+++ b/otel-integration/k8s-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: otel-integration
 description: OpenTelemetry Integration
-version: 0.0.347
+version: 0.0.348
 keywords:
   - OpenTelemetry Collector
   - OpenTelemetry Agent

--- a/otel-integration/k8s-helm/tests/golden/ebpf-profiler.yaml
+++ b/otel-integration/k8s-helm/tests/golden/ebpf-profiler.yaml
@@ -188,14 +188,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -217,13 +217,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:
@@ -1079,14 +1079,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -1108,13 +1108,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:

--- a/otel-integration/k8s-helm/tests/golden/eks-fargate.yaml
+++ b/otel-integration/k8s-helm/tests/golden/eks-fargate.yaml
@@ -54,14 +54,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -86,7 +86,7 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
       debug: {}
     extensions:
       health_check:
@@ -347,14 +347,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -379,7 +379,7 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
       debug: {}
     extensions:
       health_check:

--- a/otel-integration/k8s-helm/tests/golden/tail-sampling.yaml
+++ b/otel-integration/k8s-helm/tests/golden/tail-sampling.yaml
@@ -192,14 +192,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -221,13 +221,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:
@@ -1080,14 +1080,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -1109,13 +1109,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:
@@ -1787,14 +1787,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -1816,7 +1816,7 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
       debug: {}
     extensions:
       health_check:

--- a/otel-integration/k8s-helm/tests/golden/windows.yaml
+++ b/otel-integration/k8s-helm/tests/golden/windows.yaml
@@ -67,14 +67,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -96,7 +96,7 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
       debug: {}
     extensions:
       file_storage:
@@ -648,14 +648,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -677,13 +677,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:
@@ -1539,14 +1539,14 @@ data:
             timeout: 10s
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
         metrics:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
         private_key: ${env:CORALOGIX_PRIVATE_KEY}
         profiles:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
             x-coralogix-ingress: otlp/v1.10.0
         sending_queue:
           batch:
@@ -1568,13 +1568,13 @@ data:
         timeout: 30s
         traces:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
       coralogix/resource_catalog:
         application_name: resource
         domain: eu2.coralogix.com
         logs:
           headers:
-            X-Coralogix-Distribution: helm-otel-integration/0.0.347
+            X-Coralogix-Distribution: helm-otel-integration/0.0.348
             x-coralogix-ingress: metadata-as-otlp-logs/v1
         private_key: ${CORALOGIX_PRIVATE_KEY}
         sending_queue:

--- a/otel-integration/k8s-helm/values.yaml
+++ b/otel-integration/k8s-helm/values.yaml
@@ -5,7 +5,7 @@ global:
   defaultSubsystemName: "integration"
   logLevel: "info"
   collectionInterval: "30s"
-  version: "0.0.347"
+  version: "0.0.348"
   deploymentEnvironmentName: ""
 
   extensions:
@@ -72,7 +72,7 @@ opentelemetry-autoinstrumentation:
               value: none
           java:
             # Image must be set explicitly because this no-CRD mode does not use CRD defaulting.
-            image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:2.30.0
+            image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:2.31.1
             env:
               - name: OTEL_EXPORTER_OTLP_ENDPOINT
                 value: http://$(OTEL_NODE_IP):4317
@@ -80,7 +80,7 @@ opentelemetry-autoinstrumentation:
                 value: grpc
           python:
             # Python uses HTTP/protobuf on 4318; Java and .NET use gRPC on 4317.
-            image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-python:0.64b0
+            image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-python:0.65b0
             env:
               - name: OTEL_EXPORTER_OTLP_ENDPOINT
                 value: http://$(OTEL_NODE_IP):4318


### PR DESCRIPTION
# Description

One-time catch-up of autoinstrumentation image pins that GHCR already published, but the OpenTelemetry Operator has not adopted yet:

- java `2.30.0` -> `2.31.1`
- python `0.64b0` -> `0.65b0`
- .NET stays `1.16.0`, Apache/nginx stay `1.0.4`

Chart `0.0.347` -> `0.0.348`.

(catch-up follow-up to #1020)

## Why this is manual

[#1020](https://github.com/coralogix/telemetry-shippers/pull/1020) watches **Operator releases** (`versions.txt`), not GHCR “latest”. Latest Operator is still [v0.158.0](https://github.com/open-telemetry/opentelemetry-operator/releases/tag/v0.158.0), which lists java `2.30.0` and python `0.64b0`. GHCR already has [java 2.31.1](https://github.com/open-telemetry/opentelemetry-operator/pkgs/container/opentelemetry-operator%2Fautoinstrumentation-java) and [python 0.65b0](https://github.com/open-telemetry/opentelemetry-operator/pkgs/container/opentelemetry-operator%2Fautoinstrumentation-python).

After #1020 merges, the scheduled job will correctly no-op until the next Operator release. This PR takes the images that already exist so we are not waiting on that.

# How Has This Been Tested?

- Compared current pins to Operator `v0.158.0` `versions.txt` and to GHCR package tags
- Chart version and golden `X-Coralogix-Distribution` headers updated to `0.0.348`

# Checklist:
- [x] I have updated the relevant Helm chart(s) version(s)
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's CI or docs change)

Made with [Cursor](https://cursor.com)